### PR TITLE
Fix doxygen warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,14 +91,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Install Doxygen
-        run: |
-          wget -qO- "http://doxygen.nl/files/doxygen-1.8.20.linux.bin.tar.gz" | sudo tar --strip-components=1 -xz -C /usr/local
-          sudo apt-get install -y libclang-9-dev graphviz
-      - name: Run Doxygen And Verify Stdout Is Empty
-        run: |
-          doxygen docs/doxygen/config.doxyfile 2>&1 | tee doxyoutput.txt
-          if [[ "$(wc -c < doxyoutput.txt | bc)" = "0" ]]; then exit 0; else exit 1; fi
+      - name: Run doxygen build
+        uses: FreeRTOS/CI-CD-Github-Actions/doxygen@main
+        with:
+          path: ./
 
   spell-check:
     runs-on: ubuntu-latest

--- a/source/include/ota_mqtt_interface.h
+++ b/source/include/ota_mqtt_interface.h
@@ -146,7 +146,7 @@ typedef OtaMqttStatus_t ( * OtaMqttPublish_t )( const char * const pacTopic,
                                                 uint16_t usTopicLen,
                                                 const char * pcMsg,
                                                 uint32_t ulMsgSize,
-                                                uint8_t ucQos );
+                                                uint8_t ucQoS );
 
 /**
  * @ingroup ota_struct_types


### PR DESCRIPTION
*Description*:

Fixes a typo resulting in the following warning from doxygen:
```
warning: argument 'ucQoS' of command @param is not found in the argument list of OtaMqttPublish_t(const char *const pacTopic, uint16_t usTopicLen, const char *pcMsg, uint32_t ulMsgSize, uint8_t ucQos)
```
