### PR TITLE
Fix asserts for snprintf results in ota mqtt (#66)

### DIFF
--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -503,7 +503,7 @@ static uint32_t buildStatusMessageReceiving( char * pMsgBuffer,
                                          pOtaJobStatusStatusTemplate,
                                          pOtaJobStatusStrings[ status ] );
         /* The buffer is static and the size is calculated to fit. */
-        assert( ( msgSize > 0U ) && ( msgSize < sizeof( pMsgBuffer ) ) );
+        assert( ( msgSize > 0U ) && ( msgSize < msgBufferSize ) );
 
         msgTailSize = ( uint32_t ) snprintf( &pMsgBuffer[ msgSize ], /*lint -e586 Intentionally using snprintf. */
                                              msgBufferSize - msgSize,
@@ -513,7 +513,7 @@ static uint32_t buildStatusMessageReceiving( char * pMsgBuffer,
                                              numBlocks );
         msgSize += msgTailSize;
         /* The buffer is static and the size is calculated to fit. */
-        assert( ( msgTailSize > 0U ) && ( msgSize < sizeof( pMsgBuffer ) ) );
+        assert( ( msgTailSize > 0U ) && ( msgSize < msgBufferSize ) );
     }
 
     return msgSize;
@@ -534,7 +534,7 @@ static uint32_t prvBuildStatusMessageSelfTest( char * pMsgBuffer,
                                      pOtaJobStatusStatusTemplate,
                                      pOtaJobStatusStrings[ status ] );
     /* The buffer is static and the size is calculated to fit. */
-    assert( ( msgSize > 0U ) && ( msgSize < sizeof( pMsgBuffer ) ) );
+    assert( ( msgSize > 0U ) && ( msgSize < msgBufferSize ) );
 
     msgTailSize = ( uint32_t ) snprintf( &pMsgBuffer[ msgSize ], /*lint -e586 Intentionally using snprintf. */
                                          msgBufferSize - msgSize,
@@ -544,7 +544,7 @@ static uint32_t prvBuildStatusMessageSelfTest( char * pMsgBuffer,
                                          appFirmwareVersion.u.unsignedVersion32 );
     msgSize += msgTailSize;
     /* The buffer is static and the size is calculated to fit. */
-    assert( ( msgTailSize > 0U ) && ( msgSize < sizeof( pMsgBuffer ) ) );
+    assert( ( msgTailSize > 0U ) && ( msgSize < msgBufferSize ) );
 
     return msgSize;
 }
@@ -564,8 +564,10 @@ static uint32_t prvBuildStatusMessageFinish( char * pMsgBuffer,
                                      msgBufferSize,
                                      pOtaJobStatusStatusTemplate,
                                      pOtaJobStatusStrings[ status ] );
+
     /* The buffer is static and the size is calculated to fit. */
-    assert( ( msgSize > 0U ) && ( msgSize < sizeof( pMsgBuffer ) ) );
+    assert( ( msgSize > 0U ) && ( msgSize < msgBufferSize ) );
+
 
     /* FailedWithVal uses a numeric OTA error code and sub-reason code to cover
      * the case where there may be too many description strings to reasonably
@@ -580,7 +582,7 @@ static uint32_t prvBuildStatusMessageFinish( char * pMsgBuffer,
                                              subReason );
         msgSize += msgTailSize;
         /* The buffer is static and the size is calculated to fit. */
-        assert( ( msgTailSize > 0U ) && ( msgSize < sizeof( pMsgBuffer ) ) );
+        assert( ( msgTailSize > 0U ) && ( msgSize < msgBufferSize ) );
     }
 
     /* If the status update is for "Succeeded," we are identifying the version
@@ -603,7 +605,7 @@ static uint32_t prvBuildStatusMessageFinish( char * pMsgBuffer,
                                              newVersion.u.x.build );
         msgSize += msgTailSize;
         /* The buffer is static and the size is calculated to fit. */
-        assert( ( msgTailSize > 0U ) && ( msgSize < sizeof( pMsgBuffer ) ) );
+        assert( ( msgTailSize > 0U ) && ( msgSize < msgBufferSize ) );
     }
 
     /* Status updates that are NOT "InProgress" or "Succeeded" or "FailedWithVal" map status and
@@ -618,7 +620,7 @@ static uint32_t prvBuildStatusMessageFinish( char * pMsgBuffer,
                                              subReason );
         msgSize += msgTailSize;
         /* The buffer is static and the size is calculated to fit. */
-        assert( ( msgTailSize > 0U ) && ( msgSize < sizeof( pMsgBuffer ) ) );
+        assert( ( msgTailSize > 0U ) && ( msgSize < msgBufferSize ) );
     }
 
     return msgSize;

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -564,10 +564,8 @@ static uint32_t prvBuildStatusMessageFinish( char * pMsgBuffer,
                                      msgBufferSize,
                                      pOtaJobStatusStatusTemplate,
                                      pOtaJobStatusStrings[ status ] );
-
     /* The buffer is static and the size is calculated to fit. */
     assert( ( msgSize > 0U ) && ( msgSize < msgBufferSize ) );
-
 
     /* FailedWithVal uses a numeric OTA error code and sub-reason code to cover
      * the case where there may be too many description strings to reasonably


### PR DESCRIPTION
Cherry-pick a fix for the asserts in ota_mqtt.c from development to main.

Co-authored-by: Tiangang Song <ts.whu@outlook.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
