### PR TITLE
Remove callbacks from OTA mqtt interface

### DIFF
--- a/source/include/ota_mqtt_interface.h
+++ b/source/include/ota_mqtt_interface.h
@@ -42,11 +42,6 @@ typedef enum OtaMqttStatus
 } OtaMqttStatus_t;
 
 /**
- * @brief OTA Mqtt callback.
- */
-typedef void ( * OtaMqttCallback_t )( void * pvParam );
-
-/**
  * @brief Subscribe to the Mqtt topics.
  *
  * This function subscribes to the Mqtt topics with the Quality of service
@@ -59,15 +54,12 @@ typedef void ( * OtaMqttCallback_t )( void * pvParam );
  *
  * @param[ucQoS]                Quality of Service
  *
- * @param[pvCallback]           Callback to be registered.
- *
  * @return                      OtaMqttSuccess if success , other error code on failure.
  */
 
 typedef OtaMqttStatus_t ( * OtaMqttSubscribe_t ) ( const char * pTopicFilter,
                                                    uint16_t topicFilterLength,
-                                                   uint8_t ucQoS,
-                                                   OtaMqttCallback_t callback );
+                                                   uint8_t ucQoS );
 
 /**
  * @brief Unsubscribe to the Mqtt topics.
@@ -119,8 +111,6 @@ typedef struct OtaMqttInterface
     OtaMqttSubscribe_t subscribe;     /*!< Interface for subscribing to Mqtt topics. */
     OtaMqttUnsubscribe_t unsubscribe; /*!< interface for unsubscribing to MQTT topics. */
     OtaMqttPublish_t publish;         /*!< Interface for publishing MQTT messages. */
-    OtaMqttCallback_t jobCallback;    /*!< Interface for a callback that notifies the OTA library when a job document is received. */
-    OtaMqttCallback_t dataCallback;   /*!< Interface for a callback that notifies the OTA library when a data block is received. */
 } OtaMqttInterface_t;
 
 #endif /* ifndef _OTA_MQTT_INTERFACE_H_ */

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -247,8 +247,7 @@ static OtaMqttStatus_t subscribeToJobNotificationTopics( const OtaAgentContext_t
 
     mqttStatus = pAgentCtx->pOtaInterface->mqtt.subscribe( pJobTopicGetNext,
                                                            topicLen,
-                                                           1,
-                                                           pAgentCtx->pOtaInterface->mqtt.jobCallback );
+                                                           1 );
 
     if( mqttStatus == OtaMqttSuccess )
     {
@@ -280,8 +279,7 @@ static OtaMqttStatus_t subscribeToJobNotificationTopics( const OtaAgentContext_t
 
         mqttStatus = pAgentCtx->pOtaInterface->mqtt.subscribe( pJobTopicNotifyNext,
                                                                topicLen,
-                                                               1,
-                                                               pAgentCtx->pOtaInterface->mqtt.jobCallback );
+                                                               1 );
 
         if( mqttStatus == OtaMqttSuccess )
         {
@@ -804,8 +802,7 @@ OtaErr_t initFileTransfer_Mqtt( OtaAgentContext_t * pAgentCtx )
 
     mqttStatus = pAgentCtx->pOtaInterface->mqtt.subscribe( pRxStreamTopic,
                                                            topicLen,
-                                                           0,
-                                                           pAgentCtx->pOtaInterface->mqtt.dataCallback );
+                                                           0 );
 
     if( mqttStatus == OtaMqttSuccess )
     {

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -269,8 +269,7 @@ static OtaOsStatus_t stubOSTimerDelete( OtaTimerId_t timerId )
 
 static OtaMqttStatus_t stubMqttSubscribe( const char * unused_1,
                                           uint16_t unused_2,
-                                          uint8_t unused_3,
-                                          OtaMqttCallback_t unused_4 )
+                                          uint8_t unused_3 )
 {
     return OtaMqttSuccess;
 }
@@ -298,14 +297,6 @@ static OtaMqttStatus_t stubMqttUnsubscribe( const char * unused_1,
                                             uint8_t unused_3 )
 {
     return OtaMqttSuccess;
-}
-
-static void stubMqttJobCallback( void * unused )
-{
-}
-
-static void stubMqttDataCallback( void * unused )
-{
 }
 
 static OtaHttpStatus_t stubHttpInit( char * url )
@@ -441,8 +432,6 @@ static void otaInterfaceDefault()
     otaInterfaces.mqtt.subscribe = stubMqttSubscribe;
     otaInterfaces.mqtt.publish = stubMqttPublish;
     otaInterfaces.mqtt.unsubscribe = stubMqttUnsubscribe;
-    otaInterfaces.mqtt.jobCallback = stubMqttJobCallback;
-    otaInterfaces.mqtt.dataCallback = stubMqttDataCallback;
 
     otaInterfaces.http.init = stubHttpInit;
     otaInterfaces.http.deinit = stubHttpDeinit;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change removes the unnecessary round trip for mqtt callbacks and updates the OTA mqtt interface definition.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
