### PR TITLE
Conditionally rename delete timer for C++ builds.

### DIFF
--- a/source/include/ota_os_interface.h
+++ b/source/include/ota_os_interface.h
@@ -269,7 +269,11 @@ typedef struct OtaTimerInterface
 {
     OtaStartTimer_t start;   /*!< @brief Timer start state. */
     OtaStopTimer_t stop;     /*!< @brief Timer stop state. */
+#ifndef __cplusplus
     OtaDeleteTimer_t delete; /*!< @brief Delete timer. */
+#else
+    OtaDeleteTimer_t deleteTimer; /*!< @brief Delete timer for C++ builds. */
+#endif
 } OtaTimerInterface_t;
 
 /**

--- a/source/include/ota_os_interface.h
+++ b/source/include/ota_os_interface.h
@@ -267,13 +267,13 @@ typedef struct OtaEventInterface
  */
 typedef struct OtaTimerInterface
 {
-    OtaStartTimer_t start;   /*!< @brief Timer start state. */
-    OtaStopTimer_t stop;     /*!< @brief Timer stop state. */
-#ifndef __cplusplus
-    OtaDeleteTimer_t delete; /*!< @brief Delete timer. */
-#else
-    OtaDeleteTimer_t deleteTimer; /*!< @brief Delete timer for C++ builds. */
-#endif
+    OtaStartTimer_t start;            /*!< @brief Timer start state. */
+    OtaStopTimer_t stop;              /*!< @brief Timer stop state. */
+    #ifndef __cplusplus
+        OtaDeleteTimer_t delete;      /*!< @brief Delete timer. */
+    #else
+        OtaDeleteTimer_t deleteTimer; /*!< @brief Delete timer for C++ builds. */
+    #endif
 } OtaTimerInterface_t;
 
 /**

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -108,7 +108,7 @@ defgroup
 deinit
 deinitialize
 deinitializing
-deleteTimer
+deletetimer
 destlen
 destoffset
 developerguide

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -108,6 +108,7 @@ defgroup
 deinit
 deinitialize
 deinitializing
+deleteTimer
 destlen
 destoffset
 developerguide


### PR DESCRIPTION

*Description of changes:*

The member in the OTA OS timer interface was incorrectly named as deleted which breaks the C++ builds. This change conditionally renames delete timer for C++ builds.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
