### PR TITLE
Fix compiler warning due to unnessary config assert

### DIFF
--- a/source/portable/os/ota_os_freertos.c
+++ b/source/portable/os/ota_os_freertos.c
@@ -215,7 +215,6 @@ OtaOsStatus_t OtaStartTimer_FreeRTOS( OtaTimerId_t otaTimerId,
 
     configASSERT( callback != NULL );
     configASSERT( pTimerName != NULL );
-    configASSERT( ( otaTimerId >= OtaRequestTimer ) && ( otaTimerId < OtaNumOfTimers ) );
 
     /* Set OTA lib callback. */
     otaTimerCallback = callback;
@@ -287,8 +286,6 @@ OtaOsStatus_t OtaStopTimer_FreeRTOS( OtaTimerId_t otaTimerId )
     OtaOsStatus_t otaOsStatus = OtaOsSuccess;
     BaseType_t retVal = pdFALSE;
 
-    configASSERT( ( otaTimerId >= OtaRequestTimer ) && ( otaTimerId < OtaNumOfTimers ) );
-
     if( otaTimer[ otaTimerId ] != NULL )
     {
         /* Stop the timer. */
@@ -320,8 +317,6 @@ OtaOsStatus_t OtaDeleteTimer_FreeRTOS( OtaTimerId_t otaTimerId )
 {
     OtaOsStatus_t otaOsStatus = OtaOsSuccess;
     BaseType_t retVal = pdFALSE;
-
-    configASSERT( ( otaTimerId >= OtaRequestTimer ) && ( otaTimerId < OtaNumOfTimers ) );
 
     if( otaTimer[ otaTimerId ] != NULL )
     {


### PR DESCRIPTION

*Description of changes:*

The change removes unnecessary assert in the ota freertos port which was throwing compiler warning as the comparison is always true.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
