### PR TITLE
Fix ignored zero version number in job status

### DIFF
--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -292,7 +292,7 @@ static size_t stringBuilderUInt32Decimal( char * pBuffer,
     assert( bufferSizeBytes >= U32_MAX_LEN );
     ( void ) bufferSizeBytes;
 
-    while( value > 0U )
+    while( value >= 0U )
     {
         *pCur++ = asciiDigits[ ( value % 10U ) ];
         value /= 10U;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Zeroes in version numbers were being ignored when reporting job status.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
