### PR TITLE
Reset self test flag before parsing job doc

### DIFF
--- a/source/ota.c
+++ b/source/ota.c
@@ -954,6 +954,9 @@ static OtaErr_t processJobHandler( const OtaEventData_t * pEventData )
     OtaErr_t retVal = OtaErrNone;
     OtaFileContext_t * pOtaFileContext = NULL;
 
+    /* Clear the self test flag before parsing job document.*/
+    otaAgent.fileContext.isInSelfTest = false;
+
     /*
      * Parse the job document and update file information in the file context.
      */
@@ -1416,6 +1419,9 @@ static void freeFileContextMem( OtaFileContext_t * const pFileContext )
             pFileContext->pAuthScheme = NULL;
         }
     }
+
+    /* Clear the self test flag.*/
+    otaAgent.fileContext.isInSelfTest = false;
 }
 
 /* Close an existing OTA file context and free its resources. */


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Clear the self test flag when file is closed.
* Make sure the flag is cleared before parsing new job document 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
