### PR TITLE
Fix/ota interface coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-      - name: Generate build files
+      - name: Generate Build Files
         run: |
           sudo apt-get install -y lcov
           cmake -S test -B build \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,13 +58,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-      - name: Build
+      - name: Generate build files
         run: |
           sudo apt-get install -y lcov
           cmake -S test -B build \
           -DCMAKE_BUILD_TYPE=Debug \
           -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -DNDEBUG'
-          cmake --build build
       - name: Run Coverage
         run: |
           cmake --build build/ --target coverage

--- a/docs/doxygen/include/size_table.html
+++ b/docs/doxygen/include/size_table.html
@@ -14,8 +14,8 @@
     </tr>
     <tr>
         <td>ota_interface.c</td>
-        <td><center>0.2K</center></td>
-        <td><center>0.2K</center></td>
+        <td><center>0.1K</center></td>
+        <td><center>0.1K</center></td>
     </tr>
     <tr>
         <td>ota_base64.c</td>
@@ -39,7 +39,7 @@
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>12.0K</center></b></td>
-        <td><b><center>10.8K</center></b></td>
+        <td><b><center>11.9K</center></b></td>
+        <td><b><center>10.7K</center></b></td>
     </tr>
 </table>

--- a/docs/doxygen/include/size_table.html
+++ b/docs/doxygen/include/size_table.html
@@ -9,8 +9,8 @@
     </tr>
     <tr>
         <td>ota.c</td>
-        <td><center>7.5K</center></td>
-        <td><center>6.6K</center></td>
+        <td><center>7.8K</center></td>
+        <td><center>6.9K</center></td>
     </tr>
     <tr>
         <td>ota_interface.c</td>
@@ -39,7 +39,7 @@
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>11.6K</center></b></td>
-        <td><b><center>10.4K</center></b></td>
+        <td><b><center>11.9K</center></b></td>
+        <td><b><center>10.7K</center></b></td>
     </tr>
 </table>

--- a/docs/doxygen/include/size_table.html
+++ b/docs/doxygen/include/size_table.html
@@ -14,8 +14,8 @@
     </tr>
     <tr>
         <td>ota_interface.c</td>
-        <td><center>0.1K</center></td>
-        <td><center>0.1K</center></td>
+        <td><center>0.2K</center></td>
+        <td><center>0.2K</center></td>
     </tr>
     <tr>
         <td>ota_base64.c</td>
@@ -39,7 +39,7 @@
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>11.9K</center></b></td>
-        <td><b><center>10.7K</center></b></td>
+        <td><b><center>12.0K</center></b></td>
+        <td><b><center>10.8K</center></b></td>
     </tr>
 </table>

--- a/source/include/ota_interface_private.h
+++ b/source/include/ota_interface_private.h
@@ -91,17 +91,20 @@ typedef struct
 void setControlInterface( OtaControlInterface_t * pControlInterface );
 
 /**
- * @brief Set data interface for OTA operations.
+ * @brief Set the data interface used for OTA operations.
  *
- * This function updates the OTA data operation functions as per the config
- * options selected.
+ * This function updates the OTA data operation based on the config options.
+ * The interface can be set to the MQTT interface or the HTTP interface.
  *
- * @param[out] pDataInterface OTA data interface.
+ * These interfaces can be enabled with the configENABLED_DATA_PROTOCOLS macro.
+ * The protocol interface that should be prioritized when both protocols are
+ * valid options is configured with the configOTA_PRIMARY_DATA_PROTOCOL macro.
  *
- * @param[in] pProtocol Protocols used for the download.
+ * @param[out] pDataInterface OTA data interface to overwite.
+ *
+ * @param[in] pProtocol String containing a list of protocols that may be set.
  *
  */
-
 OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
                            const uint8_t * pProtocol );
 

--- a/source/include/ota_interface_private.h
+++ b/source/include/ota_interface_private.h
@@ -100,7 +100,7 @@ void setControlInterface( OtaControlInterface_t * pControlInterface );
  * The protocol interface that should be prioritized when both protocols are
  * valid options is configured with the configOTA_PRIMARY_DATA_PROTOCOL macro.
  *
- * @param[out] pDataInterface OTA data interface to overwite.
+ * @param[out] pDataInterface OTA data interface to overwrite.
  *
  * @param[in] pProtocol String containing a list of protocols that may be set.
  *

--- a/source/include/ota_private.h
+++ b/source/include/ota_private.h
@@ -98,19 +98,19 @@
  * @brief Number of parameters in the job document.
  *
  */
-#define OTA_NUM_JOB_PARAMS     ( 21 )
+#define OTA_NUM_JOB_PARAMS          ( 21 )
 
 /**
  * @brief Maximum size of the Job ID.
  *
  */
-#define OTA_JOB_ID_MAX_SIZE    ( 72UL + 1UL )
+#define OTA_JOB_ID_MAX_SIZE         ( 72UL + 1UL )
 
 /**
  * @brief Size of the buffer used to store the protocol field of the job document.
  *
  */
-#define OTA_PROTOCOL_BUFFER_SIZE        20U
+#define OTA_PROTOCOL_BUFFER_SIZE    20U
 
 /**
  * @ingroup ota_constants

--- a/source/include/ota_private.h
+++ b/source/include/ota_private.h
@@ -107,6 +107,12 @@
 #define OTA_JOB_ID_MAX_SIZE    ( 72UL + 1UL )
 
 /**
+ * @brief Size of the buffer used to store the protocol field of the job document.
+ *
+ */
+#define OTA_PROTOCOL_BUFFER_SIZE        20U
+
+/**
  * @ingroup ota_constants
  * @brief A composite cryptographic signature structure able to hold our largest supported signature.
  */

--- a/source/ota.c
+++ b/source/ota.c
@@ -577,7 +577,7 @@ static const char * pOtaEventStrings[ OtaAgentEventMax ] =
 };
 
 static uint8_t pJobNameBuffer[ OTA_JOB_ID_MAX_SIZE ]; /*!< Buffer to store job name. */
-static uint8_t pProtocolBuffer[ 20 ];                 /*!< Buffer to store data protocol. */
+static uint8_t pProtocolBuffer[ OTA_PROTOCOL_BUFFER_SIZE ];                 /*!< Buffer to store data protocol. */
 static Sig256_t sig256Buffer;                         /*!< Buffer to store key file signature. */
 
 static void otaTimerCallback( OtaTimerId_t otaTimerId )

--- a/source/ota.c
+++ b/source/ota.c
@@ -576,9 +576,9 @@ static const char * pOtaEventStrings[ OtaAgentEventMax ] =
     "Shutdown"
 };
 
-static uint8_t pJobNameBuffer[ OTA_JOB_ID_MAX_SIZE ]; /*!< Buffer to store job name. */
-static uint8_t pProtocolBuffer[ OTA_PROTOCOL_BUFFER_SIZE ];                 /*!< Buffer to store data protocol. */
-static Sig256_t sig256Buffer;                         /*!< Buffer to store key file signature. */
+static uint8_t pJobNameBuffer[ OTA_JOB_ID_MAX_SIZE ];       /*!< Buffer to store job name. */
+static uint8_t pProtocolBuffer[ OTA_PROTOCOL_BUFFER_SIZE ]; /*!< Buffer to store data protocol. */
+static Sig256_t sig256Buffer;                               /*!< Buffer to store key file signature. */
 
 static void otaTimerCallback( OtaTimerId_t otaTimerId )
 {

--- a/source/ota_interface.c
+++ b/source/ota_interface.c
@@ -77,16 +77,57 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
                            const uint8_t * pProtocol )
 {
     OtaErr_t err = OtaErrInvalidDataProtocol;
+    size_t i;
     bool httpInJobDoc;
     bool mqttInJobDoc;
 
-    /* The explicit type casts create additional branches tracked by code
-     * coverage tools that are unreachable. These macros prevent the tools
-     * from tracking branch coverage for these lines. */
-    /* LCOV_EXCL_BR_START */
-    httpInJobDoc = ( strstr( ( const char * ) pProtocol, "HTTP" ) != NULL ) ? true : false;
-    mqttInJobDoc = ( strstr( ( const char * ) pProtocol, "MQTT" ) != NULL ) ? true : false;
-    /* LCOV_EXCL_BR_STOP */
+    static const char * pOtaTransferTypes[] =
+    {
+        /* Do not change the order of these. */
+        "[\"MQTT\"]",
+        "[\"HTTP\"]",
+        "[\"MQTT\",\"HTTP\"]",
+        "[\"HTTP\",\"MQTT\"]"
+    };
+    static size_t numTransferTypes = sizeof( pOtaTransferTypes ) / sizeof( const char * );
+
+    for( i = 0; i < numTransferTypes; ++i )
+    {
+        /* The explicit type cast creates additional branches tracked by code
+         * coverage tools that are unreachable. These macros prevent the tools
+         * from tracking branch coverage for these lines. */
+        /* LCOV_EXCL_BR_START */
+        if( strcmp( pOtaTransferTypes[ i ], ( const char * ) pProtocol ) == 0 )
+        {
+            break;
+        }
+
+        /* LCOV_EXCL_BR_STOP */
+    }
+
+    switch( i )
+    {
+        case 0: /* MQTT enabled. */
+            mqttInJobDoc = true;
+            httpInJobDoc = false;
+            break;
+
+        case 1: /* HTTP enabled */
+            mqttInJobDoc = false;
+            httpInJobDoc = true;
+            break;
+
+        case 2:
+        case 3:
+            mqttInJobDoc = true;
+            httpInJobDoc = true;
+            break;
+
+        default:
+            mqttInJobDoc = false;
+            httpInJobDoc = false;
+            break;
+    }
 
     #if ( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) && !( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) )
         ( void ) httpInJobDoc;

--- a/source/ota_interface.c
+++ b/source/ota_interface.c
@@ -94,8 +94,13 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
         bool httpInJobDoc;
         bool mqttInJobDoc;
 
+        /* The explicit type casts create additional branches tracked by code
+         * coverage tools that are unreachable. These macros prevent the tools
+         * from tracking branch coverage for these lines. */
+        /* LCOV_EXCL_BR_START */
         httpInJobDoc = ( strstr( ( const char * ) pProtocol, "HTTP" ) != NULL ) ? true : false;
         mqttInJobDoc = ( strstr( ( const char * ) pProtocol, "MQTT" ) != NULL ) ? true : false;
+        /* LCOV_EXCL_BR_STOP */
 
         #if ( configOTA_PRIMARY_DATA_PROTOCOL == OTA_DATA_OVER_MQTT )
             if( mqttInJobDoc == true )

--- a/source/ota_interface.c
+++ b/source/ota_interface.c
@@ -61,17 +61,6 @@ void setControlInterface( OtaControlInterface_t * pControlInterface )
     #endif
 }
 
-/**
- * @brief Set the data interface used by the OTA Agent for streaming file
- *        blocks based on the user configuration and job document.
- *
- *        - If only one of the protocols is enabled, then that protocol is set.
- *        - If the job document specifies which protocol to use, then that
- *          protocol will be used unless it is disabled.
- *        - If both of the protocols are enabled and the user lists both of
- *          them in the job document, then the higher priority protocol will
- *          be selected.
- */
 OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
                            const uint8_t * pProtocol )
 {
@@ -97,8 +86,8 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
         pDataInterface->cleanup = cleanupData_Http;
     #else /* if !( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) | ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) ) */
         char protocolBuffer[ OTA_PROTOCOL_BUFFER_SIZE ] = { 0 };
-        bool httpInJobDoc = false;
-        bool mqttInJobDoc = false;
+        bool httpInJobDoc;
+        bool mqttInJobDoc;
 
         ( void ) memcpy( protocolBuffer, pProtocol, OTA_PROTOCOL_BUFFER_SIZE );
         httpInJobDoc = ( strstr( protocolBuffer, "HTTP" ) != NULL ) ? true : false;

--- a/source/ota_interface.c
+++ b/source/ota_interface.c
@@ -78,32 +78,32 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
     OtaErr_t err = OtaErrNone;
 
     #if !( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) | ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) )
-        #error "One or more of the data protocols must be set with configENABLED_DATA_PROTOCOLS."
+    #error "One or more of the data protocols must be set with configENABLED_DATA_PROTOCOLS."
     #elif !( ( configOTA_PRIMARY_DATA_PROTOCOL & OTA_DATA_OVER_MQTT ) | ( configOTA_PRIMARY_DATA_PROTOCOL & OTA_DATA_OVER_HTTP ) )
-        #error "configOTA_PRIMARY_DATA_PROTOCOL must be set to one of the data protocols."
+    #error "configOTA_PRIMARY_DATA_PROTOCOL must be set to one of the data protocols."
     #elif ( configOTA_PRIMARY_DATA_PROTOCOL >= ( OTA_DATA_OVER_MQTT | OTA_DATA_OVER_HTTP ) )
-        #error "Invalid value for configOTA_PRIMARY_DATA_PROTOCOL: Value is expected to be OTA_DATA_OVER_MQTT or OTA_DATA_OVER_HTTP."
-    #elif ( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) && !(configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) )
+    #error "Invalid value for configOTA_PRIMARY_DATA_PROTOCOL: Value is expected to be OTA_DATA_OVER_MQTT or OTA_DATA_OVER_HTTP."
+    #elif ( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) && !( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) )
         pDataInterface->initFileTransfer = initFileTransfer_Mqtt;
         pDataInterface->requestFileBlock = requestFileBlock_Mqtt;
         pDataInterface->decodeFileBlock = decodeFileBlock_Mqtt;
         pDataInterface->cleanup = cleanupData_Mqtt;
-    #elif ( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) && !(configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) )
+    #elif ( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) && !( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) )
         pDataInterface->initFileTransfer = initFileTransfer_Http;
         pDataInterface->requestFileBlock = requestDataBlock_Http;
         pDataInterface->decodeFileBlock = decodeFileBlock_Http;
         pDataInterface->cleanup = cleanupData_Http;
-    #else
+    #else  /* if !( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) | ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) ) */
         char protocolBuffer[ OTA_PROTOCOL_BUFFER_SIZE ] = { 0 };
         bool httpInJobDoc;
         bool mqttInJobDoc;
 
-        memcpy( protocolBuffer ,pProtocol, OTA_PROTOCOL_BUFFER_SIZE );
-        httpInJobDoc = ( strstr( protocolBuffer, "HTTP") != NULL ) ? true : false;
-        mqttInJobDoc = ( strstr( protocolBuffer, "MQTT") != NULL ) ? true : false;
+        memcpy( protocolBuffer, pProtocol, OTA_PROTOCOL_BUFFER_SIZE );
+        httpInJobDoc = ( strstr( protocolBuffer, "HTTP" ) != NULL ) ? true : false;
+        mqttInJobDoc = ( strstr( protocolBuffer, "MQTT" ) != NULL ) ? true : false;
 
         #if ( configOTA_PRIMARY_DATA_PROTOCOL == OTA_DATA_OVER_MQTT )
-            if ( mqttInJobDoc == true )
+            if( mqttInJobDoc == true )
             {
                 pDataInterface->initFileTransfer = initFileTransfer_Mqtt;
                 pDataInterface->requestFileBlock = requestFileBlock_Mqtt;
@@ -129,7 +129,7 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
                 pDataInterface->decodeFileBlock = decodeFileBlock_Http;
                 pDataInterface->cleanup = cleanupData_Http;
             }
-            else if ( mqttInJobDoc == true )
+            else if( mqttInJobDoc == true )
             {
                 pDataInterface->initFileTransfer = initFileTransfer_Mqtt;
                 pDataInterface->requestFileBlock = requestFileBlock_Mqtt;
@@ -141,7 +141,7 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
                 err = OtaErrInvalidDataProtocol;
             }
         #endif /* if ( configOTA_PRIMARY_DATA_PROTOCOL == OTA_DATA_OVER_MQTT ) */
-    #endif
+    #endif /* if !( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) | ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) ) */
 
     return err;
 }

--- a/source/ota_interface.c
+++ b/source/ota_interface.c
@@ -76,7 +76,7 @@ void setControlInterface( OtaControlInterface_t * pControlInterface )
 OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
                            const uint8_t * pProtocol )
 {
-    OtaErr_t err = OtaErrNone;
+    OtaErr_t err = OtaErrInvalidDataProtocol;
     bool httpInJobDoc;
     bool mqttInJobDoc;
 
@@ -97,10 +97,7 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
             pDataInterface->requestFileBlock = requestFileBlock_Mqtt;
             pDataInterface->decodeFileBlock = decodeFileBlock_Mqtt;
             pDataInterface->cleanup = cleanupData_Mqtt;
-        }
-        else
-        {
-            err = OtaErrInvalidDataProtocol;
+            err = OtaErrNone;
         }
     #elif ( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) && !( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) )
         ( void ) mqttInJobDoc;
@@ -111,10 +108,7 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
             pDataInterface->requestFileBlock = requestDataBlock_Http;
             pDataInterface->decodeFileBlock = decodeFileBlock_Http;
             pDataInterface->cleanup = cleanupData_Http;
-        }
-        else
-        {
-            err = OtaErrInvalidDataProtocol;
+            err = OtaErrNone;
         }
     #else /* if ( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) && !( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) ) */
         #if ( configOTA_PRIMARY_DATA_PROTOCOL == OTA_DATA_OVER_MQTT )
@@ -124,6 +118,7 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
                 pDataInterface->requestFileBlock = requestFileBlock_Mqtt;
                 pDataInterface->decodeFileBlock = decodeFileBlock_Mqtt;
                 pDataInterface->cleanup = cleanupData_Mqtt;
+                err = OtaErrNone;
             }
             else if( httpInJobDoc == true )
             {
@@ -131,10 +126,7 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
                 pDataInterface->requestFileBlock = requestDataBlock_Http;
                 pDataInterface->decodeFileBlock = decodeFileBlock_Http;
                 pDataInterface->cleanup = cleanupData_Http;
-            }
-            else
-            {
-                err = OtaErrInvalidDataProtocol;
+                err = OtaErrNone;
             }
         #elif ( configOTA_PRIMARY_DATA_PROTOCOL == OTA_DATA_OVER_HTTP )
             if( httpInJobDoc == true )
@@ -143,6 +135,7 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
                 pDataInterface->requestFileBlock = requestDataBlock_Http;
                 pDataInterface->decodeFileBlock = decodeFileBlock_Http;
                 pDataInterface->cleanup = cleanupData_Http;
+                err = OtaErrNone;
             }
             else if( mqttInJobDoc == true )
             {
@@ -150,10 +143,7 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
                 pDataInterface->requestFileBlock = requestFileBlock_Mqtt;
                 pDataInterface->decodeFileBlock = decodeFileBlock_Mqtt;
                 pDataInterface->cleanup = cleanupData_Mqtt;
-            }
-            else
-            {
-                err = OtaErrInvalidDataProtocol;
+                err = OtaErrNone;
             }
         #endif /* if ( configOTA_PRIMARY_DATA_PROTOCOL == OTA_DATA_OVER_MQTT ) */
     #endif /* if ( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) && !( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) ) */

--- a/source/ota_interface.c
+++ b/source/ota_interface.c
@@ -84,8 +84,8 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
      * coverage tools that are unreachable. These macros prevent the tools
      * from tracking branch coverage for these lines. */
     /* LCOV_EXCL_BR_START */
-    httpInJobDoc = ( strstr( ( const char * ) pProtocol, "HTTP" ) != NULL ) ? true : false;
-    mqttInJobDoc = ( strstr( ( const char * ) pProtocol, "MQTT" ) != NULL ) ? true : false;
+    httpInJobDoc = ( strstr( ( const char * ) pProtocol, "\"HTTP\"" ) != NULL ) ? true : false;
+    mqttInJobDoc = ( strstr( ( const char * ) pProtocol, "\"MQTT\"" ) != NULL ) ? true : false;
     /* LCOV_EXCL_BR_STOP */
 
     #if ( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) && !( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) )

--- a/source/ota_interface.c
+++ b/source/ota_interface.c
@@ -95,7 +95,7 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
         pDataInterface->requestFileBlock = requestDataBlock_Http;
         pDataInterface->decodeFileBlock = decodeFileBlock_Http;
         pDataInterface->cleanup = cleanupData_Http;
-    #else  /* if !( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) | ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) ) */
+    #else /* if !( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) | ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) ) */
         char protocolBuffer[ OTA_PROTOCOL_BUFFER_SIZE ] = { 0 };
         bool httpInJobDoc = false;
         bool mqttInJobDoc = false;

--- a/source/ota_interface.c
+++ b/source/ota_interface.c
@@ -97,8 +97,8 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
         pDataInterface->cleanup = cleanupData_Http;
     #else  /* if !( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) | ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) ) */
         char protocolBuffer[ OTA_PROTOCOL_BUFFER_SIZE ] = { 0 };
-        bool httpInJobDoc;
-        bool mqttInJobDoc;
+        bool httpInJobDoc = false;
+        bool mqttInJobDoc = false;
 
         ( void ) memcpy( protocolBuffer, pProtocol, OTA_PROTOCOL_BUFFER_SIZE );
         httpInJobDoc = ( strstr( protocolBuffer, "HTTP" ) != NULL ) ? true : false;

--- a/source/ota_interface.c
+++ b/source/ota_interface.c
@@ -80,15 +80,17 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
     #if !( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) | ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) )
     #error "One or more of the data protocols must be set with configENABLED_DATA_PROTOCOLS."
     #elif !( ( configOTA_PRIMARY_DATA_PROTOCOL & OTA_DATA_OVER_MQTT ) | ( configOTA_PRIMARY_DATA_PROTOCOL & OTA_DATA_OVER_HTTP ) )
-    #error "configOTA_PRIMARY_DATA_PROTOCOL must be set to one of the data protocols."
+    #error "configOTA_PRIMARY_DATA_PROTOCOL must be set to OTA_DATA_OVER_MQTT or OTA_DATA_OVER_HTTP."
     #elif ( configOTA_PRIMARY_DATA_PROTOCOL >= ( OTA_DATA_OVER_MQTT | OTA_DATA_OVER_HTTP ) )
     #error "Invalid value for configOTA_PRIMARY_DATA_PROTOCOL: Value is expected to be OTA_DATA_OVER_MQTT or OTA_DATA_OVER_HTTP."
     #elif ( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) && !( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) )
+        ( void ) pProtocol;
         pDataInterface->initFileTransfer = initFileTransfer_Mqtt;
         pDataInterface->requestFileBlock = requestFileBlock_Mqtt;
         pDataInterface->decodeFileBlock = decodeFileBlock_Mqtt;
         pDataInterface->cleanup = cleanupData_Mqtt;
     #elif ( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) && !( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) )
+        ( void ) pProtocol;
         pDataInterface->initFileTransfer = initFileTransfer_Http;
         pDataInterface->requestFileBlock = requestDataBlock_Http;
         pDataInterface->decodeFileBlock = decodeFileBlock_Http;
@@ -98,7 +100,7 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
         bool httpInJobDoc;
         bool mqttInJobDoc;
 
-        memcpy( protocolBuffer, pProtocol, OTA_PROTOCOL_BUFFER_SIZE );
+        ( void ) memcpy( protocolBuffer, pProtocol, OTA_PROTOCOL_BUFFER_SIZE );
         httpInJobDoc = ( strstr( protocolBuffer, "HTTP" ) != NULL ) ? true : false;
         mqttInJobDoc = ( strstr( protocolBuffer, "MQTT" ) != NULL ) ? true : false;
 
@@ -140,7 +142,7 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
             {
                 err = OtaErrInvalidDataProtocol;
             }
-        #endif /* if ( configOTA_PRIMARY_DATA_PROTOCOL == OTA_DATA_OVER_MQTT ) */
+        #endif /* if ( configOTA_PRIMARY_DATA_PROTOCOL == OTA_DATA_OVER_HTTP ) */
     #endif /* if !( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) | ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) ) */
 
     return err;

--- a/source/ota_interface.c
+++ b/source/ota_interface.c
@@ -78,7 +78,6 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
 {
     OtaErr_t err = OtaErrNone;
 
-
     #if ( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) && !( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) )
         ( void ) pProtocol;
         pDataInterface->initFileTransfer = initFileTransfer_Mqtt;
@@ -92,13 +91,11 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
         pDataInterface->decodeFileBlock = decodeFileBlock_Http;
         pDataInterface->cleanup = cleanupData_Http;
     #else /* if !( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) | ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) ) */
-        char protocolBuffer[ OTA_PROTOCOL_BUFFER_SIZE ] = { 0 };
         bool httpInJobDoc;
         bool mqttInJobDoc;
 
-        ( void ) memcpy( protocolBuffer, pProtocol, OTA_PROTOCOL_BUFFER_SIZE );
-        httpInJobDoc = ( strstr( protocolBuffer, "HTTP" ) != NULL ) ? true : false;
-        mqttInJobDoc = ( strstr( protocolBuffer, "MQTT" ) != NULL ) ? true : false;
+        httpInJobDoc = ( strstr( ( const char * ) pProtocol, "HTTP" ) != NULL ) ? true : false;
+        mqttInJobDoc = ( strstr( ( const char * ) pProtocol, "MQTT" ) != NULL ) ? true : false;
 
         #if ( configOTA_PRIMARY_DATA_PROTOCOL == OTA_DATA_OVER_MQTT )
             if( mqttInJobDoc == true )

--- a/source/ota_interface.c
+++ b/source/ota_interface.c
@@ -42,10 +42,22 @@
     #include "ota_http_private.h"
 #endif
 
-/* Check if primary protocol is enabled in aws_iot_ota_agent_config.h. */
+/* Check for invalid data interface configurations. */
 
 #if !( configENABLED_DATA_PROTOCOLS & configOTA_PRIMARY_DATA_PROTOCOL )
     #error "Primary data protocol must be enabled in aws_iot_ota_agent_config.h"
+#endif
+
+#if !( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) | ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) )
+    #error "One or more of the data protocols must be set with configENABLED_DATA_PROTOCOLS."
+#endif
+
+#if !( ( configOTA_PRIMARY_DATA_PROTOCOL & OTA_DATA_OVER_MQTT ) | ( configOTA_PRIMARY_DATA_PROTOCOL & OTA_DATA_OVER_HTTP ) )
+    #error "configOTA_PRIMARY_DATA_PROTOCOL must be set to OTA_DATA_OVER_MQTT or OTA_DATA_OVER_HTTP."
+#endif
+
+#if ( configOTA_PRIMARY_DATA_PROTOCOL >= ( OTA_DATA_OVER_MQTT | OTA_DATA_OVER_HTTP ) )
+    #error "Invalid value for configOTA_PRIMARY_DATA_PROTOCOL: Value is expected to be OTA_DATA_OVER_MQTT or OTA_DATA_OVER_HTTP."
 #endif
 
 void setControlInterface( OtaControlInterface_t * pControlInterface )
@@ -66,13 +78,8 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
 {
     OtaErr_t err = OtaErrNone;
 
-    #if !( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) | ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) )
-    #error "One or more of the data protocols must be set with configENABLED_DATA_PROTOCOLS."
-    #elif !( ( configOTA_PRIMARY_DATA_PROTOCOL & OTA_DATA_OVER_MQTT ) | ( configOTA_PRIMARY_DATA_PROTOCOL & OTA_DATA_OVER_HTTP ) )
-    #error "configOTA_PRIMARY_DATA_PROTOCOL must be set to OTA_DATA_OVER_MQTT or OTA_DATA_OVER_HTTP."
-    #elif ( configOTA_PRIMARY_DATA_PROTOCOL >= ( OTA_DATA_OVER_MQTT | OTA_DATA_OVER_HTTP ) )
-    #error "Invalid value for configOTA_PRIMARY_DATA_PROTOCOL: Value is expected to be OTA_DATA_OVER_MQTT or OTA_DATA_OVER_HTTP."
-    #elif ( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) && !( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) )
+
+    #if ( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) && !( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) )
         ( void ) pProtocol;
         pDataInterface->initFileTransfer = initFileTransfer_Mqtt;
         pDataInterface->requestFileBlock = requestFileBlock_Mqtt;

--- a/source/ota_interface.c
+++ b/source/ota_interface.c
@@ -77,57 +77,16 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
                            const uint8_t * pProtocol )
 {
     OtaErr_t err = OtaErrInvalidDataProtocol;
-    size_t i;
     bool httpInJobDoc;
     bool mqttInJobDoc;
 
-    static const char * pOtaTransferTypes[] =
-    {
-        /* Do not change the order of these. */
-        "[\"MQTT\"]",
-        "[\"HTTP\"]",
-        "[\"MQTT\",\"HTTP\"]",
-        "[\"HTTP\",\"MQTT\"]"
-    };
-    static size_t numTransferTypes = sizeof( pOtaTransferTypes ) / sizeof( const char * );
-
-    for( i = 0; i < numTransferTypes; ++i )
-    {
-        /* The explicit type cast creates additional branches tracked by code
-         * coverage tools that are unreachable. These macros prevent the tools
-         * from tracking branch coverage for these lines. */
-        /* LCOV_EXCL_BR_START */
-        if( strcmp( pOtaTransferTypes[ i ], ( const char * ) pProtocol ) == 0 )
-        {
-            break;
-        }
-
-        /* LCOV_EXCL_BR_STOP */
-    }
-
-    switch( i )
-    {
-        case 0: /* MQTT enabled. */
-            mqttInJobDoc = true;
-            httpInJobDoc = false;
-            break;
-
-        case 1: /* HTTP enabled */
-            mqttInJobDoc = false;
-            httpInJobDoc = true;
-            break;
-
-        case 2:
-        case 3:
-            mqttInJobDoc = true;
-            httpInJobDoc = true;
-            break;
-
-        default:
-            mqttInJobDoc = false;
-            httpInJobDoc = false;
-            break;
-    }
+    /* The explicit type casts create additional branches tracked by code
+     * coverage tools that are unreachable. These macros prevent the tools
+     * from tracking branch coverage for these lines. */
+    /* LCOV_EXCL_BR_START */
+    httpInJobDoc = ( strstr( ( const char * ) pProtocol, "HTTP" ) != NULL ) ? true : false;
+    mqttInJobDoc = ( strstr( ( const char * ) pProtocol, "MQTT" ) != NULL ) ? true : false;
+    /* LCOV_EXCL_BR_STOP */
 
     #if ( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) && !( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) )
         ( void ) httpInJobDoc;

--- a/source/ota_interface.c
+++ b/source/ota_interface.c
@@ -45,7 +45,7 @@
 /* Check for invalid data interface configurations. */
 
 #if !( configENABLED_DATA_PROTOCOLS & configOTA_PRIMARY_DATA_PROTOCOL )
-    #error "Primary data protocol must be enabled in aws_iot_ota_agent_config.h"
+    #error "Primary data protocol must be enabled in the OTA configuration file."
 #endif
 
 #if !( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) | ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) )

--- a/source/ota_interface.c
+++ b/source/ota_interface.c
@@ -116,7 +116,7 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
         {
             err = OtaErrInvalidDataProtocol;
         }
-    #else  /* if ( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) && !( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) ) */
+    #else /* if ( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) && !( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) ) */
         #if ( configOTA_PRIMARY_DATA_PROTOCOL == OTA_DATA_OVER_MQTT )
             if( mqttInJobDoc == true )
             {

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -698,7 +698,7 @@ static void otaGoToState( OtaState_t state )
 }
 
 /* ========================================================================== */
-/* ================ Unit test setup and teardown functions ================== */
+/* ================ Unit test setup and tear down functions ================= */
 /* ========================================================================== */
 
 void setUp()
@@ -721,7 +721,7 @@ void tearDown()
 }
 
 /* ========================================================================== */
-/* ================== State machine behavior unit tests ===================== */
+/* =============================== Unit tests =============================== */
 /* ========================================================================== */
 
 void test_OTA_InitWhenStopped()
@@ -1939,25 +1939,25 @@ void test_OTA_HTTP_strerror( void )
 void test_OTA_setDataInterfaceValidInput( void )
 {
     OtaDataInterface_t dataInterface = { NULL, NULL, NULL, NULL };
-    uint8_t pProtocol[20] = { 0 };
+    uint8_t pProtocol[ OTA_PROTOCOL_BUFFER_SIZE ] = { 0 };
 
     memcpy( pProtocol, "MQTT", sizeof( "MQTT" ) );
     TEST_ASSERT_EQUAL( OtaErrNone, setDataInterface( &dataInterface, pProtocol ) );
-    TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.initFileTransfer );
-    TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.requestFileBlock );
-    TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.decodeFileBlock );
-    TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.cleanup );
+    TEST_ASSERT_EQUAL( initFileTransfer_Mqtt, dataInterface.initFileTransfer );
+    TEST_ASSERT_EQUAL( requestFileBlock_Mqtt, dataInterface.requestFileBlock );
+    TEST_ASSERT_EQUAL( decodeFileBlock_Mqtt, dataInterface.decodeFileBlock );
+    TEST_ASSERT_EQUAL( cleanupData_Mqtt, dataInterface.cleanup );
 
     memcpy( pProtocol, "HTTP", sizeof( "HTTP" ) );
-    memset( &dataInterface, 0, sizeof(dataInterface ) );
+    memset( &dataInterface, 0, sizeof( dataInterface ) );
     TEST_ASSERT_EQUAL( OtaErrNone, setDataInterface( &dataInterface, pProtocol ) );
-    TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.initFileTransfer );
-    TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.requestFileBlock );
-    TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.decodeFileBlock );
-    TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.cleanup );
+    TEST_ASSERT_EQUAL( initFileTransfer_Http, dataInterface.initFileTransfer );
+    TEST_ASSERT_EQUAL( requestDataBlock_Http, dataInterface.requestFileBlock );
+    TEST_ASSERT_EQUAL( decodeFileBlock_Http, dataInterface.decodeFileBlock );
+    TEST_ASSERT_EQUAL( cleanupData_Http, dataInterface.cleanup );
 
     memcpy( pProtocol, "HTTPMQTT", sizeof( "HTTPMQTT" ) );
-    memset( &dataInterface, 0, sizeof(dataInterface ) );
+    memset( &dataInterface, 0, sizeof( dataInterface ) );
     TEST_ASSERT_EQUAL( OtaErrNone, setDataInterface( &dataInterface, pProtocol ) );
     TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.initFileTransfer );
     TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.requestFileBlock );
@@ -1965,7 +1965,7 @@ void test_OTA_setDataInterfaceValidInput( void )
     TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.cleanup );
 
     memcpy( pProtocol, "MQTTHTTP", sizeof( "MQTTHTTP" ) );
-    memset( &dataInterface, 0, sizeof(dataInterface ) );
+    memset( &dataInterface, 0, sizeof( dataInterface ) );
     TEST_ASSERT_EQUAL( OtaErrNone, setDataInterface( &dataInterface, pProtocol ) );
     TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.initFileTransfer );
     TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.requestFileBlock );
@@ -1974,13 +1974,13 @@ void test_OTA_setDataInterfaceValidInput( void )
 }
 
 /**
- * @brief Test that setDataInterface sets the data interface when given valid
- *        inputs.
+ * @brief Test that setDataInterface returns an error and does not set the data
+ * interface when provided with an invalid input from a job document.
  */
 void test_OTA_setDataInterfaceInvalidInput( void )
 {
     OtaDataInterface_t dataInterface = { NULL, NULL, NULL, NULL };
-    uint8_t pProtocol[20] = { 0 };
+    uint8_t pProtocol[ 20 ] = { 0 };
 
     memcpy( pProtocol, "invalid_protocol", sizeof( "invalid_protocol" ) );
     TEST_ASSERT_EQUAL( OtaErrInvalidDataProtocol, setDataInterface( &dataInterface, pProtocol ) );

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -1941,14 +1941,14 @@ void test_OTA_setDataInterfaceValidInput( void )
     OtaDataInterface_t dataInterface = { NULL, NULL, NULL, NULL };
     uint8_t pProtocol[ OTA_PROTOCOL_BUFFER_SIZE ] = { 0 };
 
-    memcpy( pProtocol, "MQTT", sizeof( "MQTT" ) );
+    memcpy( pProtocol, "[\"MQTT\"]", sizeof( "[\"MQTT\"]" ) );
     TEST_ASSERT_EQUAL( OtaErrNone, setDataInterface( &dataInterface, pProtocol ) );
     TEST_ASSERT_EQUAL( initFileTransfer_Mqtt, dataInterface.initFileTransfer );
     TEST_ASSERT_EQUAL( requestFileBlock_Mqtt, dataInterface.requestFileBlock );
     TEST_ASSERT_EQUAL( decodeFileBlock_Mqtt, dataInterface.decodeFileBlock );
     TEST_ASSERT_EQUAL( cleanupData_Mqtt, dataInterface.cleanup );
 
-    memcpy( pProtocol, "HTTP", sizeof( "HTTP" ) );
+    memcpy( pProtocol, "[\"HTTP\"]", sizeof( "[\"HTTP\"]" ) );
     memset( &dataInterface, 0, sizeof( dataInterface ) );
     TEST_ASSERT_EQUAL( OtaErrNone, setDataInterface( &dataInterface, pProtocol ) );
     TEST_ASSERT_EQUAL( initFileTransfer_Http, dataInterface.initFileTransfer );
@@ -1956,7 +1956,7 @@ void test_OTA_setDataInterfaceValidInput( void )
     TEST_ASSERT_EQUAL( decodeFileBlock_Http, dataInterface.decodeFileBlock );
     TEST_ASSERT_EQUAL( cleanupData_Http, dataInterface.cleanup );
 
-    memcpy( pProtocol, "HTTPMQTT", sizeof( "HTTPMQTT" ) );
+    memcpy( pProtocol, "[\"HTTP\",\"MQTT\"]", sizeof( "[\"HTTP\",\"MQTT\"]" ) );
     memset( &dataInterface, 0, sizeof( dataInterface ) );
     TEST_ASSERT_EQUAL( OtaErrNone, setDataInterface( &dataInterface, pProtocol ) );
     TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.initFileTransfer );
@@ -1964,7 +1964,7 @@ void test_OTA_setDataInterfaceValidInput( void )
     TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.decodeFileBlock );
     TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.cleanup );
 
-    memcpy( pProtocol, "MQTTHTTP", sizeof( "MQTTHTTP" ) );
+    memcpy( pProtocol, "[\"MQTT\",\"HTTP\"]", sizeof( "[\"MQTT\",\"HTTP\"]" ) );
     memset( &dataInterface, 0, sizeof( dataInterface ) );
     TEST_ASSERT_EQUAL( OtaErrNone, setDataInterface( &dataInterface, pProtocol ) );
     TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.initFileTransfer );
@@ -1980,9 +1980,30 @@ void test_OTA_setDataInterfaceValidInput( void )
 void test_OTA_setDataInterfaceInvalidInput( void )
 {
     OtaDataInterface_t dataInterface = { NULL, NULL, NULL, NULL };
-    uint8_t pProtocol[ 20 ] = { 0 };
+    uint8_t pProtocol[ OTA_PROTOCOL_BUFFER_SIZE ] = { 0 };
 
     memcpy( pProtocol, "invalid_protocol", sizeof( "invalid_protocol" ) );
+    TEST_ASSERT_EQUAL( OtaErrInvalidDataProtocol, setDataInterface( &dataInterface, pProtocol ) );
+    TEST_ASSERT_EQUAL( NULL, dataInterface.initFileTransfer );
+    TEST_ASSERT_EQUAL( NULL, dataInterface.requestFileBlock );
+    TEST_ASSERT_EQUAL( NULL, dataInterface.decodeFileBlock );
+    TEST_ASSERT_EQUAL( NULL, dataInterface.cleanup );
+
+    memcpy( pProtocol, "MQTT", sizeof( "MQTT" ) );
+    TEST_ASSERT_EQUAL( OtaErrInvalidDataProtocol, setDataInterface( &dataInterface, pProtocol ) );
+    TEST_ASSERT_EQUAL( NULL, dataInterface.initFileTransfer );
+    TEST_ASSERT_EQUAL( NULL, dataInterface.requestFileBlock );
+    TEST_ASSERT_EQUAL( NULL, dataInterface.decodeFileBlock );
+    TEST_ASSERT_EQUAL( NULL, dataInterface.cleanup );
+
+    memcpy( pProtocol, "HTTP", sizeof( "HTTP" ) );
+    TEST_ASSERT_EQUAL( OtaErrInvalidDataProtocol, setDataInterface( &dataInterface, pProtocol ) );
+    TEST_ASSERT_EQUAL( NULL, dataInterface.initFileTransfer );
+    TEST_ASSERT_EQUAL( NULL, dataInterface.requestFileBlock );
+    TEST_ASSERT_EQUAL( NULL, dataInterface.decodeFileBlock );
+    TEST_ASSERT_EQUAL( NULL, dataInterface.cleanup );
+
+    memcpy( pProtocol, "[\"MQTT\"]", sizeof( "[\"MQTT\"]" ) );
     TEST_ASSERT_EQUAL( OtaErrInvalidDataProtocol, setDataInterface( &dataInterface, pProtocol ) );
     TEST_ASSERT_EQUAL( NULL, dataInterface.initFileTransfer );
     TEST_ASSERT_EQUAL( NULL, dataInterface.requestFileBlock );

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -1941,14 +1941,14 @@ void test_OTA_setDataInterfaceValidInput( void )
     OtaDataInterface_t dataInterface = { NULL, NULL, NULL, NULL };
     uint8_t pProtocol[ OTA_PROTOCOL_BUFFER_SIZE ] = { 0 };
 
-    memcpy( pProtocol, "[\"MQTT\"]", sizeof( "[\"MQTT\"]" ) );
+    memcpy( pProtocol, "MQTT", sizeof( "MQTT" ) );
     TEST_ASSERT_EQUAL( OtaErrNone, setDataInterface( &dataInterface, pProtocol ) );
     TEST_ASSERT_EQUAL( initFileTransfer_Mqtt, dataInterface.initFileTransfer );
     TEST_ASSERT_EQUAL( requestFileBlock_Mqtt, dataInterface.requestFileBlock );
     TEST_ASSERT_EQUAL( decodeFileBlock_Mqtt, dataInterface.decodeFileBlock );
     TEST_ASSERT_EQUAL( cleanupData_Mqtt, dataInterface.cleanup );
 
-    memcpy( pProtocol, "[\"HTTP\"]", sizeof( "[\"HTTP\"]" ) );
+    memcpy( pProtocol, "HTTP", sizeof( "HTTP" ) );
     memset( &dataInterface, 0, sizeof( dataInterface ) );
     TEST_ASSERT_EQUAL( OtaErrNone, setDataInterface( &dataInterface, pProtocol ) );
     TEST_ASSERT_EQUAL( initFileTransfer_Http, dataInterface.initFileTransfer );
@@ -1956,7 +1956,7 @@ void test_OTA_setDataInterfaceValidInput( void )
     TEST_ASSERT_EQUAL( decodeFileBlock_Http, dataInterface.decodeFileBlock );
     TEST_ASSERT_EQUAL( cleanupData_Http, dataInterface.cleanup );
 
-    memcpy( pProtocol, "[\"HTTP\",\"MQTT\"]", sizeof( "[\"HTTP\",\"MQTT\"]" ) );
+    memcpy( pProtocol, "HTTPMQTT", sizeof( "HTTPMQTT" ) );
     memset( &dataInterface, 0, sizeof( dataInterface ) );
     TEST_ASSERT_EQUAL( OtaErrNone, setDataInterface( &dataInterface, pProtocol ) );
     TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.initFileTransfer );
@@ -1964,7 +1964,7 @@ void test_OTA_setDataInterfaceValidInput( void )
     TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.decodeFileBlock );
     TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.cleanup );
 
-    memcpy( pProtocol, "[\"MQTT\",\"HTTP\"]", sizeof( "[\"MQTT\",\"HTTP\"]" ) );
+    memcpy( pProtocol, "MQTTHTTP", sizeof( "MQTTHTTP" ) );
     memset( &dataInterface, 0, sizeof( dataInterface ) );
     TEST_ASSERT_EQUAL( OtaErrNone, setDataInterface( &dataInterface, pProtocol ) );
     TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.initFileTransfer );
@@ -1980,30 +1980,9 @@ void test_OTA_setDataInterfaceValidInput( void )
 void test_OTA_setDataInterfaceInvalidInput( void )
 {
     OtaDataInterface_t dataInterface = { NULL, NULL, NULL, NULL };
-    uint8_t pProtocol[ OTA_PROTOCOL_BUFFER_SIZE ] = { 0 };
+    uint8_t pProtocol[ 20 ] = { 0 };
 
     memcpy( pProtocol, "invalid_protocol", sizeof( "invalid_protocol" ) );
-    TEST_ASSERT_EQUAL( OtaErrInvalidDataProtocol, setDataInterface( &dataInterface, pProtocol ) );
-    TEST_ASSERT_EQUAL( NULL, dataInterface.initFileTransfer );
-    TEST_ASSERT_EQUAL( NULL, dataInterface.requestFileBlock );
-    TEST_ASSERT_EQUAL( NULL, dataInterface.decodeFileBlock );
-    TEST_ASSERT_EQUAL( NULL, dataInterface.cleanup );
-
-    memcpy( pProtocol, "MQTT", sizeof( "MQTT" ) );
-    TEST_ASSERT_EQUAL( OtaErrInvalidDataProtocol, setDataInterface( &dataInterface, pProtocol ) );
-    TEST_ASSERT_EQUAL( NULL, dataInterface.initFileTransfer );
-    TEST_ASSERT_EQUAL( NULL, dataInterface.requestFileBlock );
-    TEST_ASSERT_EQUAL( NULL, dataInterface.decodeFileBlock );
-    TEST_ASSERT_EQUAL( NULL, dataInterface.cleanup );
-
-    memcpy( pProtocol, "HTTP", sizeof( "HTTP" ) );
-    TEST_ASSERT_EQUAL( OtaErrInvalidDataProtocol, setDataInterface( &dataInterface, pProtocol ) );
-    TEST_ASSERT_EQUAL( NULL, dataInterface.initFileTransfer );
-    TEST_ASSERT_EQUAL( NULL, dataInterface.requestFileBlock );
-    TEST_ASSERT_EQUAL( NULL, dataInterface.decodeFileBlock );
-    TEST_ASSERT_EQUAL( NULL, dataInterface.cleanup );
-
-    memcpy( pProtocol, "junk[\"MQTT\"]", sizeof( "junk[\"MQTT\"]" ) );
     TEST_ASSERT_EQUAL( OtaErrInvalidDataProtocol, setDataInterface( &dataInterface, pProtocol ) );
     TEST_ASSERT_EQUAL( NULL, dataInterface.initFileTransfer );
     TEST_ASSERT_EQUAL( NULL, dataInterface.requestFileBlock );

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -2003,7 +2003,7 @@ void test_OTA_setDataInterfaceInvalidInput( void )
     TEST_ASSERT_EQUAL( NULL, dataInterface.decodeFileBlock );
     TEST_ASSERT_EQUAL( NULL, dataInterface.cleanup );
 
-    memcpy( pProtocol, "[\"MQTT\"]", sizeof( "[\"MQTT\"]" ) );
+    memcpy( pProtocol, "junk[\"MQTT\"]", sizeof( "junk[\"MQTT\"]" ) );
     TEST_ASSERT_EQUAL( OtaErrInvalidDataProtocol, setDataInterface( &dataInterface, pProtocol ) );
     TEST_ASSERT_EQUAL( NULL, dataInterface.initFileTransfer );
     TEST_ASSERT_EQUAL( NULL, dataInterface.requestFileBlock );

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -1941,14 +1941,14 @@ void test_OTA_setDataInterfaceValidInput( void )
     OtaDataInterface_t dataInterface = { NULL, NULL, NULL, NULL };
     uint8_t pProtocol[ OTA_PROTOCOL_BUFFER_SIZE ] = { 0 };
 
-    memcpy( pProtocol, "MQTT", sizeof( "MQTT" ) );
+    memcpy( pProtocol, "[\"MQTT\"]", sizeof( "[\"MQTT\"]" ) );
     TEST_ASSERT_EQUAL( OtaErrNone, setDataInterface( &dataInterface, pProtocol ) );
     TEST_ASSERT_EQUAL( initFileTransfer_Mqtt, dataInterface.initFileTransfer );
     TEST_ASSERT_EQUAL( requestFileBlock_Mqtt, dataInterface.requestFileBlock );
     TEST_ASSERT_EQUAL( decodeFileBlock_Mqtt, dataInterface.decodeFileBlock );
     TEST_ASSERT_EQUAL( cleanupData_Mqtt, dataInterface.cleanup );
 
-    memcpy( pProtocol, "HTTP", sizeof( "HTTP" ) );
+    memcpy( pProtocol, "[\"HTTP\"]", sizeof( "[\"HTTP\"]" ) );
     memset( &dataInterface, 0, sizeof( dataInterface ) );
     TEST_ASSERT_EQUAL( OtaErrNone, setDataInterface( &dataInterface, pProtocol ) );
     TEST_ASSERT_EQUAL( initFileTransfer_Http, dataInterface.initFileTransfer );
@@ -1956,7 +1956,7 @@ void test_OTA_setDataInterfaceValidInput( void )
     TEST_ASSERT_EQUAL( decodeFileBlock_Http, dataInterface.decodeFileBlock );
     TEST_ASSERT_EQUAL( cleanupData_Http, dataInterface.cleanup );
 
-    memcpy( pProtocol, "HTTPMQTT", sizeof( "HTTPMQTT" ) );
+    memcpy( pProtocol, "[\"MQTT\",\"HTTP\"]", sizeof( "[\"MQTT\",\"HTTP\"]" ) );
     memset( &dataInterface, 0, sizeof( dataInterface ) );
     TEST_ASSERT_EQUAL( OtaErrNone, setDataInterface( &dataInterface, pProtocol ) );
     TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.initFileTransfer );
@@ -1964,7 +1964,7 @@ void test_OTA_setDataInterfaceValidInput( void )
     TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.decodeFileBlock );
     TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.cleanup );
 
-    memcpy( pProtocol, "MQTTHTTP", sizeof( "MQTTHTTP" ) );
+    memcpy( pProtocol, "[\"HTTP\",\"MQTT\"]", sizeof( "[\"HTTP\",\"MQTT\"]" ) );
     memset( &dataInterface, 0, sizeof( dataInterface ) );
     TEST_ASSERT_EQUAL( OtaErrNone, setDataInterface( &dataInterface, pProtocol ) );
     TEST_ASSERT_NOT_EQUAL( NULL, dataInterface.initFileTransfer );
@@ -1980,9 +1980,23 @@ void test_OTA_setDataInterfaceValidInput( void )
 void test_OTA_setDataInterfaceInvalidInput( void )
 {
     OtaDataInterface_t dataInterface = { NULL, NULL, NULL, NULL };
-    uint8_t pProtocol[ 20 ] = { 0 };
+    uint8_t pProtocol[ OTA_PROTOCOL_BUFFER_SIZE ] = { 0 };
 
     memcpy( pProtocol, "invalid_protocol", sizeof( "invalid_protocol" ) );
+    TEST_ASSERT_EQUAL( OtaErrInvalidDataProtocol, setDataInterface( &dataInterface, pProtocol ) );
+    TEST_ASSERT_EQUAL( NULL, dataInterface.initFileTransfer );
+    TEST_ASSERT_EQUAL( NULL, dataInterface.requestFileBlock );
+    TEST_ASSERT_EQUAL( NULL, dataInterface.decodeFileBlock );
+    TEST_ASSERT_EQUAL( NULL, dataInterface.cleanup );
+
+    memcpy( pProtocol, "junkMQTT", sizeof( "junkMQTT" ) );
+    TEST_ASSERT_EQUAL( OtaErrInvalidDataProtocol, setDataInterface( &dataInterface, pProtocol ) );
+    TEST_ASSERT_EQUAL( NULL, dataInterface.initFileTransfer );
+    TEST_ASSERT_EQUAL( NULL, dataInterface.requestFileBlock );
+    TEST_ASSERT_EQUAL( NULL, dataInterface.decodeFileBlock );
+    TEST_ASSERT_EQUAL( NULL, dataInterface.cleanup );
+
+    memcpy( pProtocol, "HTTPjunk", sizeof( "HTTPjunk" ) );
     TEST_ASSERT_EQUAL( OtaErrInvalidDataProtocol, setDataInterface( &dataInterface, pProtocol ) );
     TEST_ASSERT_EQUAL( NULL, dataInterface.initFileTransfer );
     TEST_ASSERT_EQUAL( NULL, dataInterface.requestFileBlock );

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -657,6 +657,7 @@ sendtimeout
 sendtimeoutms
 serverfileid
 serverinfo
+setdatainterface
 setimagestate
 setplatformimagestate
 shutdownhandler


### PR DESCRIPTION
The previous implementation for setting the data interface for OTA had some issues that were preventing branch coverage. It was also missing some test cases. This change:
* Reduces the total number of branches for ota_interface.c
* Makes the string parsing more strict. Only strings that are an exact match with what is expected to be seen in the job document will count as match.
* Adds a macro for a previously hard coded value for the protocol buffer size
* Adds unit tests for covering the potential invalid and valid inputs
* Adds more preprocessor checks for invalid user configurations
* Removed an unnecessary build step from the CI that was causing issues with the coverage report


For testing, I successfully:
* Downloaded OTA updates with MQTT, HTTP, and both MQTT and HTTP enabled.
* Locally tested all permutations of the data interface configurations with the unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
