### PR TITLE
Update error handling for processing data blocks

### DIFF
--- a/source/include/ota_private.h
+++ b/source/include/ota_private.h
@@ -164,19 +164,19 @@
  */
 typedef enum
 {
-    IngestResultFileComplete = -1,       /*!< The file transfer is complete and the signature check passed. */
-    IngestResultSigCheckFail = -2,       /*!< The file transfer is complete but the signature check failed. */
-    IngestResultFileCloseFail = -3,      /*!< There was a problem trying to close the receive file. */
-    IngestResultNullInput = -4,          /*!< One of the input pointers is NULL. */
-    IngestResultBadFileHandle = -5,      /*!< The receive file pointer is invalid. */
-    IngestResultUnexpectedBlock = -6,    /*!< We were asked to ingest a block but were not expecting one. */
-    IngestResultBlockOutOfRange = -7,    /*!< The received block is out of the expected range. */
-    IngestResultBadData = -8,            /*!< The data block from the server was malformed. */
-    IngestResultWriteBlockFailed = -9,   /*!< The PAL layer failed to write the file block. */
-    IngestResultNoDecodeMemory = -10,    /*!< Memory could not be allocated for decoding . */
-    IngestResultUninitialized = -127,    /*!< Software BUG: We forgot to set the result code. */
-    IngestResultAccepted_Continue = 0,   /*!< The block was accepted and we're expecting more. */
-    IngestResultDuplicate_Continue = 1   /*!< The block was a duplicate but that's OK. Continue. */
+    IngestResultFileComplete = -1,     /*!< The file transfer is complete and the signature check passed. */
+    IngestResultSigCheckFail = -2,     /*!< The file transfer is complete but the signature check failed. */
+    IngestResultFileCloseFail = -3,    /*!< There was a problem trying to close the receive file. */
+    IngestResultNullInput = -4,        /*!< One of the input pointers is NULL. */
+    IngestResultBadFileHandle = -5,    /*!< The receive file pointer is invalid. */
+    IngestResultUnexpectedBlock = -6,  /*!< We were asked to ingest a block but were not expecting one. */
+    IngestResultBlockOutOfRange = -7,  /*!< The received block is out of the expected range. */
+    IngestResultBadData = -8,          /*!< The data block from the server was malformed. */
+    IngestResultWriteBlockFailed = -9, /*!< The PAL layer failed to write the file block. */
+    IngestResultNoDecodeMemory = -10,  /*!< Memory could not be allocated for decoding . */
+    IngestResultUninitialized = -127,  /*!< Software BUG: We forgot to set the result code. */
+    IngestResultAccepted_Continue = 0, /*!< The block was accepted and we're expecting more. */
+    IngestResultDuplicate_Continue = 1 /*!< The block was a duplicate but that's OK. Continue. */
 } IngestResult_t;
 
 /**

--- a/source/include/ota_private.h
+++ b/source/include/ota_private.h
@@ -167,14 +167,13 @@ typedef enum
     IngestResultFileComplete = -1,       /*!< The file transfer is complete and the signature check passed. */
     IngestResultSigCheckFail = -2,       /*!< The file transfer is complete but the signature check failed. */
     IngestResultFileCloseFail = -3,      /*!< There was a problem trying to close the receive file. */
-    IngestResultNullContext = -4,        /*!< The specified OTA context pointer is null. */
+    IngestResultNullInput = -4,          /*!< One of the input pointers is NULL. */
     IngestResultBadFileHandle = -5,      /*!< The receive file pointer is invalid. */
     IngestResultUnexpectedBlock = -6,    /*!< We were asked to ingest a block but were not expecting one. */
     IngestResultBlockOutOfRange = -7,    /*!< The received block is out of the expected range. */
     IngestResultBadData = -8,            /*!< The data block from the server was malformed. */
     IngestResultWriteBlockFailed = -9,   /*!< The PAL layer failed to write the file block. */
-    IngestResultNullResultPointer = -10, /*!< The pointer to the close result pointer was null. */
-    IngestResultNoDecodeMemory = -11,    /*!< Memory could not be allocated for decoding . */
+    IngestResultNoDecodeMemory = -10,    /*!< Memory could not be allocated for decoding . */
     IngestResultUninitialized = -127,    /*!< Software BUG: We forgot to set the result code. */
     IngestResultAccepted_Continue = 0,   /*!< The block was accepted and we're expecting more. */
     IngestResultDuplicate_Continue = 1   /*!< The block was a duplicate but that's OK. Continue. */

--- a/source/ota.c
+++ b/source/ota.c
@@ -1162,15 +1162,23 @@ static OtaErr_t processDataHandler( const OtaEventData_t * pEventData )
     OtaErr_t err = OtaErrNone;
     OtaPalStatus_t closeResult = OTA_PAL_COMBINE_ERR( OtaPalUninitialized, 0 );
     OtaEventMsg_t eventMsg = { 0 };
+    IngestResult_t result = IngestResultUninitialized;
 
     /* Get the file context. */
     OtaFileContext_t * pFileContext = &( otaAgent.fileContext );
 
     /* Ingest data blocks received. */
-    IngestResult_t result = ingestDataBlock( pFileContext,
-                                             pEventData->data,
-                                             pEventData->dataLength,
-                                             &closeResult );
+    if( pEventData != NULL )
+    {
+        result = ingestDataBlock( pFileContext,
+                                  pEventData->data,
+                                  pEventData->dataLength,
+                                  &closeResult );
+    }
+    else
+    {
+        result = IngestResultNullInput;
+    }
 
     if( result == IngestResultFileComplete )
     {
@@ -2653,27 +2661,15 @@ static IngestResult_t ingestDataBlock( OtaFileContext_t * pFileContext,
     uint32_t uBlockIndex = 0;
     uint8_t * pPayload = NULL;
 
-    /* Check if the file context is NULL. */
-    if( pFileContext == NULL )
-    {
-        eIngestResult = IngestResultNullContext;
-    }
-
-    /* Check if the result pointer is NULL. */
-    if( eIngestResult == IngestResultUninitialized )
-    {
-        if( pCloseResult == NULL )
-        {
-            eIngestResult = IngestResultNullResultPointer;
-        }
-    }
+    /* Assume the file context and result pointers are not NULL. This function
+     * is only intended to be called by processDataHandler, which always passes
+     * them in as pointers to static variables. */
+    assert( pFileContext != NULL );
+    assert( pCloseResult != NULL );
 
     /* Decode the received data block. */
-    if( eIngestResult == IngestResultUninitialized )
-    {
-        /* If we have a block bitmap available then process the message. */
-        eIngestResult = decodeAndStoreDataBlock( pFileContext, pRawMsg, messageSize, &pPayload, &uBlockSize, &uBlockIndex );
-    }
+    /* If we have a block bitmap available then process the message. */
+    eIngestResult = decodeAndStoreDataBlock( pFileContext, pRawMsg, messageSize, &pPayload, &uBlockSize, &uBlockIndex );
 
     /* Validate the data block and process it to store the information.*/
     if( eIngestResult == IngestResultUninitialized )

--- a/source/ota.c
+++ b/source/ota.c
@@ -1075,8 +1075,6 @@ static OtaErr_t requestDataHandler( const OtaEventData_t * pEventData )
 
     ( void ) pEventData;
 
-    ( void ) pEventData;
-
     if( otaAgent.fileContext.blocksRemaining > 0U )
     {
         /* Start the request timer. */

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -2027,7 +2027,7 @@ void test_OTA_initFileHandler_EventSendFails( void )
     TEST_ASSERT_EQUAL( OtaErrSignalEventFailed, initFileHandler( otaEvent.pEventData ) );
 
     /* Test failing while trying to send the request block event after
-     * successfuly initializing the file. */
+     * successfully initializing the file. */
     otaInitDefault();
 
     /* Succeed with the file initialization to then attempt to send the event

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -2051,8 +2051,10 @@ void test_OTA_requestDataHandler_EventSendFails( void )
 
     /* File context has a non-zero number of blocks remaining. */
     otaAgent.fileContext.blocksRemaining = 1U;
-    /* Fail to start the timer. */
-    otaInterfaces.os.timer.start = mockOSTimerStartAlwaysFail;
+    /* Simulate reaching the maximum number of attempts before considering
+     * the attempt to be a failure. In this scenario, the handler will attempt
+     * to send a shutdown event to the OTA Agent.*/
+    otaAgent.requestMomentum = otaconfigMAX_NUM_REQUEST_MOMENTUM;
     /* Fail to send the OTA event. */
     otaInterfaces.os.event.send = mockOSEventSendAlwaysFail;
 

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -363,7 +363,7 @@ OtaErr_t mockDataInterfaceInitFileTransferAlwaysFail( OtaAgentContext_t * unused
 }
 
 
-OtaErr_t mockMqttInitFileTransferAlwaysSucceed( OtaAgentContext_t * unused )
+OtaErr_t mockDataInitFileTransferAlwaysSucceed( OtaAgentContext_t * unused )
 {
     ( void ) unused;
 
@@ -2032,7 +2032,7 @@ void test_OTA_initFileHandler_EventSendFails( void )
 
     /* Succeed with the file initialization to then attempt to send the event
      * for requesting a block. */
-    otaDataInterface.initFileTransfer = mockMqttInitFileTransferAlwaysSucceed;
+    otaDataInterface.initFileTransfer = mockDataInitFileTransferAlwaysSucceed;
     /* Fail to send the OTA event. */
     otaInterfaces.os.event.send = mockOSEventSendAlwaysFail;
 

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -143,10 +143,7 @@ extern void receiveAndProcessOtaEvent( void );
 extern OtaErr_t initFileHandler( const OtaEventData_t * pEventData );
 extern OtaErr_t requestDataHandler( const OtaEventData_t * pEventData );
 extern OtaErr_t requestJobHandler( const OtaEventData_t * pEventData );
-<<<<<<< HEAD
 extern OtaErr_t processDataHandler( const OtaEventData_t * pEventData );
-=======
->>>>>>> main
 
 /* ========================================================================== */
 /* ====================== Unit test helper functions ======================== */

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -132,8 +132,9 @@ extern OtaDataInterface_t otaDataInterface;
 /* Static function defined in ota.c for processing events. */
 extern void receiveAndProcessOtaEvent( void );
 
-/* State machine function handler for initializing the file. */
+/* Static state machine function handlers under test defined in ota.c. */
 extern OtaErr_t initFileHandler( const OtaEventData_t * pEventData );
+extern OtaErr_t requestDataHandler( const OtaEventData_t * pEventData );
 
 /* ========================================================================== */
 
@@ -1977,8 +1978,8 @@ void test_OTA_initFileHandler_TimerFails( void )
 }
 
 /**
- * @brief Test that initFileHandler returns the proper error when the OS event
- * send functionality fails.
+ * @brief Test that initFileHandler returns the proper error when the OTA event
+ *        send functionality fails.
  */
 void test_OTA_initFileHandler_EventSendFails( void )
 {
@@ -2009,4 +2010,24 @@ void test_OTA_initFileHandler_EventSendFails( void )
     otaInterfaces.os.event.send = mockOSEventSendAlwaysFail;
 
     TEST_ASSERT_EQUAL( OtaErrSignalEventFailed, initFileHandler( otaEvent.pEventData ) );
+}
+
+/**
+ * @brief Test that requestDataHandler returns the proper error when the OTA
+ *        event send functionality fails.
+ */
+void test_OTA_requestDataHandler_EventSendFails( void )
+{
+    OtaEventMsg_t otaEvent = { 0 };
+
+    otaInitDefault();
+
+    /* File context has a non-zero number of blocks remaining. */
+    otaAgent.fileContext.blocksRemaining = 1U;
+    /* Fail to start the timer. */
+    otaInterfaces.os.timer.start = mockOSTimerStartAlwaysFail;
+    /* Fail to send the OTA event. */
+    otaInterfaces.os.event.send = mockOSEventSendAlwaysFail;
+
+    TEST_ASSERT_EQUAL( OtaErrSignalEventFailed, requestDataHandler( otaEvent.pEventData ) );
 }

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -143,6 +143,7 @@ extern void receiveAndProcessOtaEvent( void );
 extern OtaErr_t initFileHandler( const OtaEventData_t * pEventData );
 extern OtaErr_t requestDataHandler( const OtaEventData_t * pEventData );
 extern OtaErr_t requestJobHandler( const OtaEventData_t * pEventData );
+extern OtaErr_t processDataHandler( const OtaEventData_t * pEventData );
 
 /* ========================================================================== */
 /* ====================== Unit test helper functions ======================== */
@@ -2104,6 +2105,22 @@ void test_OTA_requestJobHandler_EventSendFails( void )
     otaInterfaces.os.event.send = mockOSEventSendAlwaysFail;
 
     TEST_ASSERT_EQUAL( OtaErrSignalEventFailed, requestJobHandler( otaEvent.pEventData ) );
+}
+
+
+/**
+ * @brief Test that processDataHandler safely handles receiving invalid events.
+ */
+void test_OTA_processDataHandler_InvalidEvent( void )
+{
+    /* Initialize the OTA interfaces so they are not NULL. */
+    otaGoToState( OtaAgentStateReady );
+
+    /* Test that passing NULL event data does not cause a segmentation fault.
+     * The expected return is OtaErrNone because the error return value of this
+     * handler represents the success of updating the job document when there
+     * is an issue processing the block. */
+    TEST_ASSERT_EQUAL( OtaErrNone, processDataHandler( NULL ) );
 }
 
 /* ========================================================================== */

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -1995,7 +1995,7 @@ void test_OTA_initFileHandler_TimerFails( void )
     OtaEventMsg_t otaEvent = { 0 };
 
     /* Initialize the OTA interfaces so they are not NULL. */
-    otaInitDefault();
+    otaGoToState( OtaAgentStateReady );
     /* Fail to initialize the file transfer so the timer is started. */
     otaDataInterface.initFileTransfer = mockDataInterfaceInitFileTransferAlwaysFail;
     /* Fail to start the timer. */
@@ -2012,9 +2012,11 @@ void test_OTA_initFileHandler_EventSendFails( void )
 {
     OtaEventMsg_t otaEvent = { 0 };
 
+    /* Initialize the OTA interfaces so they are not NULL. */
+    otaGoToState( OtaAgentStateReady );
+
     /* Test failing while trying to send the shutdown event after failing
      * to initialize the file. */
-    otaInitDefault();
     /* Fail to initialize the file transfer so the timer is started. */
     otaDataInterface.initFileTransfer = mockDataInterfaceInitFileTransferAlwaysFail;
 
@@ -2028,7 +2030,6 @@ void test_OTA_initFileHandler_EventSendFails( void )
 
     /* Test failing while trying to send the request block event after
      * successfully initializing the file. */
-    otaInitDefault();
 
     /* Succeed with the file initialization to then attempt to send the event
      * for requesting a block. */
@@ -2047,10 +2048,12 @@ void test_OTA_requestDataHandler_EventSendFails( void )
 {
     OtaEventMsg_t otaEvent = { 0 };
 
-    otaInitDefault();
+    /* Initialize the OTA interfaces so they are not NULL. */
+    otaGoToState( OtaAgentStateReady );
 
     /* File context has a non-zero number of blocks remaining. */
     otaAgent.fileContext.blocksRemaining = 1U;
+
     /* Simulate reaching the maximum number of attempts before considering
      * the attempt to be a failure. In this scenario, the handler will attempt
      * to send a shutdown event to the OTA Agent.*/
@@ -2069,7 +2072,8 @@ void test_OTA_requestJobHandler_TimerFails( void )
 {
     OtaEventMsg_t otaEvent = { 0 };
 
-    otaInitDefault();
+    /* Initialize the OTA interfaces so they are not NULL. */
+    otaGoToState( OtaAgentStateReady );
 
     /* Fail requesting the job document. */
     otaControlInterface.requestJob = mockControlInterfaceRequestJobAlwaysFail;
@@ -2087,7 +2091,8 @@ void test_OTA_requestJobHandler_EventSendFails( void )
 {
     OtaEventMsg_t otaEvent = { 0 };
 
-    otaInitDefault();
+    /* Initialize the OTA interfaces so they are not NULL. */
+    otaGoToState( OtaAgentStateReady );
 
     /* Fail requesting the job document. */
     otaControlInterface.requestJob = mockControlInterfaceRequestJobAlwaysFail;

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -212,6 +212,7 @@ ingestresultfilecomplete
 ingestresultfilecomplete
 ingestresultnodecodememory
 ingestresultnullcontext
+ingestresultnullinput
 ingestresultnullresultpointer
 ingestresultsigcheckfail
 ingestresultunexpectedblock


### PR DESCRIPTION
  Fix error handling in code for ingesting blocks:
  * Replaced NULL checks for pointers to static variables with asserts.
  * Added a check for receiving a data block event from the application that has NULL data.
  * Add a unit test for receiving a null data block.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
