### PR TITLE
Remove static from ota.c before running unit tests

### DIFF
--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -7,18 +7,18 @@ set(project_name "aws_ota")
 # ================= Create the library under test here (edit) ==================
 
 
-set( OTA_MOCK_BASE "${CMAKE_BINARY_DIR}/ota_temp" )
+set( OTA_C_TMP_BASE "${CMAKE_BINARY_DIR}/ota" )
 
 # Strip static constraints so unit tests may call internal functions
 execute_process( COMMAND sed "s/^static //"
                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
                  INPUT_FILE "${MODULE_ROOT_DIR}/source/ota.c"
-                 OUTPUT_FILE ${OTA_MOCK_BASE}.c
+                 OUTPUT_FILE ${OTA_C_TMP_BASE}.c
 )
 
 # list the files you would like to test here
 list(APPEND real_source_files
-    ${OTA_MOCK_BASE}.c
+    ${OTA_C_TMP_BASE}.c
     "${MODULE_ROOT_DIR}/source/ota_interface.c"
     "${MODULE_ROOT_DIR}/source/ota_base64.c"
     "${MODULE_ROOT_DIR}/source/ota_mqtt.c"

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -6,9 +6,19 @@ set(project_name "aws_ota")
 
 # ================= Create the library under test here (edit) ==================
 
+
+set( OTA_MOCK_BASE "${CMAKE_BINARY_DIR}/ota_temp" )
+
+# Strip static constraints so unit tests may call internal functions
+execute_process( COMMAND sed "s/^static //"
+                 WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                 INPUT_FILE "${MODULE_ROOT_DIR}/source/ota.c"
+                 OUTPUT_FILE ${OTA_MOCK_BASE}.c
+)
+
 # list the files you would like to test here
 list(APPEND real_source_files
-    "${MODULE_ROOT_DIR}/source/ota.c"
+    ${OTA_MOCK_BASE}.c
     "${MODULE_ROOT_DIR}/source/ota_interface.c"
     "${MODULE_ROOT_DIR}/source/ota_base64.c"
     "${MODULE_ROOT_DIR}/source/ota_mqtt.c"

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -121,6 +121,8 @@ static uint8_t pOtaFileBuffer[ OTA_TEST_FILE_SIZE ];
 /* 2 seconds default wait time for OTA state machine transition. */
 static const int otaDefaultWait = 2000;
 
+extern OtaAgentContext_t otaAgent;
+
 /* ========================================================================== */
 
 static void * mockMallocAlwaysFail( size_t size )

--- a/tools/cmock/coverage.cmake
+++ b/tools/cmock/coverage.cmake
@@ -69,7 +69,7 @@ execute_process(COMMAND lcov
 # remove source files from dependencies and unit tests
 execute_process(COMMAND lcov
     --rc lcov_branch_coverage=1
-    --remove ${CMAKE_BINARY_DIR}/coverage.info *dependency* *unit-test* /usr*
+    --remove ${CMAKE_BINARY_DIR}/coverage.info *dependency* *unit-test* /usr* */source/ota.c
     --output-file ${CMAKE_BINARY_DIR}/coverage.info
 )
 


### PR DESCRIPTION
The ota.c file has a static global variable and a number of static functions that need to be accessed for unit testing. 

This change is to run sed before building to generate a temporary file that is a copy of the original ota.c, but the static keyword has been removed. This temporary file is generated in the build directory and is used in place of the original for building. The coverage report generation was also updated to check the code coverage of this temporary file instead of the original.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
