### PR TITLE
Move cleanup of job id to after OtaAppCallback

### DIFF
--- a/source/ota.c
+++ b/source/ota.c
@@ -1157,9 +1157,6 @@ static void dataHandlerCleanup( void )
                    "event=%d",
                    eventMsg.eventId ) );
     }
-
-    /* Clear any remaining string memory holding the job name since this job is done. */
-    ( void ) memset( otaAgent.pActiveJobName, 0, OTA_JOB_ID_MAX_SIZE );
 }
 
 static OtaErr_t processDataHandler( const OtaEventData_t * pEventData )
@@ -1224,6 +1221,9 @@ static OtaErr_t processDataHandler( const OtaEventData_t * pEventData )
 
         /* Let main application know that update is complete */
         otaAgent.OtaAppCallback( otaJobEvent, &jobDoc );
+
+        /* Clear any remaining string memory holding the job name since this job is done. */
+        ( void ) memset( otaAgent.pActiveJobName, 0, OTA_JOB_ID_MAX_SIZE );
     }
     else if( result < IngestResultFileComplete )
     {
@@ -1243,6 +1243,9 @@ static OtaErr_t processDataHandler( const OtaEventData_t * pEventData )
 
         /* Let main application know activate event. */
         otaAgent.OtaAppCallback( OtaJobEventFail, &jobDoc );
+
+        /* Clear any remaining string memory holding the job name since this job is done. */
+        ( void ) memset( otaAgent.pActiveJobName, 0, OTA_JOB_ID_MAX_SIZE );
     }
     else
     {

--- a/source/ota.c
+++ b/source/ota.c
@@ -2733,7 +2733,7 @@ static IngestResult_t ingestDataBlock( OtaFileContext_t * pFileContext,
     }
 
     /* Free the payload if it's dynamically allocated by us. */
-    if( eIngestResult != IngestResultNullInput &&
+    if( ( eIngestResult != IngestResultNullInput ) &&
         ( otaAgent.fileContext.decodeMemMaxSize == 0u ) &&
         ( pPayload != NULL ) )
     {

--- a/source/ota.c
+++ b/source/ota.c
@@ -2733,7 +2733,8 @@ static IngestResult_t ingestDataBlock( OtaFileContext_t * pFileContext,
     }
 
     /* Free the payload if it's dynamically allocated by us. */
-    if( ( otaAgent.fileContext.decodeMemMaxSize == 0u ) &&
+    if( eIngestResult != IngestResultNullInput &&
+        ( otaAgent.fileContext.decodeMemMaxSize == 0u ) &&
         ( pPayload != NULL ) )
     {
         otaAgent.pOtaInterface->os.mem.free( pPayload );

--- a/test/cbmc/proofs/ingestDataBlock/ingestDataBlock_harness.c
+++ b/test/cbmc/proofs/ingestDataBlock/ingestDataBlock_harness.c
@@ -31,8 +31,7 @@
 
 extern OtaAgentContext_t otaAgent;
 extern IngestResult_t ingestDataBlock( OtaFileContext_t * pFileContext,
-                                       const uint8_t * pRawMsg,
-                                       uint32_t messageSize,
+                                       const OtaEventData_t * pEventData,
                                        OtaPalStatus_t * pCloseResult );
 
 IngestResult_t ingestDataBlockCleanup( OtaFileContext_t * pFileContext,
@@ -99,12 +98,11 @@ void ingestDataBlock_harness()
     OtaInterfaces_t otaInterface;
     OtaFileContext_t fileContext;
     OtaPalStatus_t closeResult;
-    uint8_t rawMsg[ OTA_DATA_BLOCK_SIZE ];
-    uint32_t messageSize;
+    OtaEventData_t eventData;
 
     uint32_t decodeMemMaxSize;
 
-    __CPROVER_assume( messageSize <= OTA_DATA_BLOCK_SIZE );
+    __CPROVER_assume( eventData.dataLength <= OTA_DATA_BLOCK_SIZE );
 
     /* CBMC preconditions. */
 
@@ -115,5 +113,5 @@ void ingestDataBlock_harness()
     otaInterface.os.mem.free = freeMemStub;
     otaAgent.pOtaInterface = &otaInterface;
 
-    ( void ) ingestDataBlock( &fileContext, rawMsg, messageSize, &closeResult );
+    ( void ) ingestDataBlock( &fileContext, &eventData, &closeResult );
 }

--- a/test/cbmc/proofs/processDataHandler/processDataHandler_harness.c
+++ b/test/cbmc/proofs/processDataHandler/processDataHandler_harness.c
@@ -35,8 +35,7 @@ extern OtaErr_t processDataHandler( const OtaEventData_t * pEventData );
 
 /* Stub for ingestDataBlock. */
 IngestResult_t ingestDataBlock( OtaFileContext_t * pFileContext,
-                                const uint8_t * pRawMsg,
-                                uint32_t messageSize,
+                                const OtaEventData_t * pEventData,
                                 OtaPalStatus_t * pCloseResult )
 {
     IngestResult_t result;
@@ -44,7 +43,6 @@ IngestResult_t ingestDataBlock( OtaFileContext_t * pFileContext,
 
     __CPROVER_assert( pFileContext != NULL, "Error: pFileContext cannot be NULL" );
     __CPROVER_assert( pCloseResult != NULL, "Error: pCloseResult cannot be NULL" );
-    __CPROVER_assert( pRawMsg != NULL, "Error: pRawMsg buffer cannot be NULL." );
 
     return result;
 }


### PR DESCRIPTION
Moves the clearing of otaAgent.pActiveJobName to after OtaAppCallback is called in order to enable the callback to access the job name.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.