### PR TITLE
3rdparty: Specify C99 compiler flag for tinycbor source files

### DIFF
--- a/otaFilePaths.cmake
+++ b/otaFilePaths.cmake
@@ -20,6 +20,14 @@ set( TINYCBOR_SOURCES
 set(TINYCBOR_INCLUDE_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/source/dependency/3rdparty/tinycbor/src"
 )
+# Use C99 for tinycbor as it is incompatible with C90
+if(CMAKE_C_STANDARD LESS 99)
+    set_source_files_properties(
+        ${TINYCBOR_SOURCES}
+        PROPERTIES
+        COMPILE_FLAGS "-std=gnu99"
+    )
+endif()
 
 # OTA library source files, including 3rdparties.
 set( OTA_SOURCES


### PR DESCRIPTION
<!--- Title -->
3rdparty: Specify C99 compiler flag for tinycbor source files

Description
-----------
<!--- Describe your changes in detail -->
The tinycbor codes use several macros from C99 math.h, like
FP_INFINITE, FP_NAN, INFINITE, NAN. Although it currently builds
fine with -std=gnu90 against Linux glibc, it fails to build with
a stricter C library.

Specify C99 compiler flag for tinycbor source files.

This relates to https://github.com/aws/aws-iot-device-sdk-embedded-C/pull/1748

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is formatted using Uncrustify.
- [x] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.