### PR TITLE
Fix the MQTT status message "receiving"

### DIFF
--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -625,7 +625,7 @@ static uint32_t buildStatusMessageReceiving( char * pMsgBuffer,
         payloadStringParts[ 5 ] = numBlocksString;
 
         ( void ) stringBuilderUInt32Decimal( receivedString, sizeof( receivedString ), received );
-        ( void ) stringBuilderUInt32Decimal( numBlocksString, sizeof( numBlocksString ), received );
+        ( void ) stringBuilderUInt32Decimal( numBlocksString, sizeof( numBlocksString ), numBlocks );
 
 
         msgSize = ( uint32_t ) stringBuilder(


### PR DESCRIPTION
Resolves: https://github.com/aws/ota-for-aws-iot-embedded-sdk/issues/208

The number of received blocks in the message was always equal to the total number of blocks because the same value was used twice. I have changed the denominator value to the right one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.
