### PR TITLE
Disable fsanitizer from unit-test

### DIFF
--- a/source/ota_http.c
+++ b/source/ota_http.c
@@ -145,13 +145,7 @@ OtaErr_t decodeFileBlock_Http( const uint8_t * pMessageBuffer,
         *pBlockSize = ( int32_t ) messageSize;
 
         /* The data received over HTTP does not require any decoding. */
-
-        /* The __THROW in library functions create additional branches tracked
-         * by code coverage tools that are unreachable. These macros prevent
-         * the tools from tracking branch coverage for these lines. */
-        /* LCOV_EXCL_BR_START */
         ( void ) memcpy( *pPayload, pMessageBuffer, messageSize );
-        /* LCOV_EXCL_BR_STOP */
 
         *pPayloadSize = messageSize;
 

--- a/source/ota_interface.c
+++ b/source/ota_interface.c
@@ -80,13 +80,8 @@ OtaErr_t setDataInterface( OtaDataInterface_t * pDataInterface,
     bool httpInJobDoc;
     bool mqttInJobDoc;
 
-    /* The explicit type casts create additional branches tracked by code
-     * coverage tools that are unreachable. These macros prevent the tools
-     * from tracking branch coverage for these lines. */
-    /* LCOV_EXCL_BR_START */
     httpInJobDoc = ( strstr( ( const char * ) pProtocol, "\"HTTP\"" ) != NULL ) ? true : false;
     mqttInJobDoc = ( strstr( ( const char * ) pProtocol, "\"MQTT\"" ) != NULL ) ? true : false;
-    /* LCOV_EXCL_BR_STOP */
 
     #if ( ( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_MQTT ) && !( configENABLED_DATA_PROTOCOLS & OTA_DATA_OVER_HTTP ) )
         ( void ) httpInJobDoc;

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -265,23 +265,13 @@ static size_t stringBuilder( char * pBuffer,
 
     for( i = 0; strings[ i ] != NULL; i++ )
     {
-        /* The __THROW in library functions create additional branches tracked
-         * by code coverage tools that are unreachable. These macros prevent
-         * the tools from tracking branch coverage for these lines. */
-        /* LCOV_EXCL_BR_START */
         thisLength = strlen( strings[ i ] );
-        /* LCOV_EXCL_BR_STOP */
 
         /* Assert if there is not enough buffer space. */
 
         assert( thisLength + curLen + 1 <= bufferSizeBytes );
 
-        /* The __THROW in library functions create additional branches tracked
-         * by code coverage tools that are unreachable. These macros prevent
-         * the tools from tracking branch coverage for these lines. */
-        /* LCOV_EXCL_BR_START */
         strncat( pBuffer, strings[ i ], bufferSizeBytes - curLen - 1 );
-        /* LCOV_EXCL_BR_STOP */
         curLen += thisLength;
     }
 

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -110,11 +110,3 @@ create_test(ota_os_posix_utest
 )
 # Disable unity memory handling since we need to free memory allocated from library.
 target_compile_definitions(ota_cbor_utest PRIVATE UNITY_FIXTURE_NO_EXTRAS)
-
-# Enable sanitizers.
-target_compile_options(
-    ${real_name} PUBLIC -fsanitize=address -fsanitize=leak -fsanitize=undefined
-)
-target_link_options(
-    ${real_name} PUBLIC -fsanitize=address -fsanitize=leak -fsanitize=undefined
-)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
fsanitizer causes the coverage tools to track more branches than expected. This was originally introduced when the unit-tests were multi-threaded and can be removed now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
