### PR TITLE
Enable logging macros in CI checks for OTA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,18 @@ jobs:
           path: ./build/coverage.info
           line-coverage-min: 100
           branch-coverage-min: 100
-
+  build-with-default-config:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone This Repo
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          cmake -S test -B build/ \
+          -G "Unix Makefiles" \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_C_FLAGS='-Wall -Wextra -Werror -DOTA_DO_NOT_USE_CUSTOM_CONFIG'
+          make -C build/ all
   doxygen:
     runs-on: ubuntu-20.04
     steps:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,15 +45,13 @@ add_library( coverity_analysis
     ${OTA_MQTT_SOURCES}
     ${OTA_HTTP_SOURCES} )
 
-# Build OTA library target without custom config dependency
-target_compile_definitions( coverity_analysis PUBLIC OTA_DO_NOT_USE_CUSTOM_CONFIG=1 )
-
 # OTA include path.
 target_include_directories( coverity_analysis PUBLIC
     ${OTA_INCLUDE_PUBLIC_DIRS}
     ${OTA_INCLUDE_OS_POSIX_DIRS}
     ${CMAKE_CURRENT_LIST_DIR}/unit-test
-    ${CMAKE_CURRENT_LIST_DIR}/unit-test-http )
+    ${CMAKE_CURRENT_LIST_DIR}/unit-test-http
+    "${CMAKE_CURRENT_LIST_DIR}/include" )
 target_include_directories( coverity_analysis PRIVATE
     ${OTA_INCLUDE_PRIVATE_DIRS} )
 

--- a/test/cbmc/proofs/Makefile-project-defines
+++ b/test/cbmc/proofs/Makefile-project-defines
@@ -26,6 +26,7 @@ SRCDIR = $(abspath $(PROOF_ROOT)/../../..)
 # include directories in your project.
 #
 INCLUDES += -I$(SRCDIR)/source/include -I$(SRCDIR)/test/unit-test
+INCLUDES += -I$(SRCDIR)/test/include
 
 # Preprocessor definitions -D...
 # DEFINES =

--- a/test/include/ota_config.h
+++ b/test/include/ota_config.h
@@ -1,0 +1,41 @@
+/*
+ * AWS IoT Over-the-air Update v3.1.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+ /**
+ * @file ota_config.h
+ * @brief Config values for testing the AWS IoT Over-The-Air Updates Client Library.
+ */
+
+#ifndef OTA_CONFIG_H_
+#define OTA_CONFIG_H_
+
+#include <stdio.h>
+
+#define LogError( message )    printf( "Error: " ); printf message; printf( "\n" )
+
+#define LogWarn( message )     printf( "Warn: " ); printf message; printf( "\n" )
+
+#define LogInfo( message )     printf( "Info: " ); printf message; printf( "\n" )
+
+#define LogDebug( message )    printf( "Debug: " ); printf message; printf( "\n" )
+
+#endif /* OTA_CONFIG_H_ */

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -35,6 +35,7 @@ list(APPEND real_include_directories
     ${OTA_INCLUDE_PUBLIC_DIRS}
     ${OTA_INCLUDE_PRIVATE_DIRS}
     ${OTA_INCLUDE_OS_POSIX_DIRS}
+    "${CMAKE_CURRENT_LIST_DIR}/../include"
 )
 
 # =====================  Create UnitTest Code here (edit)  =====================


### PR DESCRIPTION
<!--- Title -->

Fix all unit testing and CBMC to use a custom config that enables logging and tests using printf. Adds a new CI check to ensure DO_NOT_USE_CUSTOM_CONFIG builds still are tested.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [ x ] I have tested my changes. No regression in existing tests.
- [ x ] My code is formatted using Uncrustify.
- [ x ] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.