### PR TITLE
Remove old reference for message queue and fix the queue buffer size

### DIFF
--- a/source/include/ota_private.h
+++ b/source/include/ota_private.h
@@ -59,11 +59,7 @@
 #define OTA_REQUEST_MSG_MAX_SIZE     ( 3U * OTA_MAX_BLOCK_BITMAP_SIZE )                   /*!< @brief Maximum size of the message */
 #define OTA_REQUEST_URL_MAX_SIZE     ( 1500 )                                             /*!< @brief Maximum size of the S3 presigned URL */
 #define OTA_ERASED_BLOCKS_VAL        0xffU                                                /*!< @brief The starting state of a group of erased blocks in the Rx block bitmap. */
-#ifdef configOTA_NUM_MSG_Q_ENTRIES
-    #define OTA_NUM_MSG_Q_ENTRIES    configOTA_NUM_MSG_Q_ENTRIES
-#else
-    #define OTA_NUM_MSG_Q_ENTRIES    20U                   /*!< Maximum number of entries in the OTA message queue. */
-#endif
+
 /** @} */
 
 /**

--- a/source/portable/os/ota_os_freertos.c
+++ b/source/portable/os/ota_os_freertos.c
@@ -43,7 +43,7 @@
 #define MAX_MSG_SIZE    sizeof( OtaEventMsg_t )
 
 /* Array containing pointer to the OTA event structures used to send events to the OTA task. */
-static OtaEventMsg_t queueData[ MAX_MESSAGES ];
+static OtaEventMsg_t queueData[ MAX_MESSAGES * MAX_MSG_SIZE ];
 
 /* The queue control structure.  .*/
 static StaticQueue_t staticQueue;
@@ -68,7 +68,7 @@ OtaOsStatus_t OtaInitEvent_FreeRTOS( OtaEventContext_t * pEventCtx )
 
     ( void ) pEventCtx;
 
-    otaEventQueue = xQueueCreateStatic( ( UBaseType_t ) OTA_NUM_MSG_Q_ENTRIES,
+    otaEventQueue = xQueueCreateStatic( ( UBaseType_t ) MAX_MESSAGES,
                                         ( UBaseType_t ) MAX_MSG_SIZE,
                                         ( uint8_t * ) queueData,
                                         &staticQueue );

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -91,6 +91,8 @@
 
 #define min( x, y )    ( x < y ? x : y )
 
+#define OTA_NUM_MSG_Q_ENTRIES 20
+
 /* Firmware version. */
 const AppVersion32_t appFirmwareVersion =
 {

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -91,7 +91,7 @@
 
 #define min( x, y )    ( x < y ? x : y )
 
-#define OTA_NUM_MSG_Q_ENTRIES 20
+#define OTA_NUM_MSG_Q_ENTRIES    20
 
 /* Firmware version. */
 const AppVersion32_t appFirmwareVersion =


### PR DESCRIPTION

*Description of changes:* This pull request includes two changes - 
1. Remove old macro definition for OTA_NUM_MSG_Q_ENTRIES and its use in the freertos ota port.
2. Fix the queue buffer size in the freertos ota port.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
