### PR TITLE
Update CBMC proof infrastructure

### DIFF
--- a/test/cbmc/proofs/Makefile-project-defines
+++ b/test/cbmc/proofs/Makefile-project-defines
@@ -13,6 +13,8 @@
 # Makefile.common.
 ################################################################
 
+SRCDIR = $(abspath $(PROOF_ROOT)/../../..)
+
 # Flags to pass to goto-cc for compilation (typically those passed to gcc -c)
 # COMPILE_FLAGS =
 
@@ -25,7 +27,7 @@
 # You will want to decide what order that comes in relative to the other
 # include directories in your project.
 #
-# INCLUDES =
+INCLUDES = -I$(SRCDIR)/source/include -I$(SRCDIR)/test/unit-test
 
 # Preprocessor definitions -D...
 # DEFINES =


### PR DESCRIPTION
This pull request updates the CBMC proof infrastructure to use the latest version of the aws-templates-for-cbmc-proofs submodule (the starter kit).  The prior version was from July and the computation of proof_root in run-cbmc-proofs.py changed in late July in commit 6a361dcb of aws-templates-for-cbmc-proofs.

This pull request also sets the include paths in Makefile-project-defines to the include directories needed to build the goto binaries.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.