### PR TITLE
Added assert statement to avoid memcpy failure. 

### DIFF
--- a/source/ota.c
+++ b/source/ota.c
@@ -2583,7 +2583,7 @@ static IngestResult_t decodeAndStoreDataBlock( OtaFileContext_t * pFileContext,
         eIngestResult = IngestResultUnexpectedBlock;
     }
 
-    assert(payloadSize >= messageSize);
+    assert( payloadSize >= messageSize );
 
     /* Decode the file block if space is allocated. */
     if( payloadSize > 0u )

--- a/source/ota.c
+++ b/source/ota.c
@@ -2583,6 +2583,8 @@ static IngestResult_t decodeAndStoreDataBlock( OtaFileContext_t * pFileContext,
         eIngestResult = IngestResultUnexpectedBlock;
     }
 
+    assert(payloadSize >= messageSize);
+
     /* Decode the file block if space is allocated. */
     if( payloadSize > 0u )
     {


### PR DESCRIPTION
*Issue #, if available:*
Inside the decodeFileBlock function, If the payloadSize is lesser than the message buffer size then the memcpy function could fail.

*Description of changes:*
I have added an assert statement to check if the payloadSize is greater than the message buffer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
