### PR TITLE
Add custom job callback and empty job handling

### DIFF
--- a/source/include/ota.h
+++ b/source/include/ota.h
@@ -294,6 +294,7 @@ typedef struct OtaAgentContext
  * @param[in] pThingName A pointer to a C string holding the Thing name.
  * @param[in] OtaAppCallback Static callback function for when an OTA job is complete. This function will have
  * input of the state of the OTA image after download and during self-test.
+ * @param[in] OtaCustomJobCallback The custom job callback function to be called when custom job parsing is required.
  * @return OtaErr_t The state of the OTA Agent upon return from the OtaState_t enum.
  * If the agent was successfully initialized and ready to operate, the state will be
  * OtaAgentStateReady. Otherwise, it will be one of the other OtaState_t enum values.
@@ -302,7 +303,8 @@ typedef struct OtaAgentContext
 OtaErr_t OTA_Init( OtaAppBuffer_t * pOtaBuffer,
                    OtaInterfaces_t * pOtaInterfaces,
                    const uint8_t * pThingName,
-                   OtaAppCallback_t OtaAppCallback );
+                   OtaAppCallback_t OtaAppCallback,
+                   OtaCustomJobCallback_t OtaCustomJobCallback );
 /* @[declare_ota_init] */
 
 /**

--- a/source/ota.c
+++ b/source/ota.c
@@ -1910,10 +1910,18 @@ static OtaJobParseErr_t parseJobDocFromCustomCallback( const char * pJson,
                                                               JobStatusSucceeded,
                                                               JobReasonAccepted,
                                                               0 );
-
-                /* Everything looks OK. Set final context structure to start OTA. */
-                **pFinalFile = *pFileContext;
-                LogInfo( ( "Job document parsed from external callback" ) );
+															  
+				if( otaErr != OtaErrNone )
+				{
+					LogError( ( "Failed to update job status: updateJobStatus returned error: OtaErr_t=%s",
+                    OTA_Err_strerror( otaErr ) ) );
+				}
+				else
+				{
+					/* Everything looks OK. Set final context structure to start OTA. */
+					**pFinalFile = *pFileContext;
+					LogInfo( ( "Job document parsed from external callback" ) );
+				}
 
                 /* We don't need the job name memory anymore since we're done with this job. */
                 ( void ) memset( otaAgent.pActiveJobName, 0, OTA_JOB_ID_MAX_SIZE );
@@ -1942,12 +1950,6 @@ static OtaJobParseErr_t parseJobDocFromCustomCallback( const char * pJson,
                 err = OtaJobParseErrNonConformingJobDoc;
             }
         }
-    }
-
-    if( otaErr != OtaErrNone )
-    {
-        LogError( ( "Failed to update job status: updateJobStatus returned error: OtaErr_t=%s",
-                    OTA_Err_strerror( otaErr ) ) );
     }
 
     return err;
@@ -3006,7 +3008,8 @@ static void initializeLocalBuffers( void )
 OtaErr_t OTA_Init( OtaAppBuffer_t * pOtaBuffer,
                    OtaInterfaces_t * pOtaInterfaces,
                    const uint8_t * pThingName,
-                   OtaAppCallback_t OtaAppCallback )
+                   OtaAppCallback_t OtaAppCallback,
+				   OtaCustomJobCallback_t OtaCustomJobCallback )
 {
     /* Return value from this function */
     OtaErr_t returnStatus = OtaErrUninitialized;
@@ -3044,6 +3047,9 @@ OtaErr_t OTA_Init( OtaAppBuffer_t * pOtaBuffer,
 
         /* Initialize ota application callback.*/
         otaAgent.OtaAppCallback = OtaAppCallback;
+		
+		/* Initialize ota custom job callback.*/
+        otaAgent.OtaAppCallback = OtaCustomJobCallback;
 
         /*
          * The current OTA image state as set by the OTA agent.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change adds a parameter to OTA Init API for receiving custom job callback function and enables handling of custom job and empty job logging. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
