### PR TITLE
Fix the string buffer used for topic

### DIFF
--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -407,8 +407,8 @@ static OtaMqttStatus_t subscribeToJobNotificationTopics( const OtaAgentContext_t
         /* Build and subscribe to the second topic. Only the last part of the topic string changes. */
         topicStringParts[ 2 ] = MQTT_API_JOBS_NOTIFY_NEXT;
         topicLen = ( uint16_t ) stringBuilder(
-            pJobTopicGetNext,
-            sizeof( pJobTopicGetNext ),
+            pJobTopicNotifyNext,
+            sizeof( pJobTopicNotifyNext ),
             topicStringParts );
 
         /* The buffer is static and the size is calculated to fit. */


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change fixes a bug in the ota_mqtt component where incorrect string buffer was used.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
