### PR TITLE
Add unit tests for ota.c

### DIFF
--- a/source/ota.c
+++ b/source/ota.c
@@ -3136,7 +3136,7 @@ OtaState_t OTA_Shutdown( uint32_t ticksToWait,
          * stopped. */
         otaAgent.state = OtaAgentStateStopped;
     }
-    else if( ( otaAgent.state != OtaAgentStateStopped ) && ( otaAgent.state != OtaAgentStateShuttingDown ) )
+    else if( ( otaAgent.state != OtaAgentStateStopped ) && ( otaAgent.state != OtaAgentStateShuttingDown ) ) /* LCOV_EXCL_BR_LINE */
     {
         otaAgent.unsubscribeOnShutdown = unsubscribeFlag;
 
@@ -3156,7 +3156,7 @@ OtaState_t OTA_Shutdown( uint32_t ticksToWait,
             /*
              * Wait for the OTA agent to complete shutdown, if requested.
              */
-            while( ( ticks > 0U ) && ( otaAgent.state != OtaAgentStateStopped ) )
+            while( ( ticks > 0U ) && ( otaAgent.state != OtaAgentStateStopped ) ) /* LCOV_EXCL_BR_LINE */
             {
                 ticks--;
             }

--- a/source/ota.c
+++ b/source/ota.c
@@ -2776,25 +2776,24 @@ static void executeHandler( uint32_t index,
 {
     OtaErr_t err = OtaErrNone;
 
-    if( otaTransitionTable[ index ].handler != NULL )
+    assert( otaTransitionTable[ index ].handler != NULL );
+
+    err = otaTransitionTable[ index ].handler( pEventMsg->pEventData );
+
+    if( err == OtaErrNone )
     {
-        err = otaTransitionTable[ index ].handler( pEventMsg->pEventData );
+        LogDebug( ( "Executing handler for state transition: " ) );
 
-        if( err == OtaErrNone )
-        {
-            LogDebug( ( "Executing handler for state transition: " ) );
-
-            /*
-             * Update the current state in OTA agent context.
-             */
-            otaAgent.state = otaTransitionTable[ index ].nextState;
-        }
-        else
-        {
-            LogError( ( "Failed to execute state transition handler: "
-                        "Handler returned error: OtaErr_t=%s",
-                        OTA_Err_strerror( err ) ) );
-        }
+        /*
+            * Update the current state in OTA agent context.
+            */
+        otaAgent.state = otaTransitionTable[ index ].nextState;
+    }
+    else
+    {
+        LogError( ( "Failed to execute state transition handler: "
+                    "Handler returned error: OtaErr_t=%s",
+                    OTA_Err_strerror( err ) ) );
     }
 
     LogInfo( ( "Current State=[%s]"

--- a/source/ota.c
+++ b/source/ota.c
@@ -2527,8 +2527,7 @@ static IngestResult_t decodeAndStoreDataBlock( OtaFileContext_t * pFileContext,
                                                          otaconfigFILE_REQUEST_WAIT_MS,
                                                          otaTimerCallback );
 
-        if( ( otaAgent.fileContext.pDecodeMem != NULL ) &&
-            ( otaAgent.fileContext.decodeMemMaxSize != 0u ) )
+        if( otaAgent.fileContext.decodeMemMaxSize != 0U )
         {
             *pPayload = otaAgent.fileContext.pDecodeMem;
             payloadSize = otaAgent.fileContext.decodeMemMaxSize;

--- a/source/ota.c
+++ b/source/ota.c
@@ -2785,8 +2785,8 @@ static void executeHandler( uint32_t index,
         LogDebug( ( "Executing handler for state transition: " ) );
 
         /*
-            * Update the current state in OTA agent context.
-            */
+         * Update the current state in OTA agent context.
+         */
         otaAgent.state = otaTransitionTable[ index ].nextState;
     }
     else

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -148,6 +148,7 @@ extern OtaErr_t processDataHandler( const OtaEventData_t * pEventData );
 /* Static helper function under test defined in ota.c. */
 extern OtaErr_t setImageStateWithReason( OtaImageState_t stateToSet,
                                          uint32_t reasonToSet );
+extern bool otaClose( OtaFileContext_t * const pFileContext );
 
 /* ========================================================================== */
 /* ====================== Unit test helper functions ======================== */
@@ -861,6 +862,11 @@ void test_OTA_ShutdownFailToSendEvent()
     /* Shutdown should now fail and OTA agent should remain in ready state. */
     OTA_Shutdown( otaDefaultWait, unsubscribeFlag );
     TEST_ASSERT_EQUAL( OtaAgentStateReady, OTA_GetState() );
+}
+
+void test_OTA_CloseNullInput()
+{
+    TEST_ASSERT_EQUAL( false, otaClose( NULL ) );
 }
 
 void test_OTA_StartWhenReady()

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -859,6 +859,56 @@ void test_OTA_InitWithNameTooLong()
     TEST_ASSERT_EQUAL( OtaAgentStateStopped, OTA_GetState() );
 }
 
+void test_OTA_InitNullAppBuffers()
+{
+    /* Test for having NULL pointers but valid sizes. */
+    pOtaAppBuffer.pUpdateFilePath = NULL;
+    pOtaAppBuffer.updateFilePathsize = OTA_UPDATE_FILE_PATH_SIZE;
+    pOtaAppBuffer.pCertFilePath = NULL;
+    pOtaAppBuffer.certFilePathSize = OTA_CERT_FILE_PATH_SIZE;
+    pOtaAppBuffer.pStreamName = NULL;
+    pOtaAppBuffer.streamNameSize = OTA_STREAM_NAME_SIZE;
+    pOtaAppBuffer.pDecodeMemory = NULL;
+    pOtaAppBuffer.decodeMemorySize = OTA_DECODE_MEMORY_SIZE;
+    pOtaAppBuffer.pFileBitmap = NULL;
+    pOtaAppBuffer.fileBitmapSize = OTA_FILE_BITMAP_SIZE;
+    pOtaAppBuffer.pUrl = NULL;
+    pOtaAppBuffer.urlSize = OTA_UPDATE_URL_SIZE;
+    pOtaAppBuffer.pAuthScheme = NULL;
+    pOtaAppBuffer.authSchemeSize = OTA_AUTH_SCHEME_SIZE;
+
+    OTA_Init( &pOtaAppBuffer,
+              &otaInterfaces,
+              ( const uint8_t * ) pOtaDefaultClientId,
+              mockAppCallback );
+    TEST_ASSERT_EQUAL( OtaAgentStateInit, OTA_GetState() );
+}
+
+void test_OTA_InitZeroAppBufferSizes()
+{
+    /* Test for having valid pointers with zero sizes. */
+    pOtaAppBuffer.pUpdateFilePath = pUserBuffer;
+    pOtaAppBuffer.updateFilePathsize = 0;
+    pOtaAppBuffer.pCertFilePath = pUserBuffer;
+    pOtaAppBuffer.certFilePathSize = 0;
+    pOtaAppBuffer.pStreamName = pUserBuffer;
+    pOtaAppBuffer.streamNameSize = 0;
+    pOtaAppBuffer.pDecodeMemory = pUserBuffer;
+    pOtaAppBuffer.decodeMemorySize = 0;
+    pOtaAppBuffer.pFileBitmap = pUserBuffer;
+    pOtaAppBuffer.fileBitmapSize = 0;
+    pOtaAppBuffer.pUrl = pUserBuffer;
+    pOtaAppBuffer.urlSize = 0;
+    pOtaAppBuffer.pAuthScheme = pUserBuffer;
+    pOtaAppBuffer.authSchemeSize = 0;
+
+    OTA_Init( &pOtaAppBuffer,
+              &otaInterfaces,
+              ( const uint8_t * ) pOtaDefaultClientId,
+              mockAppCallback );
+    TEST_ASSERT_EQUAL( OtaAgentStateInit, OTA_GetState() );
+}
+
 void test_OTA_ShutdownWithDelay()
 {
     otaGoToState( OtaAgentStateReady );

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -1140,7 +1140,7 @@ void test_OTA_ActivateNewImageNullPalActivate()
               mockAppCallback );
 
     TEST_ASSERT_EQUAL( OtaAgentStateInit, OTA_GetState() );
-    TEST_ASSERT_NOT_EQUAL( OtaErrActivateFailed, OTA_ActivateNewImage() );
+    TEST_ASSERT_EQUAL( OtaErrActivateFailed, OTA_ActivateNewImage() );
 }
 
 void test_OTA_ImageStateAbortWithActiveJob()

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -118,7 +118,7 @@ static FILE * pOtaFileHandle = NULL;
 static uint8_t pOtaFileBuffer[ OTA_TEST_FILE_SIZE ];
 
 /* 2 seconds default wait time for OTA state machine transition. */
-static const int otaDefaultWait = 2000;
+static const int otaDefaultWait = 0;
 
 /* Flag to unsubscribe to topics after ota shutdown. */
 static const uint8_t unsubscribeFlag = 1;
@@ -858,10 +858,19 @@ void test_OTA_InitWithNameTooLong()
     TEST_ASSERT_EQUAL( OtaAgentStateStopped, OTA_GetState() );
 }
 
+void test_OTA_ShutdownWithDelay()
+{
+    otaGoToState( OtaAgentStateReady );
+    OTA_Shutdown( 2000, 0 );
+    receiveAndProcessOtaEvent();
+    TEST_ASSERT_EQUAL( OtaAgentStateStopped, OTA_GetState() );
+}
+
 void test_OTA_ShutdownWhenStopped()
 {
     /* Calling shutdown when already stopped should have no effect. */
     OTA_Shutdown( otaDefaultWait, unsubscribeFlag );
+    receiveAndProcessOtaEvent();
     TEST_ASSERT_EQUAL( OtaAgentStateStopped, OTA_GetState() );
 }
 
@@ -875,6 +884,7 @@ void test_OTA_ShutdownFailToSendEvent()
 
     /* Shutdown should now fail and OTA agent should remain in ready state. */
     OTA_Shutdown( otaDefaultWait, unsubscribeFlag );
+    receiveAndProcessOtaEvent();
     TEST_ASSERT_EQUAL( OtaAgentStateReady, OTA_GetState() );
 }
 

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -1126,6 +1126,23 @@ void test_OTA_ActivateNewImageWhenStopped()
     TEST_ASSERT_NOT_EQUAL( OtaErrNone, OTA_ActivateNewImage() );
 }
 
+void test_OTA_ActivateNewImageNullPalActivate()
+{
+    /* Have all other interfaces besides the activate function of the PAL
+     * interface. */
+    otaInterfaces.pal.activate = NULL;
+
+    /* Initialize the OTA Agent to set the interfaces before trying to
+     * activate the new image. */
+    OTA_Init( &pOtaAppBuffer,
+              &otaInterfaces,
+              ( const uint8_t * ) pOtaDefaultClientId,
+              mockAppCallback );
+
+    TEST_ASSERT_EQUAL( OtaAgentStateInit, OTA_GetState() );
+    TEST_ASSERT_NOT_EQUAL( OtaErrActivateFailed, OTA_ActivateNewImage() );
+}
+
 void test_OTA_ImageStateAbortWithActiveJob()
 {
     otaGoToState( OtaAgentStateWaitingForFileBlock );

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -332,6 +332,7 @@ otaagenteventstart
 otaagenteventstartselftest
 otaagenteventsuspend
 otaagenteventuserabort
+otaagentstateshuttingdown
 otaagentstatenotready
 otaagentstatenotready
 otaagentstateready


### PR DESCRIPTION
Add unit tests for ota.c
* Add a test for closing a NULL file pointer
* Update and test memory handling for data block buf 
* Remove delay and fix the incorrect shutdown tests
* Exclude two lines in OTA_Shutdown from branch cov.
* Test calling shutdownHandler with NULL interfaces
* Change if check to an assert in executeHandler
* Test receiving a data block and failing to send it
* Add more tests for user inputs to OTA_Init
* Test activating a new image with a null PAL function

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.