### PR TITLE
Stabilize the ota.c unit tests

### DIFF
--- a/source/ota.c
+++ b/source/ota.c
@@ -548,10 +548,20 @@ static const char * pOtaAgentStateStrings[ OtaAgentStateAll + 1 ] =
     "All"
 };
 
-/* Helper functions used by the processing loop for OTA events. These need to 
- * be public so they can be called by the unit tests. These functions should
- * not be called by the user application. */
+/**
+ * @brief Private helper function used by the processing loop for OTA events to
+ * set the OTA Agent state machine into the ready state. This function needs to
+ * be public so that it can be called by the unit tests directly. This function
+ * should not be called by the user application.
+ */
 void setAgentToReady( void );
+
+/**
+ * @brief Private helper function for receiving the next available OTA Event
+ * from the event queue. This function should only be called by the
+ * OTA_EventProcessingTask function. This function needs to be public so that
+ * it can be called by the unit tests directly.
+ */
 void receiveAndProcessOtaEvent( void );
 
 /* coverity[misra_c_2012_rule_2_2_violation] */

--- a/source/ota.c
+++ b/source/ota.c
@@ -548,6 +548,9 @@ static const char * pOtaAgentStateStrings[ OtaAgentStateAll + 1 ] =
     "All"
 };
 
+/* Helper functions used by the processing loop for OTA events. These need to 
+ * be public so they can be called by the unit tests. These functions should
+ * not be called by the user application. */
 void setAgentToReady( void );
 void receiveAndProcessOtaEvent( void );
 
@@ -2814,7 +2817,6 @@ static uint32_t searchTransition( const OtaEventMsg_t * pEventMsg )
     return i;
 }
 
-/* This function should only be called by OTA_EventProcessingTask(). */
 void setAgentToReady( void )
 {
     otaAgent.state = OtaAgentStateReady;

--- a/source/ota.c
+++ b/source/ota.c
@@ -464,9 +464,9 @@ static void handleJobParsingError( const OtaFileContext_t * pFileContext,
 /**
  * @brief Receive and process the next available event from the event queue.
  *
- * Each event is processed based on the behavior defined in the global
- * otaTransitionTable. The state of the OTA state machine will be updated and
- * the corresponding event handler will be called.
+ * Each event is processed based on the behavior defined in the OTA transition
+ * table. The state of the OTA state machine will be updated and the
+ * corresponding event handler will be called.
  */
 static void receiveAndProcessOtaEvent( void );
 

--- a/source/ota.c
+++ b/source/ota.c
@@ -2838,10 +2838,11 @@ void receiveAndProcessOtaEvent( void )
     uint32_t i = 0;
     uint32_t transitionTableLen = ( uint32_t ) ( sizeof( otaTransitionTable ) / sizeof( otaTransitionTable[ 0 ] ) );
 
-    if( otaAgent.pOtaInterface == NULL)
+    if( otaAgent.pOtaInterface == NULL )
     {
-        LogError(("Failed to receive event: OS Interface not set"));
+        LogError( ( "Failed to receive event: OS Interface not set" ) );
     }
+
     /*
      * Receive the next event form the OTA event queue to process.
      */

--- a/source/ota.c
+++ b/source/ota.c
@@ -461,6 +461,15 @@ static void freeFileContextMem( OtaFileContext_t * const pFileContext );
 static void handleJobParsingError( const OtaFileContext_t * pFileContext,
                                    OtaJobParseErr_t err );
 
+/**
+ * @brief Receive and process the next available event from the event queue.
+ *
+ * Each event is processed based on the behavior defined in the global
+ * otaTransitionTable. The state of the OTA state machine will be updated and
+ * the corresponding event handler will be called.
+ */
+static void receiveAndProcessOtaEvent( void );
+
 /* OTA state event handler functions. */
 
 static OtaErr_t startHandler( const OtaEventData_t * pEventData );           /*!< Start timers and initiate request for job document. */
@@ -547,22 +556,6 @@ static const char * pOtaAgentStateStrings[ OtaAgentStateAll + 1 ] =
     "Stopped",
     "All"
 };
-
-/**
- * @brief Private helper function used by the processing loop for OTA events to
- * set the OTA Agent state machine into the ready state. This function needs to
- * be public so that it can be called by the unit tests directly. This function
- * should not be called by the user application.
- */
-void setAgentToReady( void );
-
-/**
- * @brief Private helper function for receiving the next available OTA Event
- * from the event queue. This function should only be called by the
- * OTA_EventProcessingTask function. This function needs to be public so that
- * it can be called by the unit tests directly.
- */
-void receiveAndProcessOtaEvent( void );
 
 /* coverity[misra_c_2012_rule_2_2_violation] */
 /*!< String set to represent the Events for the OTA agent. */
@@ -2827,12 +2820,7 @@ static uint32_t searchTransition( const OtaEventMsg_t * pEventMsg )
     return i;
 }
 
-void setAgentToReady( void )
-{
-    otaAgent.state = OtaAgentStateReady;
-}
-
-void receiveAndProcessOtaEvent( void )
+static void receiveAndProcessOtaEvent( void )
 {
     OtaEventMsg_t eventMsg = { 0 };
     uint32_t i = 0;
@@ -2885,7 +2873,7 @@ void OTA_EventProcessingTask( void * pUnused )
     /*
      * OTA Agent is ready to receive and process events so update the state to ready.
      */
-    setAgentToReady();
+    otaAgent.state = OtaAgentStateReady;
 
     while( otaAgent.state != OtaAgentStateStopped )
     {

--- a/source/ota.c
+++ b/source/ota.c
@@ -548,6 +548,9 @@ static const char * pOtaAgentStateStrings[ OtaAgentStateAll + 1 ] =
     "All"
 };
 
+void setAgentToReady( void );
+void receiveAndProcessOtaEvent( void );
+
 /* coverity[misra_c_2012_rule_2_2_violation] */
 /*!< String set to represent the Events for the OTA agent. */
 static const char * pOtaEventStrings[ OtaAgentEventMax ] =

--- a/source/ota.c
+++ b/source/ota.c
@@ -2811,9 +2811,7 @@ static uint32_t searchTransition( const OtaEventMsg_t * pEventMsg )
     return i;
 }
 
-/* This function should only be called by OTA_EventProcessingTask(). This is
- * required so that the unit tests can set the OTA Agent to ready without
- * calling OTA_EventProcessingTask. */
+/* This function should only be called by OTA_EventProcessingTask(). */
 void setAgentToReady( void )
 {
     otaAgent.state = OtaAgentStateReady;
@@ -2871,7 +2869,7 @@ void OTA_EventProcessingTask( void * pUnused )
     /*
      * OTA Agent is ready to receive and process events so update the state to ready.
      */
-    otaAgent.state = OtaAgentStateReady;
+    setAgentToReady();
 
     while( otaAgent.state != OtaAgentStateStopped )
     {

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -110,7 +110,6 @@ static uint8_t pUserBuffer[ OTA_APP_BUFFER_SIZE ];
 static OtaEventMsg_t otaEventQueue[ OTA_NUM_MSG_Q_ENTRIES ];
 static OtaEventMsg_t * otaEventQueueEnd = otaEventQueue;
 static OtaEventData_t eventBuffer;
-static pthread_mutex_t eventLock;
 static bool eventIgnore;
 
 /* OTA File handle and buffer. */

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -121,8 +121,11 @@ static const int otaDefaultWait = 2000;
 
 /* ========================================================================== */
 
-/* Global variable defined in ota.c. */
+/* Global static variable defined in ota.c for managing the state machine. */
 extern OtaAgentContext_t otaAgent;
+
+/* Static function defined in ota.c for processing events. */
+extern void receiveAndProcessOtaEvent( void );
 
 /* ========================================================================== */
 

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -121,9 +121,8 @@ static const int otaDefaultWait = 2000;
 
 /* ========================================================================== */
 
-/* Helper functions defined by the OTA library. */
-extern void setAgentToReady( void );
-extern void receiveAndProcessOtaEvent( void );
+/* Global variable defined in ota.c. */
+extern OtaAgentContext_t otaAgent;
 
 /* ========================================================================== */
 
@@ -641,7 +640,7 @@ static void otaGoToState( OtaState_t state )
             break;
 
         case OtaAgentStateReady:
-            setAgentToReady();
+            otaAgent.state = OtaAgentStateReady;
             break;
 
         case OtaAgentStateRequestingJob:

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -120,6 +120,9 @@ static uint8_t pOtaFileBuffer[ OTA_TEST_FILE_SIZE ];
 /* 2 seconds default wait time for OTA state machine transition. */
 static const int otaDefaultWait = 2000;
 
+/* ========================================================================== */
+
+/* Helper functions defined by the OTA library. */
 extern void setAgentToReady( void );
 extern void receiveAndProcessOtaEvent( void );
 

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -120,7 +120,8 @@ static uint8_t pOtaFileBuffer[ OTA_TEST_FILE_SIZE ];
 /* 2 seconds default wait time for OTA state machine transition. */
 static const int otaDefaultWait = 2000;
 
-extern OtaAgentContext_t otaAgent;
+extern void setAgentToReady( void );
+extern void receiveAndProcessOtaEvent( void );
 
 /* ========================================================================== */
 

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -205,6 +205,7 @@ static OtaOsStatus_t mockOSEventSend( OtaEventContext_t * unused_1,
     {
         return OtaOsEventQueueSendFailed;
     }
+
     const OtaEventMsg_t * pOtaEvent = pEventMsg;
 
     otaEventQueueEnd->eventId = pOtaEvent->eventId;
@@ -567,7 +568,7 @@ static void processEntireQueue()
     {
         return;
     }
-    
+
     while( otaEventQueueEnd != otaEventQueue )
     {
         receiveAndProcessOtaEvent();
@@ -634,6 +635,7 @@ static void otaGoToState( OtaState_t state )
     switch( state )
     {
         case OtaAgentStateInit:
+
             /* Nothing needs to be done here since we should either be in init state already or
              * we are in other running states. */
             break;
@@ -1148,6 +1150,7 @@ void test_OTA_InitFileTransferHttp()
 void test_OTA_InitFileTransferRetryFail()
 {
     uint32_t i = 0U;
+
     /* Use HTTP data transfer so we can intentionally fail the init transfer. */
     pOtaJobDoc = JOB_DOC_HTTP;
 
@@ -1288,6 +1291,7 @@ void test_OTA_ReceiveFileBlockEmpty()
     OTA_SignalEvent( &otaEvent );
     /* Process the event for receiving the block to trigger digesting it. */
     receiveAndProcessOtaEvent();
+
     /* Process the event generated after failing to decode the block. The
      * expected result is that we close the file and begin waiting for a new
      * job document. */

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -564,6 +564,7 @@ static void otaAppBufferDefault()
     pOtaAppBuffer.authSchemeSize = OTA_AUTH_SCHEME_SIZE;
 }
 
+/* Helper function for processing all elements in the queue if there are any. */
 static void processEntireQueue()
 {
     if( otaEventQueueEnd >= otaEventQueue + OTA_NUM_MSG_Q_ENTRIES )


### PR DESCRIPTION
The unit tests were intermittently failing due to timing issues. This PR fixes these timing issues by removing multithreading from the ota.c unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
