### PR TITLE
Fix PAL error codes

### DIFF
--- a/source/include/ota.h
+++ b/source/include/ota.h
@@ -285,29 +285,6 @@ typedef struct OtaAgentContext
     OtaCustomJobCallback_t customJobCallback;              /*!< Custom job callback. */
 } OtaAgentContext_t;
 
-/*------------------------- OTA defined constants --------------------------*/
-
-/**
- * @constantspage{ota,OTA library}
- *
- * @section ota_constants_err_code_helpers OTA Error Code Helper constants
- * @brief OTA Error code helper constant for extracting the error code from the OTA error returned.
- *
- * @snippet this define_ota_err_code_helpers
- *
- * OTA error codes consist of an agent code in the upper 8 bits of a 32 bit word and sometimes
- * merged with a platform specific code in the lower 24 bits. You must refer to the platform PAL
- * layer in use to determine the meaning of the lower 24 bits.
- */
-
-/* @[define_ota_err_code_helpers] */
-#define OTA_PAL_ERR_MASK                0xffffffUL                                               /*!< The PAL layer uses the signed low 24 bits of the OTA error code. */
-#define OTA_MAIN_ERR_SHIFT_DOWN_BITS    24U                                                      /*!< The OTA Agent error code is the highest 8 bits of the word. */
-#define OTA_MAIN_ERR( err )    ( ( uint32_t ) err >> ( uint32_t ) OTA_MAIN_ERR_SHIFT_DOWN_BITS ) /*!< Helper to get the OTA library error code. */
-#define OTA_PAL_ERR( err )     ( ( uint32_t ) err & ( uint32_t ) OTA_PAL_ERR_MASK )              /*!< Helper to get the OTA PAL error code. */
-/* @[define_ota_err_code_helpers] */
-
-
 /*------------------------- OTA Public API --------------------------*/
 
 /**

--- a/source/include/ota.h
+++ b/source/include/ota.h
@@ -99,7 +99,8 @@ typedef enum OtaErr
     OtaErrNoActiveJob,            /*!< Attempt to set final image state without an active job. */
     OtaErrUserAbort,              /*!< User aborted the active OTA. */
     OtaErrFailedToEncodeCbor,     /*!< Failed to encode CBOR object for requesting data block from streaming service. */
-    OtaErrFailedToDecodeCbor      /*!< Failed to decode CBOR object from streaming service response. */
+    OtaErrFailedToDecodeCbor,     /*!< Failed to decode CBOR object from streaming service response. */
+    OtaErrActivateFailed          /*!< Failed to activate the new image. */
 } OtaErr_t;
 
 /**

--- a/source/include/ota_platform_interface.h
+++ b/source/include/ota_platform_interface.h
@@ -45,6 +45,8 @@ typedef enum OtaPalMainStatus
 {
     OtaPalSuccess = 0,          /*!< OTA platform interface success. */
     OtaPalUninitialized = 0xe0, /*!< Result is not yet initialized from PAL. */
+    OtaPalOutOfMemory,          /*!< Out of memory. */
+    OtaPalNullFileContext,      /*!< The PAL is called with a NULL file context. */
     OtaPalSignatureCheckFailed, /*!< The signature check failed for the specified file. */
     OtaPalRxFileCreateFailed,   /*!< The PAL failed to create the OTA receive file. */
     OtaPalRxFileTooLarge,       /*!< The OTA receive file is too big for the platform to support. */

--- a/source/include/ota_platform_interface.h
+++ b/source/include/ota_platform_interface.h
@@ -29,9 +29,19 @@
 #include "ota_private.h"
 
 /**
- * @brief The OTA platform interface return status.
+ * @brief The OTA platform interface return status. Composed of main and sub status.
  */
-typedef enum OtaPalStatus
+typedef uint32_t   OtaPalStatus_t;
+
+/**
+ * @brief The OTA platform interface sub status.
+ */
+typedef uint32_t   OtaPalSubStatus_t;
+
+/**
+ * @brief The OTA platform interface main status.
+ */
+typedef enum OtaPalMainStatus
 {
     OtaPalSuccess = 0,          /*!< OTA platform interface success. */
     OtaPalUninitialized = 0xe0, /*!< Result is not yet initialized from PAL. */
@@ -47,7 +57,28 @@ typedef enum OtaPalStatus
     OtaPalActivateFailed,       /*!< The activation of the new OTA image failed. */
     OtaPalFileAbort,            /*!< Error in low level file abort. */
     OtaPalFileClose             /*!< Error in low level file close. */
-} OtaPalStatus_t;
+} OtaPalMainStatus_t;
+
+/**
+ * @constantspage{ota,OTA library}
+ *
+ * @section ota_constants_err_code_helpers OTA Error Code Helper constants
+ * @brief OTA PAL Error code helper for extracting the error code from the OTA PAL.
+ *
+ * @snippet this define_ota_err_code_helpers
+ *
+ * OTA pal error codes consist of an main code in the upper 8 bits of a 32 bit word and sometimes
+ * merged with a platform specific code in the lower 24 bits. You must refer to the platform PAL
+ * layer in use to determine the meaning of the lower 24 bits.
+ */
+
+/* @[define_ota_err_code_helpers] */
+#define OTA_PAL_ERR_MASK    0xffffffUL                                                                                /*!< The PAL layer uses the signed low 24 bits of the OTA error code. */
+#define OTA_PAL_SUB_BITS    24U                                                                                       /*!< The OTA Agent error code is the highest 8 bits of the word. */
+#define OTA_PAL_MAIN_ERR( err )             ( ( uint32_t ) err >> ( uint32_t ) OTA_PAL_SUB_BITS )                     /*!< Helper to get the OTA library error code. */
+#define OTA_PAL_SUB_ERR( err )              ( ( uint32_t ) err & ( uint32_t ) OTA_PAL_ERR_MASK )                      /*!< Helper to get the OTA PAL error code. */
+#define OTA_PAL_COMBINE_ERR( main, sub )    ( ( uint32_t ) main << ( uint32_t ) OTA_PAL_SUB_BITS | ( uint32_t ) sub ) /*!< Helper to combine the OTA PAL main and sub error code. */
+/* @[define_ota_err_code_helpers] */
 
 /**
  * @brief Abort an OTA transfer.

--- a/source/ota.c
+++ b/source/ota.c
@@ -446,18 +446,18 @@ static OtaErr_t setImageStateWithReason( OtaImageState_t stateToSet,
                                          uint32_t reasonToSet )
 {
     OtaErr_t err = OtaErrNone;
-    OtaPalStatus_t palErr = OtaPalSuccess;
     OtaImageState_t state = stateToSet;
     uint32_t reason = reasonToSet;
+    OtaPalStatus_t palStatus;
 
     /* Call the platform specific code to set the image state. */
-    palErr = otaAgent.pOtaInterface->pal.setPlatformImageState( &( otaAgent.fileContext ), state );
+    palStatus = otaAgent.pOtaInterface->pal.setPlatformImageState( &( otaAgent.fileContext ), state );
 
     /*
      * If the platform image state couldn't be set correctly, force fail the update by setting the
      * image state to "Rejected" unless it's already in "Aborted".
      */
-    if( ( palErr != OtaPalSuccess ) && ( state != OtaImageStateAborted ) )
+    if( ( OTA_PAL_MAIN_ERR( palStatus ) != OtaPalSuccess ) && ( state != OtaImageStateAborted ) )
     {
         /* Intentionally override state since we failed within this function. */
         state = OtaImageStateRejected;
@@ -470,7 +470,7 @@ static OtaErr_t setImageStateWithReason( OtaImageState_t stateToSet,
         if( reason == OtaErrNone )
         {
             /* Intentionally override reason since we failed within this function. */
-            reason = palErr;
+            reason = palStatus;
         }
     }
 
@@ -494,7 +494,7 @@ static OtaErr_t setImageStateWithReason( OtaImageState_t stateToSet,
                    ", state=%d"
                    ", reason=%d",
                    err,
-                   palErr,
+                   palStatus,
                    stateToSet,
                    reasonToSet ) );
     }
@@ -614,11 +614,9 @@ static OtaErr_t requestJobHandler( const OtaEventData_t * pEventData )
             }
             else
             {
-                /*
-                 * Too many requests have been sent without a response or too many failures
-                 * when trying to publish the request message. Abort. Store attempt count in low bits.
-                 */
-                retVal = ( uint32_t ) OtaErrMomentumAbort | OTA_PAL_ERR( otaconfigMAX_NUM_REQUEST_MOMENTUM );
+                /* Too many requests have been sent without a response or too many failures
+                 * when trying to publish the request message. Abort. */
+                retVal = OtaErrMomentumAbort;
             }
         }
     }
@@ -804,8 +802,8 @@ static OtaErr_t initFileHandler( const OtaEventData_t * pEventData )
             else
             {
                 /* Too many requests have been sent without a response or too many failures
-                 * when trying to publish the request message. Abort. Store attempt count in low bits. */
-                err = ( uint32_t ) OtaErrMomentumAbort | OTA_PAL_ERR( otaconfigMAX_NUM_REQUEST_MOMENTUM );
+                 * when trying to publish the request message. Abort. */
+                err = OtaErrMomentumAbort;
             }
         }
     }
@@ -875,8 +873,8 @@ static OtaErr_t requestDataHandler( const OtaEventData_t * pEventData )
             else
             {
                 /* Too many requests have been sent without a response or too many failures
-                 * when trying to publish the request message. Abort. Store attempt count in low bits. */
-                err = ( uint32_t ) OtaErrMomentumAbort | OTA_PAL_ERR( otaconfigMAX_NUM_REQUEST_MOMENTUM );
+                 * when trying to publish the request message. Abort. */
+                err = OtaErrMomentumAbort;
 
                 /* Reset the request momentum. */
                 otaAgent.requestMomentum = 0;
@@ -919,7 +917,7 @@ static void dataHandlerCleanup( IngestResult_t result )
 static OtaErr_t processDataHandler( const OtaEventData_t * pEventData )
 {
     OtaErr_t err = OtaErrNone;
-    OtaPalStatus_t closeResult = OtaPalUninitialized;
+    OtaPalStatus_t closeResult = OTA_PAL_COMBINE_ERR( OtaPalUninitialized, 0 );
     OtaEventMsg_t eventMsg = { 0 };
 
     /* Get the file context. */
@@ -2158,7 +2156,7 @@ static IngestResult_t processDataBlock( OtaFileContext_t * pFileContext,
                         pFileContext->blocksRemaining ) );
 
             eIngestResult = IngestResultDuplicate_Continue;
-            *pCloseResult = OtaPalSuccess; /* This is a success path. */
+            *pCloseResult = OTA_PAL_COMBINE_ERR( OtaPalSuccess, 0 ); /* This is a success path. */
         }
     }
     else
@@ -2191,7 +2189,7 @@ static IngestResult_t processDataBlock( OtaFileContext_t * pFileContext,
                 pFileContext->pRxBlockBitmap[ byte ] &= ( uint8_t ) ~bitMask;
                 pFileContext->blocksRemaining--;
                 eIngestResult = IngestResultAccepted_Continue;
-                *pCloseResult = OtaPalSuccess;
+                *pCloseResult = OTA_PAL_COMBINE_ERR( OtaPalSuccess, 0 );
             }
         }
         else
@@ -2286,6 +2284,8 @@ static IngestResult_t ingestDataBlockCleanup( OtaFileContext_t * pFileContext,
                                               OtaPalStatus_t * pCloseResult )
 {
     IngestResult_t eIngestResult = IngestResultAccepted_Continue;
+    OtaPalMainStatus_t otaPalMainErr;
+    OtaPalSubStatus_t otaPalSubErr;
 
     if( pFileContext->blocksRemaining == 0U )
     {
@@ -2305,21 +2305,20 @@ static IngestResult_t ingestDataBlockCleanup( OtaFileContext_t * pFileContext,
         if( pFileContext->pFile != NULL )
         {
             *pCloseResult = otaAgent.pOtaInterface->pal.closeFile( pFileContext );
+            otaPalMainErr = OTA_PAL_MAIN_ERR( *pCloseResult );
+            otaPalSubErr = OTA_PAL_SUB_ERR( *pCloseResult );
 
-            if( *pCloseResult == OtaPalSuccess )
+            if( otaPalMainErr == OtaPalSuccess )
             {
                 LogInfo( ( "Received entire update and validated the signature." ) );
                 eIngestResult = IngestResultFileComplete;
             }
             else
             {
-                uint32_t closeResult = ( uint32_t ) *pCloseResult;
-
                 LogError( ( "Failed to close the OTA file: Error=(%u:0x%06x)",
-                            OTA_MAIN_ERR( closeResult ),
-                            OTA_PAL_ERR( closeResult ) ) );
+                            otaPalMainErr, otaPalSubErr ) );
 
-                if( OTA_PAL_ERR( closeResult ) == OtaPalSignatureCheckFailed )
+                if( otaPalMainErr == OtaPalSignatureCheckFailed )
                 {
                     eIngestResult = IngestResultSigCheckFail;
                 }

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -105,7 +105,7 @@ static FILE * pOtaFileHandle = NULL;
 static uint8_t pOtaFileBuffer[ OTA_TEST_FILE_SIZE ];
 
 /* Default wait time for OTA state machine transition. */
-static const int otaDefaultWait = 1000;
+static const int otaDefaultWait = 2000;
 
 /* ========================================================================== */
 

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -272,19 +272,19 @@ static OtaHttpStatus_t stubHttpDeinit()
 
 OtaPalStatus_t mockPalAbort( OtaFileContext_t * const pFileContext )
 {
-    return OtaPalSuccess;
+    return OTA_PAL_COMBINE_ERR( OtaPalSuccess, 0 );
 }
 
 OtaPalStatus_t mockPalCreateFileForRx( OtaFileContext_t * const pFileContext )
 {
     pOtaFileHandle = ( FILE * ) pOtaFileBuffer;
     pFileContext->pFile = pOtaFileHandle;
-    return OtaPalSuccess;
+    return OTA_PAL_COMBINE_ERR( OtaPalSuccess, 0 );
 }
 
 OtaPalStatus_t mockPalCloseFile( OtaFileContext_t * const pFileContext )
 {
-    return OtaPalSuccess;
+    return OTA_PAL_COMBINE_ERR( OtaPalSuccess, 0 );
 }
 
 int16_t mockPalWriteBlock( OtaFileContext_t * const pFileContext,
@@ -303,24 +303,24 @@ int16_t mockPalWriteBlock( OtaFileContext_t * const pFileContext,
 
 OtaPalStatus_t mockPalActivate( OtaFileContext_t * const pFileContext )
 {
-    return OtaPalSuccess;
+    return OTA_PAL_COMBINE_ERR( OtaPalSuccess, 0 );
 }
 
 OtaPalStatus_t mockPalActivateReturnFail( OtaFileContext_t * const pFileContext )
 {
-    return OtaPalActivateFailed;
+    return OTA_PAL_COMBINE_ERR( OtaPalActivateFailed, 0 );
 }
 
 OtaPalStatus_t mockPalResetDevice( OtaFileContext_t * const pFileContext )
 {
-    return OtaPalSuccess;
+    return OTA_PAL_COMBINE_ERR( OtaPalSuccess, 0 );
 }
 
 OtaPalStatus_t mockPalSetPlatformImageState( OtaFileContext_t * const pFileContext,
                                              OtaImageState_t eState )
 {
     imageState = eState;
-    return OtaPalSuccess;
+    return OTA_PAL_COMBINE_ERR( OtaPalSuccess, 0 );
 }
 
 OtaPalImageState_t mockPalGetPlatformImageState( OtaFileContext_t * const pFileContext )
@@ -786,7 +786,7 @@ void test_OTA_ActivateNewImage()
     TEST_ASSERT_EQUAL( OtaErrNone, OTA_ActivateNewImage() );
 
     otaInterfaces.pal.activate = mockPalActivateReturnFail;
-    TEST_ASSERT_EQUAL( OtaPalActivateFailed, OTA_ActivateNewImage() );
+    TEST_ASSERT_EQUAL( OtaErrActivateFailed, OTA_ActivateNewImage() );
 }
 
 /* OTA pal function pointers should be NULL when OTA agent stopped. Calling OTA_ActivateNewImage

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -648,3 +648,4 @@ deinitializing
 palerr
 otapaloutofmemory
 otapalnullfilecontext
+otaerractivatefailed

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -646,3 +646,5 @@ otaostimerstopfailed
 otaostimerdeletefailed
 deinitializing
 palerr
+otapaloutofmemory
+otapalnullfilecontext


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
OTA PAL error codes are composed inside PAL implementation, thus PAL interface should return uint32_t error codes (combined with main and sub) instead.

**Notes:**

- `otaconfigMAX_NUM_REQUEST_MOMENTUM` is removed from `OtaErrMomentumAbort` because it's directly returned from state machine handler and not reported to the cloud. We will print this error, so composing here is unnecessary and will cause confusing when reading the log error message.
- Default wait time in OTA unit tests is increased to 2s since it seems too short for `test_OTA_ReceiveFileBlockComplete` test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
