### PR TITLE
Add checks to avoid arithmetic overflow

### DIFF
--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -10,7 +10,7 @@
     <tr>
         <td>ota.c</td>
         <td><center>8.0K</center></td>
-        <td><center>7.1K</center></td>
+        <td><center>7.2K</center></td>
     </tr>
     <tr>
         <td>ota_interface.c</td>
@@ -40,6 +40,6 @@
     <tr>
         <td><b>Total estimates</b></td>
         <td><b><center>12.1K</center></b></td>
-        <td><b><center>10.9K</center></b></td>
+        <td><b><center>11.0K</center></b></td>
     </tr>
 </table>

--- a/source/include/ota.h
+++ b/source/include/ota.h
@@ -99,7 +99,8 @@ typedef enum OtaErr
     OtaErrUserAbort,              /*!< @brief User aborted the active OTA. */
     OtaErrFailedToEncodeCbor,     /*!< @brief Failed to encode CBOR object for requesting data block from streaming service. */
     OtaErrFailedToDecodeCbor,     /*!< @brief Failed to decode CBOR object from streaming service response. */
-    OtaErrActivateFailed          /*!< @brief Failed to activate the new image. */
+    OtaErrActivateFailed,         /*!< @brief Failed to activate the new image. */
+    OtaErrFileSizeOverflow        /*!< @brief Firmware file size greater than the max allowed size. */
 } OtaErr_t;
 
 /**

--- a/source/include/ota_private.h
+++ b/source/include/ota_private.h
@@ -65,7 +65,7 @@
 #define OTA_REQUEST_MSG_MAX_SIZE     ( 3U * OTA_MAX_BLOCK_BITMAP_SIZE )                   /*!< @brief Maximum size of the message */
 #define OTA_REQUEST_URL_MAX_SIZE     ( 1500 )                                             /*!< @brief Maximum size of the S3 presigned URL */
 #define OTA_ERASED_BLOCKS_VAL        0xffU                                                /*!< @brief The starting state of a group of erased blocks in the Rx block bitmap. */
-
+#define OTA_MAX_FILE_SIZE            UINT32_MAX - OTA_FILE_BLOCK_SIZE + 1                 /*!< @brief The maximum file size supported by the library. */
 /** @} */
 
 /**

--- a/source/ota.c
+++ b/source/ota.c
@@ -2383,10 +2383,17 @@ static OtaFileContext_t * getFileContextFromJob( const char * pRawMsg,
         numBlocks = ( pUpdateFile->fileSize + ( OTA_FILE_BLOCK_SIZE - 1U ) ) >> otaconfigLOG2_FILE_BLOCK_SIZE;
         bitmapLen = ( numBlocks + ( BITS_PER_BYTE - 1U ) ) >> LOG2_BITS_PER_BYTE;
 
-        if( ( pUpdateFile->blockBitmapMaxSize == 0u ) && ( pUpdateFile->pRxBlockBitmap != NULL ) )
+        /* This conditional statement has been excluded from the coverage report because one of branches in the
+         * if conditions cannot be reached because it is not possible for the code to have
+         * pUpdateFile->blockBitmapMaxSize not equal to 0 and pUpdateFile->pRxBlockBitmap equal to NULL. */
+
+        /* LCOV_EXCL_START */
+        if( ( pUpdateFile->pRxBlockBitmap != NULL ) && ( pUpdateFile->blockBitmapMaxSize == 0u ) )
         {
             otaAgent.pOtaInterface->os.mem.free( pUpdateFile->pRxBlockBitmap );
         }
+
+        /* LCOV_EXCL_STOP */
 
         if( pUpdateFile->blockBitmapMaxSize == 0u )
         {
@@ -2431,16 +2438,13 @@ static OtaFileContext_t * getFileContextFromJob( const char * pRawMsg,
                 pUpdateFile = NULL;
             }
         }
-        else
-        {
-            /* Can't receive the image without enough memory. */
-            ( void ) otaClose( pUpdateFile );
-            pUpdateFile = NULL;
-        }
     }
 
-    if( err != OtaErrNone )
+    if( ( err != OtaErrNone ) || ( ( pUpdateFile != NULL ) && ( pUpdateFile->pRxBlockBitmap == NULL ) ) )
     {
+        otaClose( pUpdateFile );
+        pUpdateFile = NULL;
+
         LogDebug( ( "Failed to parse the file context from the job document: OtaErr_t=%s",
                     OTA_Err_strerror( err ) ) );
     }

--- a/source/ota.c
+++ b/source/ota.c
@@ -1221,10 +1221,6 @@ static OtaErr_t processDataHandler( const OtaEventData_t * pEventData )
             /* Last file block processed, increment the statistics. */
             otaAgent.statistics.otaPacketsProcessed++;
         }
-        else
-        {
-            LogError( ( "Error: Total OTA packets processed exceeded the unsigned integer limit. " ) );
-        }
 
         /* Let main application know that update is complete */
         otaAgent.OtaAppCallback( otaJobEvent, &jobDoc );
@@ -1256,10 +1252,6 @@ static OtaErr_t processDataHandler( const OtaEventData_t * pEventData )
             {
                 /* Last file block processed, increment the statistics. */
                 otaAgent.statistics.otaPacketsProcessed++;
-            }
-            else
-            {
-                LogError( ( "Error: Total OTA packets processed exceeded the unsigned integer limit. " ) );
             }
 
             /* Reset the momentum counter since we received a good block. */
@@ -2378,82 +2370,75 @@ static OtaFileContext_t * getFileContextFromJob( const char * pRawMsg,
     {
         LogInfo( ( "Job document for receiving an update received." ) );
     }
-    
-    if(pUpdateFile != NULL)
+
+    if( ( pUpdateFile != NULL ) && ( pUpdateFile->fileSize > OTA_MAX_FILE_SIZE ) )
     {
-        if(pUpdateFile->fileSize > OTA_MAX_FILE_SIZE)
+        err = OtaErrFileSizeOverflow;
+    }
+
+    if( ( err == OtaErrNone ) && ( updateJob == false ) && ( platformInSelftest() == false ) && ( pUpdateFile != NULL ) )
+    {
+        /* Calculate how many bytes we need in our bitmap for tracking received blocks.
+         * The below calculation requires power of 2 page sizes. */
+        numBlocks = ( pUpdateFile->fileSize + ( OTA_FILE_BLOCK_SIZE - 1U ) ) >> otaconfigLOG2_FILE_BLOCK_SIZE;
+        bitmapLen = ( numBlocks + ( BITS_PER_BYTE - 1U ) ) >> LOG2_BITS_PER_BYTE;
+
+        if( ( pUpdateFile->blockBitmapMaxSize == 0u ) && ( pUpdateFile->pRxBlockBitmap != NULL ) )
         {
-            err = OtaErrFileSizeOverflow;
+            otaAgent.pOtaInterface->os.mem.free( pUpdateFile->pRxBlockBitmap );
         }
 
-        if( ( updateJob == false ) && ( platformInSelftest() == false ) && (err == OtaErrNone))
+        if( pUpdateFile->blockBitmapMaxSize == 0u )
         {
-            /* Calculate how many bytes we need in our bitmap for tracking received blocks.
-            * The below calculation requires power of 2 page sizes. */
-            numBlocks = ( pUpdateFile->fileSize + ( OTA_FILE_BLOCK_SIZE - 1U ) ) >> otaconfigLOG2_FILE_BLOCK_SIZE;
-            bitmapLen = ( numBlocks + ( BITS_PER_BYTE - 1U ) ) >> LOG2_BITS_PER_BYTE;
+            pUpdateFile->pRxBlockBitmap = ( uint8_t * ) otaAgent.pOtaInterface->os.mem.malloc( bitmapLen );
+        }
+        else
+        {
+            assert( pUpdateFile->pRxBlockBitmap != NULL );
+            ( void ) memset( pUpdateFile->pRxBlockBitmap, 0, pUpdateFile->blockBitmapMaxSize );
+        }
 
-            if( pUpdateFile->blockBitmapMaxSize == 0u )
+        if( pUpdateFile->pRxBlockBitmap != NULL )
+        {
+            /* Mark as used any pages in the bitmap that are out of range, based on the file size.
+             * This keeps us from requesting those pages during retry processing or if using a windowed
+             * block request. It also avoids erroneously accepting an out of range data block should it
+             * get past any safety checks.
+             * Files are not always a multiple of 8 pages (8 bits/pages per byte) so some bits of the
+             * last byte may be out of range and those are the bits we want to clear. */
+
+            uint8_t bit = 1U << ( BITS_PER_BYTE - 1U );
+            uint32_t numOutOfRange = ( bitmapLen * BITS_PER_BYTE ) - numBlocks;
+
+            /* Set all bits in the bitmap to the erased state (we use 1 for erased just like flash memory). */
+            ( void ) memset( pUpdateFile->pRxBlockBitmap, ( int32_t ) OTA_ERASED_BLOCKS_VAL, bitmapLen );
+
+            for( index = 0U; index < numOutOfRange; index++ )
             {
-                /* LCOV_EXCL_START */
-                if( pUpdateFile->pRxBlockBitmap != NULL )
-                {
-                    /* Free any previously allocated bitmap. */
-                    otaAgent.pOtaInterface->os.mem.free( pUpdateFile->pRxBlockBitmap );
-                }
-
-                /* LCOV_EXCL_STOP */
-
-                pUpdateFile->pRxBlockBitmap = ( uint8_t * ) otaAgent.pOtaInterface->os.mem.malloc( bitmapLen );
+                pUpdateFile->pRxBlockBitmap[ bitmapLen - 1U ] &= ( uint8_t ) ~bit;
+                bit >>= 1U;
             }
-            else
+
+            pUpdateFile->blocksRemaining = numBlocks; /* Initialize our blocks remaining counter. */
+
+            /* Create/Open the OTA file on the file system. */
+            palStatus = otaAgent.pOtaInterface->pal.createFile( pUpdateFile );
+
+            if( OTA_PAL_MAIN_ERR( palStatus ) != OtaPalSuccess )
             {
-                assert( pUpdateFile->pRxBlockBitmap != NULL );
-                ( void ) memset( pUpdateFile->pRxBlockBitmap, 0, pUpdateFile->blockBitmapMaxSize );
-            }
-
-            if( pUpdateFile->pRxBlockBitmap != NULL )
-            {
-                /* Mark as used any pages in the bitmap that are out of range, based on the file size.
-                * This keeps us from requesting those pages during retry processing or if using a windowed
-                * block request. It also avoids erroneously accepting an out of range data block should it
-                * get past any safety checks.
-                * Files are not always a multiple of 8 pages (8 bits/pages per byte) so some bits of the
-                * last byte may be out of range and those are the bits we want to clear. */
-
-                uint8_t bit = 1U << ( BITS_PER_BYTE - 1U );
-                uint32_t numOutOfRange = ( bitmapLen * BITS_PER_BYTE ) - numBlocks;
-
-                /* Set all bits in the bitmap to the erased state (we use 1 for erased just like flash memory). */
-                ( void ) memset( pUpdateFile->pRxBlockBitmap, ( int32_t ) OTA_ERASED_BLOCKS_VAL, bitmapLen );
-
-                for( index = 0U; index < numOutOfRange; index++ )
-                {
-                    pUpdateFile->pRxBlockBitmap[ bitmapLen - 1U ] &= ( uint8_t ) ~bit;
-                    bit >>= 1U;
-                }
-
-                pUpdateFile->blocksRemaining = numBlocks; /* Initialize our blocks remaining counter. */
-
-                /* Create/Open the OTA file on the file system. */
-                palStatus = otaAgent.pOtaInterface->pal.createFile( pUpdateFile );
-
-                if( OTA_PAL_MAIN_ERR( palStatus ) != OtaPalSuccess )
-                {
-                    err = setImageStateWithReason( OtaImageStateAborted, palStatus );
-                    ( void ) otaClose( pUpdateFile ); /* Ignore false result since we're setting the pointer to null on the next line. */
-                    pUpdateFile = NULL;
-                }
-            }
-            else
-            {
-                /* Can't receive the image without enough memory. */
-                ( void ) otaClose( pUpdateFile );
+                err = setImageStateWithReason( OtaImageStateAborted, palStatus );
+                ( void ) otaClose( pUpdateFile ); /* Ignore false result since we're setting the pointer to null on the next line. */
                 pUpdateFile = NULL;
             }
         }
+        else
+        {
+            /* Can't receive the image without enough memory. */
+            ( void ) otaClose( pUpdateFile );
+            pUpdateFile = NULL;
+        }
     }
-    
+
     if( err != OtaErrNone )
     {
         LogDebug( ( "Failed to parse the file context from the job document: OtaErr_t=%s",

--- a/source/ota.c
+++ b/source/ota.c
@@ -1216,15 +1216,16 @@ static OtaErr_t processDataHandler( const OtaEventData_t * pEventData )
 
         dataHandlerCleanup();
 
-        if(otaAgent.statistics.otaPacketsProcessed < UINT32_MAX)
+        if( otaAgent.statistics.otaPacketsProcessed < UINT32_MAX )
         {
             /* Last file block processed, increment the statistics. */
             otaAgent.statistics.otaPacketsProcessed++;
         }
         else
         {
-            LogError(("Error: Total OTA packets processed exceeded the unsigned integer limit. "));
+            LogError( ( "Error: Total OTA packets processed exceeded the unsigned integer limit. " ) );
         }
+
         /* Let main application know that update is complete */
         otaAgent.OtaAppCallback( otaJobEvent, &jobDoc );
     }
@@ -1251,14 +1252,14 @@ static OtaErr_t processDataHandler( const OtaEventData_t * pEventData )
     {
         if( result == IngestResultAccepted_Continue )
         {
-            if(otaAgent.statistics.otaPacketsProcessed < UINT32_MAX)
+            if( otaAgent.statistics.otaPacketsProcessed < UINT32_MAX )
             {
                 /* Last file block processed, increment the statistics. */
                 otaAgent.statistics.otaPacketsProcessed++;
             }
             else
             {
-                LogError(("Error: Total OTA packets processed exceeded the unsigned integer limit. "));
+                LogError( ( "Error: Total OTA packets processed exceeded the unsigned integer limit. " ) );
             }
 
             /* Reset the momentum counter since we received a good block. */
@@ -2380,10 +2381,10 @@ static OtaFileContext_t * getFileContextFromJob( const char * pRawMsg,
 
     if( ( updateJob == false ) && ( pUpdateFile != NULL ) && ( platformInSelftest() == false ) )
     {
-        if(pUpdateFile->fileSize <= OTA_MAX_FILE_SIZE)
+        if( pUpdateFile->fileSize <= OTA_MAX_FILE_SIZE )
         {
             /* Calculate how many bytes we need in our bitmap for tracking received blocks.
-            * The below calculation requires power of 2 page sizes. */
+             * The below calculation requires power of 2 page sizes. */
             numBlocks = ( pUpdateFile->fileSize + ( OTA_FILE_BLOCK_SIZE - 1U ) ) >> otaconfigLOG2_FILE_BLOCK_SIZE;
             bitmapLen = ( numBlocks + ( BITS_PER_BYTE - 1U ) ) >> LOG2_BITS_PER_BYTE;
 
@@ -2409,11 +2410,11 @@ static OtaFileContext_t * getFileContextFromJob( const char * pRawMsg,
             if( pUpdateFile->pRxBlockBitmap != NULL )
             {
                 /* Mark as used any pages in the bitmap that are out of range, based on the file size.
-                * This keeps us from requesting those pages during retry processing or if using a windowed
-                * block request. It also avoids erroneously accepting an out of range data block should it
-                * get past any safety checks.
-                * Files are not always a multiple of 8 pages (8 bits/pages per byte) so some bits of the
-                * last byte may be out of range and those are the bits we want to clear. */
+                 * This keeps us from requesting those pages during retry processing or if using a windowed
+                 * block request. It also avoids erroneously accepting an out of range data block should it
+                 * get past any safety checks.
+                 * Files are not always a multiple of 8 pages (8 bits/pages per byte) so some bits of the
+                 * last byte may be out of range and those are the bits we want to clear. */
 
                 uint8_t bit = 1U << ( BITS_PER_BYTE - 1U );
                 uint32_t numOutOfRange = ( bitmapLen * BITS_PER_BYTE ) - numBlocks;
@@ -2448,7 +2449,7 @@ static OtaFileContext_t * getFileContextFromJob( const char * pRawMsg,
         }
         else
         {
-            err =  OtaErrFileSizeOverflow;
+            err = OtaErrFileSizeOverflow;
         }
     }
 

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -3302,13 +3302,8 @@ void test_OTA_packetsProcessedOverflow()
 
     processEntireQueue();
 
-    receiveAndProcessOtaEvent();
-
-    TEST_ASSERT_EQUAL( 0, otaAgent.statistics.otaPacketsProcessed );
-
     /* OTA agent should complete the update and go back to waiting for job state. */
-
-    TEST_ASSERT_EQUAL( OtaErrNone, processDataHandler( eventBuffers ) );
+    receiveAndProcessOtaEvent();
 
     /* Check if received complete file. */
     for( idx = 0; idx < OTA_TEST_FILE_SIZE; ++idx )

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -3219,3 +3219,26 @@ void test_OTA_overflowFileSize()
 
     TEST_ASSERT_EQUAL( OtaAgentStateWaitingForJob, OTA_GetState() );
 }
+
+void test_OTA_packetsProcessedOverflow()
+{
+    pOtaJobDoc = JOB_DOC_A;
+    otaGoToState( OtaAgentStateWaitingForFileBlock );
+
+    size_t job_doc_len = strlen( pOtaJobDoc );
+    OtaEventMsg_t otaEvent = { 0 };
+
+    /* Parse success would create the file, let it invoke our mock when creating file. */
+    otaEvent.eventId = OtaAgentEventReceivedFileBlock;
+    otaEvent.pEventData = &eventBuffer;
+    memcpy( otaEvent.pEventData->data, pOtaJobDoc, job_doc_len );
+    otaEvent.pEventData->dataLength = job_doc_len;
+    OTA_SignalEvent( &otaEvent );
+
+    otaAgent.statistics.otaPacketsProcessed = UINT32_MAX;
+
+    receiveAndProcessOtaEvent();
+
+    receiveAndProcessOtaEvent();
+    TEST_ASSERT_EQUAL( OtaAgentStateWaitingForFileBlock, OTA_GetState() );
+}

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -411,25 +411,6 @@ static OtaMqttStatus_t stubMqttPublish( const char * const unused_1,
     return OtaMqttSuccess;
 }
 
-OtaErr_t mockDataInterfaceDecodeFileBlock( const uint8_t * pMessageBuffer,
-                                           size_t messageSize,
-                                           int32_t * pFileId,
-                                           int32_t * pBlockId,
-                                           int32_t * pBlockSize,
-                                           uint8_t ** pPayload,
-                                           size_t * pPayloadSize )
-{
-    ( void ) pMessageBuffer;
-    ( void ) messageSize;
-    ( void ) pFileId;
-    ( void ) pBlockId;
-    ( void ) pBlockSize;
-    ( void ) pPayload;
-    ( void ) pPayloadSize;
-
-    return OtaErrNone;
-}
-
 OtaErr_t mockControlInterfaceRequestJobAlwaysFail( OtaAgentContext_t * unused )
 {
     ( void ) unused;

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -3208,25 +3208,14 @@ void test_verifyActiveJobStatus_NullCleanupInterface()
 
 
 void test_OTA_overflowFileSize()
-{   
-    OtaEventMsg_t eventMsg;
-    
-    /* Initialize the job doc with filesize greater than the maximum
-    allowed file size. */
+{
     pOtaJobDoc = JOB_DOC_FILESIZE_OVERFLOW;
-    size_t job_doc_len = strlen( pOtaJobDoc );
-    
-    eventMsg.eventId = OtaAgentEventReceivedJobDocument;
-    eventMsg.pEventData = &eventBuffer;
 
-    memcpy( eventMsg.pEventData->data, pOtaJobDoc, job_doc_len );
-    eventMsg.pEventData->dataLength = job_doc_len;
+    otaGoToState( OtaAgentStateWaitingForJob );
+    TEST_ASSERT_EQUAL( OtaAgentStateWaitingForJob, OTA_GetState() );
 
-    otaGoToState(OtaAgentStateWaitingForJob);
-    TEST_ASSERT_EQUAL(OtaAgentStateWaitingForJob, OTA_GetState());
-
-    OTA_SignalEvent(&eventMsg);
+    otaReceiveJobDocument();
     receiveAndProcessOtaEvent();
 
-    TEST_ASSERT_EQUAL(OtaAgentStateWaitingForJob, OTA_GetState());
+    TEST_ASSERT_EQUAL( OtaAgentStateWaitingForJob, OTA_GetState() );
 }

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -408,6 +408,7 @@ otaerrcleanupdatafailed
 otaerrdowngradenotallowed
 otaerrfailedtodecodecbor
 otaerrfailedtoencodecbor
+otaerrfilesizeoverflow
 otaerrimagestatemismatch
 otaerrinitfiletransferfailed
 otaerrinvalidarg


### PR DESCRIPTION
For certain values of the file size of the firmware, some statements in the OTA library may result in an arithmetic overflow. 

Description
-----------
Add conditional statements in order to avoid arithmetic overflow in some operations. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is formatted using Uncrustify.
- [x] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.