### PR TITLE
Update scope of pParamAdd

### DIFF
--- a/source/ota.c
+++ b/source/ota.c
@@ -1662,11 +1662,11 @@ static DocParseErr_t extractParameter( JsonDocParam_t docParam,
     /* Get destination offset to parameter storage location.*/
     pParamAdd = ( uint8_t * ) pContextBase + docParam.pDestOffset;
 
-    /* Get destination buffer size to parameter storage location. */
-    pParamSizeAdd = ( void * ) ( ( uint8_t * ) pContextBase + docParam.pDestSizeOffset );
-
     if( ( ModelParamTypeStringCopy == docParam.modelParamType ) || ( ModelParamTypeArrayCopy == docParam.modelParamType ) )
     {
+        /* Get destination buffer size to parameter storage location. */
+        pParamSizeAdd = ( void * ) ( ( uint8_t * ) pContextBase + docParam.pDestSizeOffset );
+
         err = extractAndStoreArray( docParam.pSrcKey, pValueInJson, valueLength, pParamAdd, pParamSizeAdd );
     }
     else if( ModelParamTypeUInt32 == docParam.modelParamType )


### PR DESCRIPTION
Since `pParamAdd` is only used when the `docParam.modelParamType` is set to either `ModelParamTypeStringCopy` or `ModelParamTypeArrayCopy`, the assignment statement should be moved to a proper scope to avoid  having undefined values in `pParamAdd` 

Description
-----------
This PR updates the changes the location of the `pParamAdd` assignment to a proper scope. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is formatted using Uncrustify.
- [ ] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.