### PR TITLE
Specify stdio FILE structure in struct OtaFileContext for VxWorks

### DIFF
--- a/source/include/ota_private.h
+++ b/source/include/ota_private.h
@@ -382,7 +382,7 @@ typedef struct OtaFileContext
 {
     uint8_t * pFilePath;          /*!< @brief Update file pathname. */
     uint16_t filePathMaxSize;     /*!< @brief Maximum size of the update file path */
-    #if defined( WIN32 ) || defined( __linux__ )
+    #if defined( WIN32 ) || defined( __linux__ ) || defined( __VXWORKS__ )
         FILE * pFile;             /*!< @brief File type is stdio FILE structure after file is open for write. */
     #else
         uint8_t * pFile;          /*!< @brief File type is RAM/Flash image pointer after file is open for write. */


### PR DESCRIPTION
<!--- Title -->
Specify stdio FILE structure in struct OtaFileContext for VxWorks

Description
-----------
<!--- Describe your changes in detail -->
As VxWorks RTOS supports stdio FILE structure operations, specify
pFile in struct OtaFileContext as "FILE *" instead of "uint8_t *"
for VxWorks.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] My code is formatted using Uncrustify.
- [x] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.