### PR TITLE
Modified configs and cmake to run test over http

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -92,6 +92,6 @@ add_subdirectory( unit-test )
 add_custom_target( coverage
     COMMAND ${CMAKE_COMMAND} -DCMOCK_DIR=${CMOCK_DIR}
     -P ${MODULE_ROOT_DIR}/tools/cmock/coverage.cmake
-    DEPENDS cmock unity ota_utest ota_base64_utest ota_job_parsing_utest ota_cbor_utest ota_http_utest ota_os_posix_utest
+    DEPENDS cmock unity ota_utest ota_base64_utest ota_job_parsing_utest ota_cbor_utest ota_http_utest ota_os_posix_utest ota_http_utest
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )

--- a/test/http_configs/ota_config.h
+++ b/test/http_configs/ota_config.h
@@ -1,0 +1,36 @@
+/*
+ * AWS IoT Device SDK for Embedded C V202009.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file ota_config.h
+ * @brief OTA user configurable settings.
+ */
+
+#ifndef OTA_CONFIG_H_
+#define OTA_CONFIG_H_
+
+/* Dummy ota_config.h for building the library. */
+
+#endif /* _OTA_CONFIG_H_ */

--- a/test/http_configs/utest_helpers.h
+++ b/test/http_configs/utest_helpers.h
@@ -1,0 +1,42 @@
+/*
+ * FreeRTOS OTA V1.2.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+#ifndef _UTEST_HELPERS_
+#define _UTEST_HELPERS_
+
+#include <cbor.h>
+
+#define CBOR_TEST_GETSTREAMRESPONSE_MESSAGE_ITEM_COUNT    4
+#define CBOR_TEST_CLIENTTOKEN_VALUE                       "ThisIsAClientToken"
+#define CBOR_TEST_FILEIDENTITY_VALUE                      0
+
+CborError createOtaStreammingMessage( uint8_t * pMessageBuffer,
+                                      size_t messageBufferSize,
+                                      int blockIndex,
+                                      uint8_t * pBlockPayload,
+                                      size_t blockPayloadSize,
+                                      size_t * pEncodedSize );
+
+#endif /* ifndef _UTEST_HELPERS_ */

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -29,6 +29,7 @@ list(APPEND real_source_files
     "${MODULE_ROOT_DIR}/source/ota.c"
     "${MODULE_ROOT_DIR}/source/ota_interface.c"
     "${MODULE_ROOT_DIR}/source/ota_base64.c"
+    "${MODULE_ROOT_DIR}/source/ota_http.c"
     "${MODULE_ROOT_DIR}/source/ota_mqtt.c"
     "${MODULE_ROOT_DIR}/source/ota_cbor.c"
     "${MODULE_ROOT_DIR}/source/portable/os/ota_os_posix.c"
@@ -44,6 +45,13 @@ list(APPEND real_include_directories
     ${OTA_INCLUDE_OS_POSIX_DIRS}
 )
 
+list(APPEND real_include_directories_http
+    "../http_configs"
+    ${OTA_INCLUDE_PUBLIC_DIRS}
+    ${OTA_INCLUDE_PRIVATE_DIRS}
+    ${OTA_INCLUDE_OS_POSIX_DIRS}
+)
+
 # =====================  Create UnitTest Code here (edit)  =====================
 
 # list the directories your test needs to include
@@ -53,6 +61,7 @@ list(APPEND test_include_directories ".")
 
 set(mock_name "${project_name}_mock")
 set(real_name "${project_name}_real")
+set(real_name_http "${project_name}_real_http")
 
 create_mock_list(${mock_name}
     "${mock_list}"
@@ -67,6 +76,12 @@ create_real_library(${real_name}
     "${mock_name}"
 )
 
+create_real_library(${real_name_http}
+    "${real_source_files}"
+    "${real_include_directories_http}"
+    "${mock_name}"
+)
+
 list(APPEND utest_link_list
     -lpthread
     -l${mock_name}
@@ -74,8 +89,18 @@ list(APPEND utest_link_list
     -lrt
 )
 
+list(APPEND utest_link_list_http
+    -lpthread
+    -l${mock_name}
+    lib${real_name_http}.a
+)
+
 list(APPEND utest_dep_list
     ${real_name}
+)
+
+list(APPEND utest_dep_list_http
+    ${real_name_http}
 )
 
 create_test(ota_utest
@@ -112,6 +137,13 @@ create_test(ota_os_posix_utest
     "${utest_mem_ops_list}"
     "${utest_dep_list}"
     "${test_include_directories}"
+)
+
+create_test(ota_http_utest
+    "ota_utest.c"
+    "${utest_link_list_http}"
+    "${utest_dep_list_http}"
+    "../http_configs"
 )
 # Disable unity memory handling since we need to free memory allocated from library.
 target_compile_definitions(ota_cbor_utest PRIVATE UNITY_FIXTURE_NO_EXTRAS)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Modifying configurations to run the ota utests on http data plane.
Changed cmake to point to different ota_config.h for ota_http_utest.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
