### PR TITLE
Register OTA time callback in ota freeRTOS port

### DIFF
--- a/source/portable/os/ota_os_freertos.c
+++ b/source/portable/os/ota_os_freertos.c
@@ -217,6 +217,9 @@ OtaOsStatus_t OtaStartTimer_FreeRTOS( OtaTimerId_t otaTimerId,
     configASSERT( pTimerName != NULL );
     configASSERT( ( otaTimerId >= OtaRequestTimer ) && ( otaTimerId < OtaNumOfTimers ) );
 
+    /* Set OTA lib callback. */
+    otaTimerCallback = callback;
+
     /* If timer is not created.*/
     if( otaTimer[ otaTimerId ] == NULL )
     {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change sets the OTA lib timer callback in OTA freeRTOS port.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
