### PR TITLE
Make pOtaInterface a pointer to const

### DIFF
--- a/source/include/ota.h
+++ b/source/include/ota.h
@@ -300,7 +300,7 @@ typedef struct OtaAgentContext
     uint32_t numOfBlocksToReceive;                         /*!< Number of data blocks to receive per data request. */
     OtaAgentStatistics_t statistics;                       /*!< The OTA agent statistics block. */
     uint32_t requestMomentum;                              /*!< The number of requests sent before a response was received. */
-    OtaInterfaces_t * pOtaInterface;                       /*!< Collection of all interfaces used by the agent. */
+    const OtaInterfaces_t * pOtaInterface;                 /*!< Collection of all interfaces used by the agent. */
     OtaAppCallback_t OtaAppCallback;                       /*!< OTA App callback. */
     uint8_t unsubscribeOnShutdown;                         /*!< Flag to indicate if unsubscribe from job topics should be done at shutdown. */
 } OtaAgentContext_t;

--- a/source/include/ota.h
+++ b/source/include/ota.h
@@ -387,7 +387,7 @@ typedef struct OtaAgentContext
  */
 /* @[declare_ota_init] */
 OtaErr_t OTA_Init( OtaAppBuffer_t * pOtaBuffer,
-                   OtaInterfaces_t * pOtaInterfaces,
+                   const OtaInterfaces_t * pOtaInterfaces,
                    const uint8_t * pThingName,
                    OtaAppCallback_t OtaAppCallback );
 /* @[declare_ota_init] */

--- a/source/ota.c
+++ b/source/ota.c
@@ -3061,7 +3061,7 @@ static void initializeLocalBuffers( void )
  * successfully.
  */
 OtaErr_t OTA_Init( OtaAppBuffer_t * pOtaBuffer,
-                   OtaInterfaces_t * pOtaInterfaces,
+                   const OtaInterfaces_t * pOtaInterfaces,
                    const uint8_t * pThingName,
                    OtaAppCallback_t OtaAppCallback )
 {


### PR DESCRIPTION
Resolves: https://github.com/aws/ota-for-aws-iot-embedded-sdk/issues/212

The library does not modify the contents of the OtaInterfaces_t instance provided by the user. Therefore, the pOtaInterface pointer should be a pointer to a constant instance of the structure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.
