### PR TITLE
Remove TODO statement from ota_os_posix_utest.c

### DIFF
--- a/test/unit-test/ota_os_posix_utest.c
+++ b/test/unit-test/ota_os_posix_utest.c
@@ -95,10 +95,6 @@ void test_OTA_posix_SendAndRecvEvent( void )
 
 /**
  * @brief Test that the event queue operations do not succeed for invalid operations.
- *
- * TODO: 1. need to use timed send or O_NONBLOCK to test event recv failure
- * 2. Since the queue is unlinked and other params are not variable, can not test init fail
- * 3. Need to set O_NONBLOCK flag for testing send failure
  */
 void test_OTA_posix_InvalidEventQueue( void )
 {


### PR DESCRIPTION
Remove this statement in favor of tracking the issue internally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
