### PR TITLE
Update coverage workflow to build with the debug flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,9 @@ jobs:
       - name: Build
         run: |
           sudo apt-get install -y lcov
-          cmake -S test -B build -DCMAKE_BUILD_TYPE=Release
+          cmake -S test -B build \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -DNDEBUG'
           cmake --build build
       - name: Run Coverage
         run: |

--- a/tools/cmock/coverage.cmake
+++ b/tools/cmock/coverage.cmake
@@ -55,7 +55,7 @@ execute_process(COMMAND lcov
     --output-file ${CMAKE_BINARY_DIR}/second_coverage.info
 )
 
-# combile baseline results (zeros) with the one after running the tests
+# compile baseline results (zeros) with the one after running the tests
 execute_process(COMMAND lcov
     --base-directory ${CMAKE_BINARY_DIR}
     --directory ${CMAKE_BINARY_DIR}
@@ -69,7 +69,7 @@ execute_process(COMMAND lcov
 # remove source files from dependencies and unit tests
 execute_process(COMMAND lcov
     --rc lcov_branch_coverage=1
-    --remove ${CMAKE_BINARY_DIR}/coverage.info *dependency* *unit-test* /usr* */source/ota.c
+    --remove ${CMAKE_BINARY_DIR}/coverage.info *dependency* *unit-test* /usr* */source/ota.c *CMakeCCompilerId*
     --output-file ${CMAKE_BINARY_DIR}/coverage.info
 )
 


### PR DESCRIPTION
The git actions workflow for gathering the code coverage data was building with the `-DCMAKE_BUILD_TYPE=Release` flag enabled. This flag was causing optimizations to be enabled which altered the coverage data. Due to these optimizations, some of the code was considered covered when it wasn't and vice versa.

This update is to change the build flag so that it doesn't have optimizations enabled. This causes the line coverage to go down in some of the files, but after investigating the dips, these are all correct and reflect the coverage of the code accurately.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
