### PR TITLE
Add check for filetype id before doing version check

### DIFF
--- a/source/include/ota_config_defaults.h
+++ b/source/include/ota_config_defaults.h
@@ -211,6 +211,19 @@
 #endif
 
 /**
+ * @brief The file type id received in the job document.
+ *
+ * @note The file type id received in the job document that allows devices
+ * to identify the type of file received from the cloud. This configuration
+ * defines the file type id used for firmware updates. If this is changed
+ * then the updated value must be used while creating firmware update jobs.
+ *
+ */
+#ifndef configOTA_FIRMWARE_UPDATE_FILE_TYPE_ID
+    #define configOTA_FIRMWARE_UPDATE_FILE_TYPE_ID    0U
+#endif
+
+/**
  * @brief The protocol selected for OTA control operations.
  *
  * @note This configurations parameter sets the default protocol for all the

--- a/source/ota.c
+++ b/source/ota.c
@@ -1860,7 +1860,7 @@ static OtaErr_t validateUpdateVersion( const OtaFileContext_t * pFileContext )
     ( void ) newVersion; /* For suppressing compiler-warning: unused variable. */
 
     /* Only check for versions if the target is self */
-    if( otaAgent.serverFileID == 0U )
+    if( ( otaAgent.serverFileID == 0U ) && ( otaAgent.fileContext.fileType == configOTA_FIRMWARE_UPDATE_FILE_TYPE_ID ) )
     {
         /* Check if version reported is the same as the running version. */
         if( pFileContext->updaterVersion == appFirmwareVersion.u.unsignedVersion32 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This change adds -
* A new configuration in the OTA config to set the file type id for firmware files
* A check on the file type as firmware before performing version check 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
