### PR TITLE
Add missing assert header in ota interface

### DIFF
--- a/source/ota_interface.c
+++ b/source/ota_interface.c
@@ -30,6 +30,7 @@
 
 /* Standard library includes. */
 #include <string.h>
+#include <assert.h>
 
 /* OTA interface includes. */
 #include "ota_interface_private.h"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change add include for the missing assert header.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
