### PR TITLE
Renaming OS timer methods ()

### DIFF
--- a/source/include/ota_os_interface.h
+++ b/source/include/ota_os_interface.h
@@ -267,9 +267,9 @@ typedef struct OtaEventInterface
  */
 typedef struct OtaTimerInterface
 {
-    OtaStartTimer_t start;   /*!< @brief Timer start state. */
-    OtaStopTimer_t stop;     /*!< @brief Timer stop state. */
-    OtaDeleteTimer_t delete; /*!< @brief Delete timer. */
+    OtaStartTimer_t startTimer;   /*!< @brief Timer start state. */
+    OtaStopTimer_t stopTimer;     /*!< @brief Timer stop state. */
+    OtaDeleteTimer_t deleteTimer; /*!< @brief Delete timer. */
 } OtaTimerInterface_t;
 
 /**

--- a/source/ota.c
+++ b/source/ota.c
@@ -769,9 +769,9 @@ static OtaErr_t startHandler( const OtaEventData_t * pEventData )
     if( platformInSelftest() == true )
     {
         ( void ) otaAgent.pOtaInterface->os.timer.startTimer( OtaSelfTestTimer,
-                                                         "OtaSelfTestTimer",
-                                                         otaconfigSELF_TEST_RESPONSE_WAIT_MS,
-                                                         otaTimerCallback );
+                                                              "OtaSelfTestTimer",
+                                                              otaconfigSELF_TEST_RESPONSE_WAIT_MS,
+                                                              otaTimerCallback );
     }
 
     /* Send event to OTA task to get job document. */
@@ -846,9 +846,9 @@ static OtaErr_t requestJobHandler( const OtaEventData_t * pEventData )
         {
             /* Start the request timer. */
             osErr = otaAgent.pOtaInterface->os.timer.startTimer( OtaRequestTimer,
-                                                            "OtaRequestTimer",
-                                                            otaconfigFILE_REQUEST_WAIT_MS,
-                                                            otaTimerCallback );
+                                                                 "OtaRequestTimer",
+                                                                 otaconfigFILE_REQUEST_WAIT_MS,
+                                                                 otaTimerCallback );
 
             if( osErr != OtaOsSuccess )
             {
@@ -1025,9 +1025,9 @@ static OtaErr_t initFileHandler( const OtaEventData_t * pEventData )
         {
             /* Start the request timer. */
             osErr = otaAgent.pOtaInterface->os.timer.startTimer( OtaRequestTimer,
-                                                            "OtaRequestTimer",
-                                                            otaconfigFILE_REQUEST_WAIT_MS,
-                                                            otaTimerCallback );
+                                                                 "OtaRequestTimer",
+                                                                 otaconfigFILE_REQUEST_WAIT_MS,
+                                                                 otaTimerCallback );
 
             if( osErr != OtaOsSuccess )
             {
@@ -1092,9 +1092,9 @@ static OtaErr_t requestDataHandler( const OtaEventData_t * pEventData )
     {
         /* Start the request timer. */
         osErr = otaAgent.pOtaInterface->os.timer.startTimer( OtaRequestTimer,
-                                                        "OtaRequestTimer",
-                                                        otaconfigFILE_REQUEST_WAIT_MS,
-                                                        otaTimerCallback );
+                                                             "OtaRequestTimer",
+                                                             otaconfigFILE_REQUEST_WAIT_MS,
+                                                             otaTimerCallback );
 
         if( ( osErr == OtaOsSuccess ) && ( otaAgent.requestMomentum < otaconfigMAX_NUM_REQUEST_MOMENTUM ) )
         {
@@ -2560,9 +2560,9 @@ static IngestResult_t decodeAndStoreDataBlock( OtaFileContext_t * pFileContext,
     if( ( pFileContext->pRxBlockBitmap != NULL ) && ( pFileContext->blocksRemaining > 0U ) )
     {
         ( void ) otaAgent.pOtaInterface->os.timer.startTimer( OtaRequestTimer,
-                                                         "OtaRequestTimer",
-                                                         otaconfigFILE_REQUEST_WAIT_MS,
-                                                         otaTimerCallback );
+                                                              "OtaRequestTimer",
+                                                              otaconfigFILE_REQUEST_WAIT_MS,
+                                                              otaTimerCallback );
 
         if( otaAgent.fileContext.decodeMemMaxSize != 0U )
         {

--- a/source/ota.c
+++ b/source/ota.c
@@ -768,7 +768,7 @@ static OtaErr_t startHandler( const OtaEventData_t * pEventData )
     /* Start self-test timer, if platform is in self-test. */
     if( platformInSelftest() == true )
     {
-        ( void ) otaAgent.pOtaInterface->os.timer.start( OtaSelfTestTimer,
+        ( void ) otaAgent.pOtaInterface->os.timer.startTimer( OtaSelfTestTimer,
                                                          "OtaSelfTestTimer",
                                                          otaconfigSELF_TEST_RESPONSE_WAIT_MS,
                                                          otaTimerCallback );
@@ -803,7 +803,7 @@ static OtaErr_t inSelfTestHandler( const OtaEventData_t * pEventData )
         otaAgent.fileContext.isInSelfTest = false;
 
         /* Stop the self test timer as it is no longer required. */
-        ( void ) otaAgent.pOtaInterface->os.timer.stop( OtaSelfTestTimer );
+        ( void ) otaAgent.pOtaInterface->os.timer.stopTimer( OtaSelfTestTimer );
     }
     else
     {
@@ -845,7 +845,7 @@ static OtaErr_t requestJobHandler( const OtaEventData_t * pEventData )
         if( otaAgent.requestMomentum < otaconfigMAX_NUM_REQUEST_MOMENTUM )
         {
             /* Start the request timer. */
-            osErr = otaAgent.pOtaInterface->os.timer.start( OtaRequestTimer,
+            osErr = otaAgent.pOtaInterface->os.timer.startTimer( OtaRequestTimer,
                                                             "OtaRequestTimer",
                                                             otaconfigFILE_REQUEST_WAIT_MS,
                                                             otaTimerCallback );
@@ -865,7 +865,7 @@ static OtaErr_t requestJobHandler( const OtaEventData_t * pEventData )
         else
         {
             /* Stop the request timer. */
-            ( void ) otaAgent.pOtaInterface->os.timer.stop( OtaRequestTimer );
+            ( void ) otaAgent.pOtaInterface->os.timer.stopTimer( OtaRequestTimer );
 
             /* Send shutdown event to the OTA Agent task. */
             eventMsg.eventId = OtaAgentEventShutdown;
@@ -885,7 +885,7 @@ static OtaErr_t requestJobHandler( const OtaEventData_t * pEventData )
     else
     {
         /* Stop the request timer. */
-        ( void ) otaAgent.pOtaInterface->os.timer.stop( OtaRequestTimer );
+        ( void ) otaAgent.pOtaInterface->os.timer.stopTimer( OtaRequestTimer );
 
         /* Reset the request momentum. */
         otaAgent.requestMomentum = 0;
@@ -1024,7 +1024,7 @@ static OtaErr_t initFileHandler( const OtaEventData_t * pEventData )
         if( otaAgent.requestMomentum < otaconfigMAX_NUM_REQUEST_MOMENTUM )
         {
             /* Start the request timer. */
-            osErr = otaAgent.pOtaInterface->os.timer.start( OtaRequestTimer,
+            osErr = otaAgent.pOtaInterface->os.timer.startTimer( OtaRequestTimer,
                                                             "OtaRequestTimer",
                                                             otaconfigFILE_REQUEST_WAIT_MS,
                                                             otaTimerCallback );
@@ -1044,7 +1044,7 @@ static OtaErr_t initFileHandler( const OtaEventData_t * pEventData )
         else
         {
             /* Stop the request timer. */
-            ( void ) otaAgent.pOtaInterface->os.timer.stop( OtaRequestTimer );
+            ( void ) otaAgent.pOtaInterface->os.timer.stopTimer( OtaRequestTimer );
 
             /* Send shutdown event. */
             eventMsg.eventId = OtaAgentEventShutdown;
@@ -1091,7 +1091,7 @@ static OtaErr_t requestDataHandler( const OtaEventData_t * pEventData )
     if( otaAgent.fileContext.blocksRemaining > 0U )
     {
         /* Start the request timer. */
-        osErr = otaAgent.pOtaInterface->os.timer.start( OtaRequestTimer,
+        osErr = otaAgent.pOtaInterface->os.timer.startTimer( OtaRequestTimer,
                                                         "OtaRequestTimer",
                                                         otaconfigFILE_REQUEST_WAIT_MS,
                                                         otaTimerCallback );
@@ -1108,7 +1108,7 @@ static OtaErr_t requestDataHandler( const OtaEventData_t * pEventData )
         else
         {
             /* Stop the request timer. */
-            ( void ) otaAgent.pOtaInterface->os.timer.stop( OtaRequestTimer );
+            ( void ) otaAgent.pOtaInterface->os.timer.stopTimer( OtaRequestTimer );
 
             /* Failed to send data request abort and close file. */
             err = setImageStateWithReason( OtaImageStateAborted, ( uint32_t ) err );
@@ -1145,7 +1145,7 @@ static void dataHandlerCleanup( void )
     OtaEventMsg_t eventMsg = { 0 };
 
     /* Stop the request timer. */
-    ( void ) otaAgent.pOtaInterface->os.timer.stop( OtaRequestTimer );
+    ( void ) otaAgent.pOtaInterface->os.timer.stopTimer( OtaRequestTimer );
 
     /* Send event to close file. */
     eventMsg.eventId = OtaAgentEventCloseFile;
@@ -1261,7 +1261,7 @@ static OtaErr_t processDataHandler( const OtaEventData_t * pEventData )
         else
         {
             /* Start the request timer. */
-            ( void ) otaAgent.pOtaInterface->os.timer.start( OtaRequestTimer, "OtaRequestTimer", otaconfigFILE_REQUEST_WAIT_MS, otaTimerCallback );
+            ( void ) otaAgent.pOtaInterface->os.timer.startTimer( OtaRequestTimer, "OtaRequestTimer", otaconfigFILE_REQUEST_WAIT_MS, otaTimerCallback );
 
             eventMsg.eventId = OtaAgentEventRequestFileBlock;
 
@@ -1367,7 +1367,7 @@ static OtaErr_t jobNotificationHandler( const OtaEventData_t * pEventData )
     ( void ) pEventData;
 
     /* Stop the request timer. */
-    ( void ) otaAgent.pOtaInterface->os.timer.stop( OtaRequestTimer );
+    ( void ) otaAgent.pOtaInterface->os.timer.stopTimer( OtaRequestTimer );
 
     /* Abort the current job. */
     ( void ) otaAgent.pOtaInterface->pal.setPlatformImageState( &( otaAgent.fileContext ), OtaImageStateAborted );
@@ -2559,7 +2559,7 @@ static IngestResult_t decodeAndStoreDataBlock( OtaFileContext_t * pFileContext,
     /* If we are expecting a data block, allocate space for it. */
     if( ( pFileContext->pRxBlockBitmap != NULL ) && ( pFileContext->blocksRemaining > 0U ) )
     {
-        ( void ) otaAgent.pOtaInterface->os.timer.start( OtaRequestTimer,
+        ( void ) otaAgent.pOtaInterface->os.timer.startTimer( OtaRequestTimer,
                                                          "OtaRequestTimer",
                                                          otaconfigFILE_REQUEST_WAIT_MS,
                                                          otaTimerCallback );
@@ -2633,7 +2633,7 @@ static IngestResult_t ingestDataBlockCleanup( OtaFileContext_t * pFileContext,
         LogInfo( ( "Received final block of the update." ) );
 
         /* Stop the request timer. */
-        ( void ) otaAgent.pOtaInterface->os.timer.stop( OtaRequestTimer );
+        ( void ) otaAgent.pOtaInterface->os.timer.stopTimer( OtaRequestTimer );
 
         /* Free the bitmap now that we're done with the download. */
         if( ( pFileContext->pRxBlockBitmap != NULL ) && ( pFileContext->blockBitmapMaxSize == 0u ) )
@@ -3372,7 +3372,7 @@ OtaErr_t OTA_Suspend( void )
     if( otaAgent.state != OtaAgentStateStopped )
     {
         /* Stop the request timer. */
-        ( void ) otaAgent.pOtaInterface->os.timer.stop( OtaRequestTimer );
+        ( void ) otaAgent.pOtaInterface->os.timer.stopTimer( OtaRequestTimer );
 
         /*
          * Send event to OTA agent task.

--- a/test/unit-test/ota_os_posix_utest.c
+++ b/test/unit-test/ota_os_posix_utest.c
@@ -52,9 +52,9 @@ static void timerCallback()
 
 void setUp( void )
 {
-    timer.start = Posix_OtaStartTimer;
-    timer.delete = Posix_OtaDeleteTimer;
-    timer.stop = Posix_OtaStopTimer;
+    timer.startTimer = Posix_OtaStartTimer;
+    timer.deleteTimer = Posix_OtaDeleteTimer;
+    timer.stopTimer = Posix_OtaStopTimer;
 
     event.init = Posix_OtaInitEvent;
     event.send = Posix_OtaSendEvent;
@@ -116,7 +116,7 @@ void timerCreateAndStop( OtaTimerId_t timer_id )
     OtaErr_t result = OtaErrUninitialized;
     int wait = 2 * OTA_DEFAULT_TIMEOUT; /* Wait for 2 times of the timeout specified. */
 
-    result = timer.start( timer_id, TIMER_NAME, OTA_DEFAULT_TIMEOUT, timerCallback );
+    result = timer.startTimer( timer_id, TIMER_NAME, OTA_DEFAULT_TIMEOUT, timerCallback );
     TEST_ASSERT_EQUAL( OtaErrNone, result );
 
     /* Wait for the timer callback to be invoked. */
@@ -129,10 +129,10 @@ void timerCreateAndStop( OtaTimerId_t timer_id )
 
     TEST_ASSERT_EQUAL( true, timerCallbackInovked );
 
-    result = timer.stop( timer_id );
+    result = timer.stopTimer( timer_id );
     TEST_ASSERT_EQUAL( OtaErrNone, result );
 
-    result = timer.delete( timer_id );
+    result = timer.deleteTimer( timer_id );
     TEST_ASSERT_EQUAL( OtaErrNone, result );
 }
 
@@ -160,21 +160,21 @@ void test_OTA_posix_InvalidTimerOperations( void )
     OtaErr_t result = OtaErrUninitialized;
     OtaTimerId_t timer_id = OtaRequestTimer;
 
-    result = timer.start( timer_id, TIMER_NAME, OTA_DEFAULT_TIMEOUT, NULL );
+    result = timer.startTimer( timer_id, TIMER_NAME, OTA_DEFAULT_TIMEOUT, NULL );
     TEST_ASSERT_EQUAL( OtaErrNone, result );
 
     /* Set the timeout to 0 and stop the timer*/
-    result = timer.start( timer_id, TIMER_NAME, 0, NULL );
+    result = timer.startTimer( timer_id, TIMER_NAME, 0, NULL );
     TEST_ASSERT_EQUAL( OtaErrNone, result );
 
-    result = timer.stop( timer_id );
+    result = timer.stopTimer( timer_id );
     TEST_ASSERT_EQUAL( OtaErrNone, result );
 
-    result = timer.delete( timer_id );
+    result = timer.deleteTimer( timer_id );
     TEST_ASSERT_EQUAL( OtaErrNone, result );
 
     /* Delete a timer that has been deleted. */
-    result = timer.delete( timer_id );
+    result = timer.deleteTimer( timer_id );
     TEST_ASSERT_NOT_EQUAL( OtaErrNone, result );
 }
 

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -708,9 +708,9 @@ static void otaInterfaceDefault()
     otaInterfaces.os.event.recv = mockOSEventReceive;
     otaInterfaces.os.event.deinit = mockOSEventReset;
 
-    otaInterfaces.os.timer.start = stubOSTimerStart;
-    otaInterfaces.os.timer.stop = stubOSTimerStop;
-    otaInterfaces.os.timer.delete = stubOSTimerDelete;
+    otaInterfaces.os.timer.startTimer = stubOSTimerStart;
+    otaInterfaces.os.timer.stopTimer = stubOSTimerStop;
+    otaInterfaces.os.timer.deleteTimer = stubOSTimerDelete;
 
     otaInterfaces.os.mem.malloc = malloc;
     otaInterfaces.os.mem.free = free;
@@ -1355,7 +1355,7 @@ void test_OTA_RequestJobDocumentRetryFail()
     otaInterfaces.mqtt.publish = stubMqttPublishAlwaysFail;
 
     /* Let timer invoke callback directly. */
-    otaInterfaces.os.timer.start = mockOSTimerInvokeCallback;
+    otaInterfaces.os.timer.startTimer = mockOSTimerInvokeCallback;
 
     /* Allow event to be sent continuously so that retries can work. */
     otaInterfaces.os.event.send = mockOSEventSend;
@@ -1622,7 +1622,7 @@ void test_OTA_InitFileTransferRetryFail()
     otaInterfaces.http.init = mockHttpInitAlwaysFail;
 
     /* Let timer invoke callback directly. */
-    otaInterfaces.os.timer.start = mockOSTimerInvokeCallback;
+    otaInterfaces.os.timer.startTimer = mockOSTimerInvokeCallback;
 
     /* Allow event to be sent continuously so that retries can work. */
     otaInterfaces.os.event.send = mockOSEventSend;
@@ -1696,7 +1696,7 @@ void test_OTA_RequestFileBlockTimerFails()
     OTA_SignalEvent( &otaEvent );
 
     /* Set the request timer to fail when attempting to start. */
-    otaInterfaces.os.timer.start = mockOSTimerStartAlwaysFail;
+    otaInterfaces.os.timer.startTimer = mockOSTimerStartAlwaysFail;
     /* Process the event to request a block. */
     receiveAndProcessOtaEvent();
     /* Process the event to shut down. */
@@ -1718,7 +1718,7 @@ void test_OTA_RequestFileBlockRetryFail()
     otaInterfaces.http.request = mockHttpRequestAlwaysFail;
 
     /* Let timer invoke callback directly. */
-    otaInterfaces.os.timer.start = mockOSTimerInvokeCallback;
+    otaInterfaces.os.timer.startTimer = mockOSTimerInvokeCallback;
 
     /* Allow event to be sent continuously so that retries can work. */
     otaInterfaces.os.event.send = mockOSEventSend;
@@ -2241,7 +2241,7 @@ void test_OTA_StartWithSelfTest()
     palImageState = OtaPalImageStatePendingCommit;
 
     /* Let timer start to invoke callback directly. */
-    otaInterfaces.os.timer.start = mockOSTimerInvokeCallback;
+    otaInterfaces.os.timer.startTimer = mockOSTimerInvokeCallback;
 
     /* Start OTA agent. */
     otaGoToState( OtaAgentStateWaitingForJob );
@@ -2803,7 +2803,7 @@ void test_OTA_initFileHandler_TimerFails( void )
     /* Fail to initialize the file transfer so the timer is started. */
     otaDataInterface.initFileTransfer = mockDataInterfaceInitFileTransferAlwaysFail;
     /* Fail to start the timer. */
-    otaInterfaces.os.timer.start = mockOSTimerStartAlwaysFail;
+    otaInterfaces.os.timer.startTimer = mockOSTimerStartAlwaysFail;
 
     TEST_ASSERT_EQUAL( OtaErrInitFileTransferFailed, initFileHandler( otaEvent.pEventData ) );
 }
@@ -2882,7 +2882,7 @@ void test_OTA_requestJobHandler_TimerFails( void )
     /* Fail requesting the job document. */
     otaControlInterface.requestJob = mockControlInterfaceRequestJobAlwaysFail;
     /* Fail to start the request timer. */
-    otaInterfaces.os.timer.start = mockOSTimerStartAlwaysFail;
+    otaInterfaces.os.timer.startTimer = mockOSTimerStartAlwaysFail;
 
     TEST_ASSERT_EQUAL( OtaErrRequestJobFailed, requestJobHandler( otaEvent.pEventData ) );
 }

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -108,6 +108,7 @@ defgroup
 deinit
 deinitialize
 deinitializing
+deletetimer
 destlen
 destoffset
 developerguide
@@ -720,11 +721,13 @@ stacksize
 starthandler
 startselftesttimer
 startselftimer
+starttimer
 statetoset
 statuscode
 statusdetails
 stddef
 stdlib
+stoptimer
 str
 streamname
 streamnamemaxsize


### PR DESCRIPTION
*Issue:*
[Build error in C ++ projects issue](https://github.com/aws/ota-for-aws-iot-embedded-sdk/issues/201)

*Description of changes:*
Changing the OS name of methods for working with timers for a successful build by the C ++ compiler (rename delete to deleteTimer)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
