### PR TITLE
Add note in documentation on handling OTA and custom jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Check formatting
-        uses: aggarw13/CI-CD-Github-Actions/formatting@formatting/take-input-parameter-for-excluding-files
+        uses: FreeRTOS/CI-CD-Github-Actions/formatting@main
         with:
           path: ./
           exclude-dirs: docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,9 +112,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Check formatting
-        uses: FreeRTOS/CI-CD-Github-Actions/formatting@main
+        uses: aggarw13/CI-CD-Github-Actions/formatting@formatting/take-input-parameter-for-excluding-files
         with:
           path: ./
+          exclude-dirs: docs
 
   git-secrets:
     runs-on: ubuntu-latest

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -17,6 +17,13 @@ The major functions that this library’s APIs provide are –
 
 AWS services can be used with this library to manage various cloud related topics such as sending firmware updates, monitoring large numbers of devices across multiple regions, reducing the blast radius of faulty deployments, and verifying the security of updates.
 
+> **NOTE**: **Handling OTA and custom jobs in your application**  
+> If your application will process both OTA and custom types of jobs from AWS IoT, we recommend using the feature support for custom jobs in OTA library through the #OtaJobEventParseCustomJob event notification in the registered #OtaAppCallback_t callback.  
+> However, if your application chooses to use the [AWS IoT Jobs library](https://github.com/aws/Jobs-for-AWS-IoT-embedded-sdk) (for handling custom jobs) and the OTA library (for handling OTA jobs) to communicate with AWS IoT through a shared MQTT connection, we suggest that you keep the application logic that uses these libraries within a single task/thread.
+> As the OTA agent also makes calls to the AWS IoT Jobs service, keeping the use of libraries within the same thread context will avoid complexity of synchronizing communication with AWS IoT Jobs topics between multiple tasks/threads.
+> However, if you choose to use different tasks/threads for calling these libraries, please be aware that the OTA library will subscribe and configurably, unsubscribe from AWS IoT Jobs topics, and also attempt to send status updates for incoming non-OTA jobs, if your application configures the OTA library to handle custom jobs.
+
+
 @section ota_dependencies OTA Dependencies
 @dot "OTA Dependencies"
 digraph ota_dependencies
@@ -79,6 +86,7 @@ Currently, the OTA library has the following direct dependencies:
 @brief Memory requirements of the OTA library.
 
 @include{doc} size_table.html
+
  */
 
 /**

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -771,3 +771,4 @@ www
 xaa
 xyz
 zg
+configurably


### PR DESCRIPTION
Equivalent of https://github.com/aws/Jobs-for-AWS-IoT-embedded-sdk/pull/39 in OTA library documentation about handling both custom and OTA jobs in application.