### PR TITLE
Changed to use csdk hub repo to get the spell check script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,8 @@ jobs:
       - name: Checkout Parent Repo
         uses: actions/checkout@v2
         with:
-          ref: ota
-          repository: aws/aws-iot-device-sdk-embedded-C-staging
+          ref: master
+          repository: aws/aws-iot-device-sdk-embedded-C
       - run: rm -r libraries/aws/ota
       - name: Clone This Repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Changed to use csdk hub repo to get the spell check script

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
