### PR TITLE
GHA: Release automation.

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,0 +1,114 @@
+name: Release automation
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_id:
+        description: 'Commit ID to tag and create a release for'
+        required: true
+      version_number:
+        description: 'Release Version Number (Eg, v1.0.0)'
+        required: true
+
+jobs:
+  tag-commit:
+    name: Tag commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.commit_id }}
+      - name: Configure git identity
+        run: |
+            git config --global user.name "Release Workflow"
+      - name: Tag Commit and Push to remote
+        run: |
+          git tag ${{ github.event.inputs.version_number }} -a -m "OTA For AWS IoT Embedded SDK ${{ github.event.inputs.version_number }}"
+          git push origin --tags
+      - name: Verify tag on remote
+        run: |
+          git tag -d ${{ github.event.inputs.version_number }}
+          git remote update
+          git checkout tags/${{ github.event.inputs.version_number }}
+          git diff ${{ github.event.inputs.commit_id }} tags/${{ github.event.inputs.version_number }}
+  create-zip:
+    needs: tag-commit
+    name: Create ZIP and verify package for release asset.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install ZIP tools
+        run: sudo apt-get install zip unzip
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.commit_id }}
+          path: ota-for-aws-iot-embedded-sdk
+          submodules: recursive
+      - name: Checkout disabled submodules
+        run: |
+          cd ota-for-aws-iot-embedded-sdk
+          git submodule update --init --checkout --recursive
+      - name: Create ZIP
+        run: |
+          zip -r ota-for-aws-iot-embedded-sdk-${{ github.event.inputs.version_number }}.zip ota-for-aws-iot-embedded-sdk -x "*.git*"
+          ls ./
+      - name: Validate created ZIP
+        run: |
+          mkdir zip-check
+          mv ota-for-aws-iot-embedded-sdk-${{ github.event.inputs.version_number }}.zip zip-check
+          cd zip-check
+          unzip ota-for-aws-iot-embedded-sdk-${{ github.event.inputs.version_number }}.zip -d ota-for-aws-iot-embedded-sdk-${{ github.event.inputs.version_number }}
+          ls ota-for-aws-iot-embedded-sdk-${{ github.event.inputs.version_number }}
+          diff -r -x "*.git*" ota-for-aws-iot-embedded-sdk-${{ github.event.inputs.version_number }}/ota-for-aws-iot-embedded-sdk/ ../ota-for-aws-iot-embedded-sdk/
+          cd ../
+      - name: Build
+        run: |
+          cd zip-check/ota-for-aws-iot-embedded-sdk-${{ github.event.inputs.version_number }}/ota-for-aws-iot-embedded-sdk
+          sudo apt-get install -y lcov
+          cmake -S test -B build/ \
+          -G "Unix Makefiles" \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DBUILD_CLONE_SUBMODULES=ON \
+          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror'
+          make -C build/ all
+      - name: Test
+        run: |
+          cd zip-check/ota-for-aws-iot-embedded-sdk-${{ github.event.inputs.version_number }}/ota-for-aws-iot-embedded-sdk/build/
+          ctest -E system --output-on-failure
+          cd ..
+      - name: Create artifact of ZIP
+        uses: actions/upload-artifact@v2
+        with:
+          name: ota-for-aws-iot-embedded-sdk-${{ github.event.inputs.version_number }}.zip
+          path: zip-check/ota-for-aws-iot-embedded-sdk-${{ github.event.inputs.version_number }}.zip
+  create-release:
+    needs: create-zip
+    name: Create Release and Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.version_number }}
+          release_name: ${{ github.event.inputs.version_number }}
+          body: Release ${{ github.event.inputs.version_number }} of OTA For AWS IoT Embedded SDK.
+          draft: false
+          prerelease: false
+      - name: Download ZIP artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ota-for-aws-iot-embedded-sdk-${{ github.event.inputs.version_number }}.zip
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./ota-for-aws-iot-embedded-sdk-${{ github.event.inputs.version_number }}.zip
+          asset_name: ota-for-aws-iot-embedded-sdk-${{ github.event.inputs.version_number }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -24,7 +24,7 @@ jobs:
             git config --global user.name "Release Workflow"
       - name: Tag Commit and Push to remote
         run: |
-          git tag ${{ github.event.inputs.version_number }} -a -m "OTA For AWS IoT Embedded SDK ${{ github.event.inputs.version_number }}"
+          git tag ${{ github.event.inputs.version_number }} -a -m "OTA for AWS IoT Embedded SDK ${{ github.event.inputs.version_number }}"
           git push origin --tags
       - name: Verify tag on remote
         run: |
@@ -95,7 +95,7 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.version_number }}
           release_name: ${{ github.event.inputs.version_number }}
-          body: Release ${{ github.event.inputs.version_number }} of OTA For AWS IoT Embedded SDK.
+          body: Release ${{ github.event.inputs.version_number }} of OTA for AWS IoT Embedded SDK.
           draft: false
           prerelease: false
       - name: Download ZIP artifact


### PR DESCRIPTION
Release automation for OTA.

*Description of changes:*
**Release automation**
**Add a GitHub Action job to trigger a release process** which includes operations of: 
1. Creating and pushing the release tag to the repository 
2. Verifying the pushed tag (performing a diff with the commit ID which is tagged) 
3. Creating a ZIP for the release asset. 
4. Verifying the ZIP by performing a diff check and running unit tests on the unzipped files.
5. Creating a release on the repository for the tag, and uploading the ZIP as the release asset

*Testing*
**Release Automation**
The workflow can be manually triggered and takes the input values of **Commit ID** (to create a release for) and the **Version string** for tagging the release with
Test run of the GHA run on my fork
https://github.com/leegeth/ota-for-aws-iot-embedded-sdk/actions/runs/409972413

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
