### PR TITLE
fix error: 'S_IRWXU' undeclared

### DIFF
--- a/source/portable/os/ota_os_posix.c
+++ b/source/portable/os/ota_os_posix.c
@@ -39,6 +39,7 @@
 
 /* Posix includes. */
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <mqueue.h>
 
 /* OTA OS POSIX Interface Includes.*/


### PR DESCRIPTION
'S_IRWXU' undeclared when compiling ota_demo_core_mqtt

*Issue #, if available:*

*Description of changes:*
add sys/stat.h head file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
