### PR TITLE
posix: Cast timer_t to (void *) before assigning to sigevent.sigev_value.sival_ptr

### DIFF
--- a/source/portable/os/ota_os_posix.c
+++ b/source/portable/os/ota_os_posix.c
@@ -260,7 +260,7 @@ OtaOsStatus_t Posix_OtaStartTimer( OtaTimerId_t otaTimerId,
 
     /* Set attributes. */
     sgEvent.sigev_notify = SIGEV_THREAD;
-    sgEvent.sigev_value.sival_ptr = otaTimers[ otaTimerId ];
+    sgEvent.sigev_value.sival_ptr = ( void * ) otaTimers[ otaTimerId ];
     sgEvent.sigev_notify_function = timerCallback[ otaTimerId ];
 
     /* Set OTA lib callback. */


### PR DESCRIPTION
<!--- Title -->
posix: Cast timer_t to (void *) before assigning to sigevent.sigev_value.sival_ptr

Description
-----------
<!--- Describe your changes in detail -->
sigevent.sigev_value.sival_ptr is of type (void *) per POSIX spec.
Currently the codes assign otaTimers[ otaTimerId ] (type timer_t) to
it without any casting.

The POSIX spec does not clearly define what type timer_t should be so
it seems to be an implementation specific type. On platforms like Linux
with glibc the timer_t is (void *) but on some other platforms this
might be an integer, like in VxWorks it is unsigned long. On such
platforms it unfortunately creates a warning during build:

  warning: incompatible integer to pointer conversion assigning to
  'void *' from 'timer_t' (aka 'unsigned long') [-Wint-conversion]
      sgEvent.sigev_value.sival_ptr = otaTimers[ otaTimerId ];

Casting timer_t to (void *) before the assignment.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is formatted using Uncrustify.
- [x] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.