### PR TITLE
add checks for pOtaBuffer to be non_null

### DIFF
--- a/source/ota.c
+++ b/source/ota.c
@@ -3072,6 +3072,8 @@ OtaErr_t OTA_Init( OtaAppBuffer_t * pOtaBuffer,
     ( void ) pOtaEventStrings;      /* For suppressing compiler-warning: unused variable. */
     ( void ) pOtaAgentStateStrings; /* For suppressing compiler-warning: unused variable. */
 
+    assert( pOtaBuffer != NULL );
+
     /* If OTA agent is stopped then start running. */
     if( otaAgent.state == OtaAgentStateStopped )
     {
@@ -3094,9 +3096,6 @@ OtaErr_t OTA_Init( OtaAppBuffer_t * pOtaBuffer,
          */
         otaAgent.pOtaInterface = pOtaInterfaces;
 
-        /* Initialize application buffers. */
-        initializeAppBuffers( pOtaBuffer );
-
         /* Initialize local buffers. */
         initializeLocalBuffers();
 
@@ -3113,26 +3112,36 @@ OtaErr_t OTA_Init( OtaAppBuffer_t * pOtaBuffer,
          */
         ( void ) otaAgent.pOtaInterface->os.event.init( NULL );
 
-        if( pThingName == NULL )
+        if( pOtaBuffer == NULL )
         {
-            LogError( ( "Error: Thing name is NULL.\r\n" ) );
+            LogError( ( "Error: pOtaBuffer is NULL.\r\n" ) );
         }
         else
         {
-            uint32_t strLength = ( uint32_t ) ( strlen( ( const char * ) pThingName ) );
+            /* Initialize application buffers. */
+            initializeAppBuffers( pOtaBuffer );
 
-            if( strLength <= otaconfigMAX_THINGNAME_LEN )
+            if( pThingName == NULL )
             {
-                /*
-                 * Store the Thing name to be used for topics later. Include zero terminator
-                 * when saving the Thing name.
-                 */
-                ( void ) memcpy( otaAgent.pThingName, pThingName, strLength + 1UL );
-                returnStatus = OtaErrNone;
+                LogError( ( "Error: Thing name is NULL.\r\n" ) );
             }
             else
             {
-                LogError( ( "Error: Thing name is too long.\r\n" ) );
+                uint32_t strLength = ( uint32_t ) ( strlen( ( const char * ) pThingName ) );
+
+                if( strLength <= otaconfigMAX_THINGNAME_LEN )
+                {
+                    /*
+                     * Store the Thing name to be used for topics later. Include zero terminator
+                     * when saving the Thing name.
+                     */
+                    ( void ) memcpy( otaAgent.pThingName, pThingName, strLength + 1UL );
+                    returnStatus = OtaErrNone;
+                }
+                else
+                {
+                    LogError( ( "Error: Thing name is too long.\r\n" ) );
+                }
             }
         }
 


### PR DESCRIPTION
`OTA_Init` is a public function and a user can pass NULL value to `pOtaBuffer` which can result in `NULL` pointer de-referencing in `initializeAppBuffers` function. 

Description
-----------
This PR adds checks such that if NULL value is passed to pOtaBuffer then the otaAgent would not run and display error in the logs indicating the `NULL` pointer in pOtaBuffer. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is formatted using Uncrustify.
- [ ] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.