### PR TITLE
Add back bufferUsed to event data stuct

### DIFF
--- a/source/include/ota_private.h
+++ b/source/include/ota_private.h
@@ -425,6 +425,7 @@ typedef struct OtaEventData
 {
     uint8_t data[ OTA_DATA_BLOCK_SIZE ]; /*!< Buffer for storing event information. */
     uint32_t dataLength;                 /*!< Total space required for the event. */
+    bool bufferUsed;                     /*!< Flag set when buffer is used otherwise cleared. */
 } OtaEventData_t;
 
 /**

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -34,6 +34,7 @@ bool
 bootloader
 br
 buf
+bufferused
 bytesreceived
 bytessent
 bytestorecv


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The event data structure was updated incorrectly and this change restores the bufferused member in it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
