### PR TITLE
Add size table to PR checks

### DIFF
--- a/.github/memory_statistics_config.json
+++ b/.github/memory_statistics_config.json
@@ -1,0 +1,19 @@
+{
+  "lib_name": "AWS IoT OTA",
+  "src": [
+    "source/ota.c",
+    "source/ota_interface.c",
+    "source/ota_base64.c",
+    "source/ota_mqtt.c",
+    "source/ota_cbor.c",
+    "source/ota_http.c"
+  ],
+  "include": [
+    "source/include",
+    "source/dependency/coreJSON/source/include",
+    "source/dependency/3rdparty/tinycbor/src"
+  ],
+  "compiler_flags": [
+    "OTA_DO_NOT_USE_CUSTOM_CONFIG"
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,3 +155,15 @@ jobs:
         run: |
           git-secrets --register-aws
           git-secrets --scan
+
+  memory_statistics:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+            submodules: 'recursive'
+      - name: Measure sizes
+        uses: FreeRTOS/CI-CD-Github-Actions/memory_statistics@main
+        with:
+            config: .github/memory_statistics_config.json
+            check_against: docs/doxygen/include/size_table.html

--- a/.github/workflows/memory_statistics.yml
+++ b/.github/workflows/memory_statistics.yml
@@ -1,0 +1,22 @@
+name: Memory statistics
+
+on:
+  workflow_dispatch:
+
+jobs:
+  memory_statistics:
+    name: Calculate object sizes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+            submodules: 'recursive'
+      - name: Measure sizes
+        uses: FreeRTOS/CI-CD-Github-Actions/memory_statistics@main
+        with:
+            config: .github/memory_statistics_config.json
+      - name: Upload table
+        uses: actions/upload-artifact@v2
+        with:
+          name: size_table
+          path: size_table.html

--- a/docs/doxygen/config.doxyfile
+++ b/docs/doxygen/config.doxyfile
@@ -915,7 +915,7 @@ EXCLUDE_SYMBOLS        =
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           = ./source/include
+EXAMPLE_PATH           = ./source/include ./docs/doxygen/include
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and

--- a/docs/doxygen/include/size_table.html
+++ b/docs/doxygen/include/size_table.html
@@ -1,0 +1,45 @@
+<table>
+    <tr>
+        <td colspan="3"><center><b>Code Size of AWS IoT OTA (example generated with GCC for ARM Cortex-M)</b></center></td>
+    </tr>
+    <tr>
+        <td><b>File</b></td>
+        <td><b><center>With -O1 Optimization</center></b></td>
+        <td><b><center>With -Os Optimization</center></b></td>
+    </tr>
+    <tr>
+        <td>ota.c</td>
+        <td><center>7.5K</center></td>
+        <td><center>6.6K</center></td>
+    </tr>
+    <tr>
+        <td>ota_interface.c</td>
+        <td><center>0.1K</center></td>
+        <td><center>0.1K</center></td>
+    </tr>
+    <tr>
+        <td>ota_base64.c</td>
+        <td><center>0.6K</center></td>
+        <td><center>0.6K</center></td>
+    </tr>
+    <tr>
+        <td>ota_mqtt.c</td>
+        <td><center>2.3K</center></td>
+        <td><center>2.2K</center></td>
+    </tr>
+    <tr>
+        <td>ota_cbor.c</td>
+        <td><center>0.7K</center></td>
+        <td><center>0.6K</center></td>
+    </tr>
+    <tr>
+        <td>ota_http.c</td>
+        <td><center>0.3K</center></td>
+        <td><center>0.3K</center></td>
+    </tr>
+    <tr>
+        <td><b>Total estimates</b></td>
+        <td><b><center>11.5K</center></b></td>
+        <td><b><center>10.4K</center></b></td>
+    </tr>
+</table>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -78,51 +78,7 @@ Currently, the OTA library has the following direct dependencies:
 @section ota_memory_requirements Memory Requirements
 @brief Memory requirements of the OTA library.
 
-<table>
-    <tr>
-        <td colspan="3"><center><b>Code size of AWS IoT OTA (example generated with GCC for ARM Cortex-M)</b></center></td>
-    </tr>
-    <tr>
-        <td><b>File</b></td>
-        <td><center><b>With -O1 Optimization</b></center></td>
-        <td><center><b>With -Os Optimization</b></center></td>
-    </tr>
-    <tr>
-        <td>ota.c</td>
-        <td><center>7.5K</center></td>
-        <td><center>6.6K</center></td>
-    </tr>
-    <tr>
-        <td>ota_interface.c</td>
-        <td><center>0.1K</center></td>
-        <td><center>0.1K</center></td>
-    </tr>
-    <tr>
-        <td>ota_base64.c</td>
-        <td><center>0.6K</center></td>
-        <td><center>0.6K</center></td>
-    </tr>
-    <tr>
-        <td>ota_mqtt.c</td>
-        <td><center>2.3K</center></td>
-        <td><center>2.2K</center></td>
-    </tr>
-    <tr>
-        <td>ota_cbor.c</td>
-        <td><center>0.7K</center></td>
-        <td><center>0.6K</center></td>
-    </tr>
-    <tr>
-        <td>ota_http.c</td>
-        <td><center>0.3K</center></td>
-        <td><center>0.3K</center></td>
-    </tr>
-    <tr>
-        <td><b>Total estimates</b></td>
-        <td><center><b>11.5K</b></center></td>
-        <td><center><b>10.4K</b></center></td>
-    </tr>
-</table>
+@include{doc} size_table.html
  */
 
 /**


### PR DESCRIPTION
Adds A PR check to check if the sizes in the doxygen documentation are up to date.
Additionally adds a manual workflow to generate the size table.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
