### PR TITLE
Polish Base64 code.

### DIFF
--- a/source/include/aws_ota_base64_private.h
+++ b/source/include/aws_ota_base64_private.h
@@ -90,7 +90,7 @@
  *
  * @return     One of the following:
  *             - #OTA_BASE64_SUCCESS if the Base64 encoded data was valid
- *               and succesfully decoded.
+ *               and successfully decoded.
  *             - An error code defined in aws_ota_base64_private.h if the
  *               encoded data or input parameters are invalid.
  */


### PR DESCRIPTION
* Remove typos from aws_ota_base64.c
* Remove typo from aws_ota_base64_private.h
* Remove macros that are not being used from aws_ota_base64.c
* Update variable names to follow the coding standard

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
