### PR TITLE
Move app callback after populating the jobDoc var

### DIFF
--- a/source/ota.c
+++ b/source/ota.c
@@ -1969,7 +1969,6 @@ static OtaJobParseErr_t handleCustomJob( const char * pJson,
                                            &jobDoc.jobIdLength,
                                            NULL ) ) )
     {
-
         if( ( jobDoc.jobIdLength > 0U ) && ( jobDoc.jobIdLength <= OTA_JOB_ID_MAX_SIZE ) ) /* LCOV_EXCL_BR_LINE */
         {
             jobDoc.pJobDocJson = ( const uint8_t * ) jobDocValue;
@@ -1980,7 +1979,7 @@ static OtaJobParseErr_t handleCustomJob( const char * pJson,
         {
             jobDoc.parseErr = OtaJobParseErrNonConformingJobDoc;
         }
-        
+
         /* We have an unknown job parser error. Check to see if we can pass control
          * to a callback for parsing */
         otaAgent.OtaAppCallback( OtaJobEventParseCustomJob, &jobDoc );

--- a/source/ota.c
+++ b/source/ota.c
@@ -1950,7 +1950,6 @@ static OtaJobParseErr_t handleCustomJob( const char * pJson,
     const char * jobDocValue = NULL;
     const char * jobIdValue = NULL;
 
-
     jobDoc.parseErr = OtaJobParseErrUnknown;
 
     /* If this is a valid custom job, extract job document and job ID data from the JSON payload.*/
@@ -1970,9 +1969,6 @@ static OtaJobParseErr_t handleCustomJob( const char * pJson,
                                            &jobDoc.jobIdLength,
                                            NULL ) ) )
     {
-        /* We have an unknown job parser error. Check to see if we can pass control
-         * to a callback for parsing */
-        otaAgent.OtaAppCallback( OtaJobEventParseCustomJob, &jobDoc );
 
         if( ( jobDoc.jobIdLength > 0U ) && ( jobDoc.jobIdLength <= OTA_JOB_ID_MAX_SIZE ) ) /* LCOV_EXCL_BR_LINE */
         {
@@ -1984,6 +1980,10 @@ static OtaJobParseErr_t handleCustomJob( const char * pJson,
         {
             jobDoc.parseErr = OtaJobParseErrNonConformingJobDoc;
         }
+        
+        /* We have an unknown job parser error. Check to see if we can pass control
+         * to a callback for parsing */
+        otaAgent.OtaAppCallback( OtaJobEventParseCustomJob, &jobDoc );
 
         if( jobDoc.parseErr == OtaJobParseErrNone )
         {


### PR DESCRIPTION


*Description of changes:* The app callback should be moved after populating the contents in jobDoc so that it is available as data to application.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
