### PR TITLE
Fix an intermittent failure in unit tests

### DIFF
--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -1223,7 +1223,7 @@ void test_OTA_ReceiveFileBlockCompleteMqtt()
     }
 
     /* OTA agent should complete the update and go back to waiting for job state. */
-    otaWaitForEmptyEvent();
+    otaWaitForState( OtaAgentStateWaitingForJob );
     TEST_ASSERT_EQUAL( OtaAgentStateWaitingForJob, OTA_GetState() );
 
     /* Check if received complete file. */
@@ -1279,7 +1279,7 @@ void test_OTA_ReceiveFileBlockCompleteHttp()
     }
 
     /* OTA agent should complete the update and go back to waiting for job state. */
-    otaWaitForEmptyEvent();
+    otaWaitForState( OtaAgentStateWaitingForJob );
     TEST_ASSERT_EQUAL( OtaAgentStateWaitingForJob, OTA_GetState() );
 
     /* Check if received complete file. */

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -1269,7 +1269,6 @@ void test_OTA_ReceiveFileBlockCompleteHttp()
         fileBlockSize = min( remainingBytes, OTA_FILE_BLOCK_SIZE );
         otaEvent.eventId = OtaAgentEventReceivedFileBlock;
         otaEvent.pEventData = &eventBuffers[ idx ];
-        memset( eventBuffer.data, 0, OTA_DATA_BLOCK_SIZE );
         memcpy( otaEvent.pEventData->data, pFileBlock, fileBlockSize );
         otaEvent.pEventData->dataLength = fileBlockSize;
         OTA_SignalEvent( &otaEvent );


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Address an intermittent failure in unit tests. Sometimes the event queue might be empty but event handler has not yet finished, which would cause the assertion fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
