### PR TITLE
Add "update = none" to submodules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,9 @@ jobs:
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v2
-        with:
-          submodules: true
       - name: Check warnings
         run: |
+          git submodule update --init --recursive --checkout --depth 1
           cmake -S test -B build -DCMAKE_BUILD_TYPE=Debug \
           -DCMAKE_C_FLAGS='-Wall -Wextra -Werror -DLOG_LEVEL=LOG_LEVEL_DEBUG'
           cmake --build build
@@ -40,10 +39,9 @@ jobs:
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v2
-        with:
-          submodules: true
       - name: Build
         run: |
+          git submodule update --init --recursive --checkout --depth 1
           cmake -S test -B build -DCMAKE_BUILD_TYPE=Debug
           cmake --build build
       - name: Test
@@ -57,10 +55,9 @@ jobs:
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v2
-        with:
-          submodules: true
       - name: Generate Build Files
         run: |
+          git submodule update --init --recursive --checkout --depth 1
           sudo apt-get install -y lcov
           cmake -S test -B build \
           -DCMAKE_BUILD_TYPE=Debug \
@@ -143,8 +140,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-            submodules: 'recursive'
+      - name: Clone submodules
+        run: git submodule update --init --recursive --checkout --depth 1
       - name: Install Python3
         uses: actions/setup-python@v2
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,11 @@
 [submodule "coreJSON"]
 	path = source/dependency/coreJSON
 	url = https://github.com/FreeRTOS/coreJSON.git
+	update = none
 [submodule "tinycbor"]
 	path = source/dependency/3rdparty/tinycbor
 	url = https://github.com/intel/tinycbor.git
+	update = none
 [submodule "test/unit-test/CMock"]
 	path = test/unit-test/CMock
 	url = https://github.com/ThrowTheSwitch/CMock.git
@@ -11,6 +13,7 @@
 [submodule "test/cbmc/aws-templates-for-cbmc-proofs"]
 	path = test/cbmc/aws-templates-for-cbmc-proofs
 	url = https://github.com/awslabs/aws-templates-for-cbmc-proofs.git
+	update = none
 [submodule "test/cbmc/litani"]
 	path = test/cbmc/litani
 	url = https://github.com/awslabs/aws-build-accumulator.git
@@ -18,3 +21,4 @@
 [submodule "test/cbmc/FreeRTOS-Kernel"]
 	path = test/cbmc/FreeRTOS-Kernel
 	url = https://github.com/FreeRTOS/FreeRTOS-Kernel.git
+	update = none


### PR DESCRIPTION
Git should not automatically clone the submodules as customers likely do not need them. In projects and hub repos submoduling this library, in the current state recursive clones will pull in multiple copies of tinycbor, coreJSON, FreeRTOS kernel, etc when they have their own copies. After this change, recursive clones will no longer get these submodules (unless user specifies --checkout).
