### PR TITLE
restore unrelated changes

### DIFF
--- a/source/include/ota.h
+++ b/source/include/ota.h
@@ -1,6 +1,6 @@
 /*
- * AWS IoT Over-the-air Update v3.1.0
- * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * AWS IoT Over-the-air Update v3.3.0
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -99,7 +99,8 @@ typedef enum OtaErr
     OtaErrUserAbort,              /*!< @brief User aborted the active OTA. */
     OtaErrFailedToEncodeCbor,     /*!< @brief Failed to encode CBOR object for requesting data block from streaming service. */
     OtaErrFailedToDecodeCbor,     /*!< @brief Failed to decode CBOR object from streaming service response. */
-    OtaErrActivateFailed          /*!< @brief Failed to activate the new image. */
+    OtaErrActivateFailed,         /*!< @brief Failed to activate the new image. */
+    OtaErrFileSizeOverflow        /*!< @brief Firmware file size greater than the max allowed size. */
 } OtaErr_t;
 
 /**

--- a/source/ota.c
+++ b/source/ota.c
@@ -1,6 +1,6 @@
 /*
- * AWS IoT Over-the-air Update v3.1.0
- * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * AWS IoT Over-the-air Update v3.3.0
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -1203,8 +1203,11 @@ static OtaErr_t processDataHandler( const OtaEventData_t * pEventData )
 
         dataHandlerCleanup();
 
-        /* Last file block processed, increment the statistics. */
-        otaAgent.statistics.otaPacketsProcessed++;
+        if( otaAgent.statistics.otaPacketsProcessed < UINT32_MAX )
+        {
+            /* Last file block processed, increment the statistics. */
+            otaAgent.statistics.otaPacketsProcessed++;
+        }
 
         /* Let main application know that update is complete */
         otaAgent.OtaAppCallback( otaJobEvent, &jobDoc );
@@ -1220,11 +1223,11 @@ static OtaErr_t processDataHandler( const OtaEventData_t * pEventData )
         ( void ) otaAgent.pOtaInterface->pal.setPlatformImageState( &( otaAgent.fileContext ), OtaImageStateRejected );
 
         jobDoc.status = JobStatusFailedWithVal;
-        jobDoc.reason = ( int32_t ) closeResult;
-        jobDoc.subReason = result;
+        jobDoc.reason = ( int32_t ) OTA_PAL_MAIN_ERR( closeResult );
+        jobDoc.subReason = ( int32_t ) OTA_PAL_SUB_ERR( closeResult );
 
         /* Update the job status with the with failure code. */
-        err = otaControlInterface.updateJobStatus( &otaAgent, JobStatusFailedWithVal, ( int32_t ) closeResult, ( int32_t ) result );
+        err = otaControlInterface.updateJobStatus( &otaAgent, JobStatusFailedWithVal, ( int32_t ) OTA_PAL_MAIN_ERR( closeResult ), ( int32_t ) OTA_PAL_SUB_ERR( closeResult ) );
 
         dataHandlerCleanup();
 
@@ -1238,8 +1241,11 @@ static OtaErr_t processDataHandler( const OtaEventData_t * pEventData )
     {
         if( result == IngestResultAccepted_Continue )
         {
-            /* File block processed, increment the statistics. */
-            otaAgent.statistics.otaPacketsProcessed++;
+            if( otaAgent.statistics.otaPacketsProcessed < UINT32_MAX )
+            {
+                /* Last file block processed, increment the statistics. */
+                otaAgent.statistics.otaPacketsProcessed++;
+            }
 
             /* Reset the momentum counter since we received a good block. */
             otaAgent.requestMomentum = 0;
@@ -1655,11 +1661,11 @@ static DocParseErr_t extractParameter( JsonDocParam_t docParam,
     /* Get destination offset to parameter storage location.*/
     pParamAdd = ( uint8_t * ) pContextBase + docParam.pDestOffset;
 
-    /* Get destination buffer size to parameter storage location. */
-    pParamSizeAdd = ( void * ) ( ( uint8_t * ) pContextBase + docParam.pDestSizeOffset );
-
     if( ( ModelParamTypeStringCopy == docParam.modelParamType ) || ( ModelParamTypeArrayCopy == docParam.modelParamType ) )
     {
+        /* Get destination buffer size to parameter storage location. */
+        pParamSizeAdd = ( void * ) ( ( uint8_t * ) pContextBase + docParam.pDestSizeOffset );
+
         err = extractAndStoreArray( docParam.pSrcKey, pValueInJson, valueLength, pParamAdd, pParamSizeAdd );
     }
     else if( ModelParamTypeUInt32 == docParam.modelParamType )
@@ -2362,24 +2368,32 @@ static OtaFileContext_t * getFileContextFromJob( const char * pRawMsg,
         LogInfo( ( "Job document for receiving an update received." ) );
     }
 
-    if( ( updateJob == false ) && ( pUpdateFile != NULL ) && ( platformInSelftest() == false ) )
+    if( ( pUpdateFile != NULL ) && ( pUpdateFile->fileSize > OTA_MAX_FILE_SIZE ) )
+    {
+        err = OtaErrFileSizeOverflow;
+    }
+
+    if( ( err == OtaErrNone ) && ( updateJob == false ) && ( platformInSelftest() == false ) && ( pUpdateFile != NULL ) )
     {
         /* Calculate how many bytes we need in our bitmap for tracking received blocks.
          * The below calculation requires power of 2 page sizes. */
         numBlocks = ( pUpdateFile->fileSize + ( OTA_FILE_BLOCK_SIZE - 1U ) ) >> otaconfigLOG2_FILE_BLOCK_SIZE;
         bitmapLen = ( numBlocks + ( BITS_PER_BYTE - 1U ) ) >> LOG2_BITS_PER_BYTE;
 
+        /* This conditional statement has been excluded from the coverage report because one of branches in the
+         * if conditions cannot be reached because it is not possible for the code to have
+         * pUpdateFile->blockBitmapMaxSize not equal to 0 and pUpdateFile->pRxBlockBitmap equal to NULL. */
+
+        /* LCOV_EXCL_START */
+        if( ( pUpdateFile->pRxBlockBitmap != NULL ) && ( pUpdateFile->blockBitmapMaxSize == 0u ) )
+        {
+            otaAgent.pOtaInterface->os.mem.free( pUpdateFile->pRxBlockBitmap );
+        }
+
+        /* LCOV_EXCL_STOP */
+
         if( pUpdateFile->blockBitmapMaxSize == 0u )
         {
-            /* LCOV_EXCL_START */
-            if( pUpdateFile->pRxBlockBitmap != NULL )
-            {
-                /* Free any previously allocated bitmap. */
-                otaAgent.pOtaInterface->os.mem.free( pUpdateFile->pRxBlockBitmap );
-            }
-
-            /* LCOV_EXCL_STOP */
-
             pUpdateFile->pRxBlockBitmap = ( uint8_t * ) otaAgent.pOtaInterface->os.mem.malloc( bitmapLen );
         }
         else
@@ -2405,7 +2419,7 @@ static OtaFileContext_t * getFileContextFromJob( const char * pRawMsg,
 
             for( index = 0U; index < numOutOfRange; index++ )
             {
-                pUpdateFile->pRxBlockBitmap[ bitmapLen - 1U ] &= ( uint8_t ) ~bit;
+                pUpdateFile->pRxBlockBitmap[ bitmapLen - 1U ] &= ( uint8_t ) ( 0xFF & ( ~bit ) );
                 bit >>= 1U;
             }
 
@@ -2421,16 +2435,13 @@ static OtaFileContext_t * getFileContextFromJob( const char * pRawMsg,
                 pUpdateFile = NULL;
             }
         }
-        else
-        {
-            /* Can't receive the image without enough memory. */
-            ( void ) otaClose( pUpdateFile );
-            pUpdateFile = NULL;
-        }
     }
 
-    if( err != OtaErrNone )
+    if( ( err != OtaErrNone ) || ( ( pUpdateFile != NULL ) && ( pUpdateFile->pRxBlockBitmap == NULL ) ) )
     {
+        otaClose( pUpdateFile );
+        pUpdateFile = NULL;
+
         LogDebug( ( "Failed to parse the file context from the job document: OtaErr_t=%s",
                     OTA_Err_strerror( err ) ) );
     }
@@ -2524,7 +2535,7 @@ static IngestResult_t processDataBlock( OtaFileContext_t * pFileContext,
             else
             {
                 /* Mark this block as received in our bitmap. */
-                pFileContext->pRxBlockBitmap[ byte ] &= ( uint8_t ) ~bitMask;
+                pFileContext->pRxBlockBitmap[ byte ] &= ( uint8_t ) ( 0xFF & ( ~bitMask ) );
                 pFileContext->blocksRemaining--;
                 eIngestResult = IngestResultAccepted_Continue;
                 *pCloseResult = OTA_PAL_COMBINE_ERR( OtaPalSuccess, 0 );
@@ -3180,6 +3191,14 @@ OtaState_t OTA_Shutdown( uint32_t ticksToWait,
     {
         otaAgent.unsubscribeOnShutdown = unsubscribeFlag;
 
+        /* Stop and delete the request timer. */
+        ( void ) otaAgent.pOtaInterface->os.timer.stop( OtaRequestTimer );
+        ( void ) otaAgent.pOtaInterface->os.timer.delete( OtaRequestTimer );
+
+        /* Stop and delete the self-test timer. */
+        ( void ) otaAgent.pOtaInterface->os.timer.stop( OtaSelfTestTimer );
+        ( void ) otaAgent.pOtaInterface->os.timer.delete( OtaSelfTestTimer );
+
         /*
          * Send shutdown signal to OTA Agent task.
          */
@@ -3380,6 +3399,9 @@ OtaErr_t OTA_Suspend( void )
         /* Stop the request timer. */
         ( void ) otaAgent.pOtaInterface->os.timer.stop( OtaRequestTimer );
 
+        /* Stop the self-test timer. */
+        ( void ) otaAgent.pOtaInterface->os.timer.stop( OtaSelfTestTimer );
+
         /*
          * Send event to OTA agent task.
          */
@@ -3410,6 +3432,19 @@ OtaErr_t OTA_Resume( void )
     /* Check if OTA Agent is running. */
     if( otaAgent.state != OtaAgentStateStopped )
     {
+        /*
+         * Resume timers.
+         */
+        ( void ) otaAgent.pOtaInterface->os.timer.start( OtaSelfTestTimer,
+                                                         "OtaSelfTestTimer",
+                                                         otaconfigSELF_TEST_RESPONSE_WAIT_MS,
+                                                         otaTimerCallback );
+
+        ( void ) otaAgent.pOtaInterface->os.timer.start( OtaRequestTimer,
+                                                         "OtaRequestTimer",
+                                                         otaconfigFILE_REQUEST_WAIT_MS,
+                                                         otaTimerCallback );
+
         /*
          * Send event to OTA agent task.
          */

--- a/test/cbmc/proofs/handleJobParsingError/Makefile
+++ b/test/cbmc/proofs/handleJobParsingError/Makefile
@@ -21,8 +21,8 @@ PROJECT_SOURCES += $(SRCDIR)/source/ota.c
 
 REMOVE_FUNCTION_BODY += otaClose
 
-RESTRICT_FUNCTION_POINTER = handleJobParsingError.function_pointer_call.1/updateJobStatusStub
-RESTRICT_FUNCTION_POINTER += handleJobParsingError.function_pointer_call.2/otaAppCallbackStub
+RESTRICT_FUNCTION_POINTER = handleJobParsingError.function_pointer_call.1/otaAppCallbackStub
+RESTRICT_FUNCTION_POINTER += handleJobParsingError.function_pointer_call.2/updateJobStatusStub
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/test/cbmc/proofs/handleJobParsingError/Makefile
+++ b/test/cbmc/proofs/handleJobParsingError/Makefile
@@ -22,7 +22,7 @@ PROJECT_SOURCES += $(SRCDIR)/source/ota.c
 REMOVE_FUNCTION_BODY += otaClose
 
 RESTRICT_FUNCTION_POINTER = handleJobParsingError.function_pointer_call.1/updateJobStatusStub
-RESTRICT_FUNCTION_POINTER += handleJobParsingError.function_pointer_call.1/otaAppCallbackStub
+RESTRICT_FUNCTION_POINTER += handleJobParsingError.function_pointer_call.2/otaAppCallbackStub
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/test/cbmc/proofs/handleJobParsingError/Makefile
+++ b/test/cbmc/proofs/handleJobParsingError/Makefile
@@ -22,6 +22,7 @@ PROJECT_SOURCES += $(SRCDIR)/source/ota.c
 REMOVE_FUNCTION_BODY += otaClose
 
 RESTRICT_FUNCTION_POINTER = handleJobParsingError.function_pointer_call.1/updateJobStatusStub
+RESTRICT_FUNCTION_POINTER += handleJobParsingError.function_pointer_call.1/otaAppCallbackStub
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/test/cbmc/proofs/handleJobParsingError/handleJobParsingError_harness.c
+++ b/test/cbmc/proofs/handleJobParsingError/handleJobParsingError_harness.c
@@ -61,10 +61,9 @@ void handleJobParsingError_harness()
     /* handleJobParsingError can never be called if the parsing err is OtaJobParseErrNone. */
     __CPROVER_assume( err != OtaJobParseErrNone );
 
-    otaControlInterface.updateJobStatus = updateJobStatusStub;
-
     /* Preconditions. */
-    otaAgent.OtaAppCallback = otaAppCallbackStub;
+    otaAgent.OtaAppCallback = otaAppCallback;
+    otaControlInterface.updateJobStatus = updateJobStatusStub;
 
     handleJobParsingError( &fileContext, err );
 }

--- a/test/cbmc/proofs/handleJobParsingError/handleJobParsingError_harness.c
+++ b/test/cbmc/proofs/handleJobParsingError/handleJobParsingError_harness.c
@@ -62,7 +62,7 @@ void handleJobParsingError_harness()
     __CPROVER_assume( err != OtaJobParseErrNone );
 
     /* Preconditions. */
-    otaAgent.OtaAppCallback = otaAppCallback;
+    otaAgent.OtaAppCallback = otaAppCallbackStub;
     otaControlInterface.updateJobStatus = updateJobStatusStub;
 
     handleJobParsingError( &fileContext, err );

--- a/test/cbmc/proofs/handleJobParsingError/handleJobParsingError_harness.c
+++ b/test/cbmc/proofs/handleJobParsingError/handleJobParsingError_harness.c
@@ -63,5 +63,8 @@ void handleJobParsingError_harness()
 
     otaControlInterface.updateJobStatus = updateJobStatusStub;
 
+    /* Preconditions. */
+    otaAgent.OtaAppCallback = otaAppCallbackStub;
+
     handleJobParsingError( &fileContext, err );
 }


### PR DESCRIPTION
restore unrelated changes to  #416 

Description
-----------
Restore the changes back to the main. Only keep the part of calling callback with OtaJobEventNoActiveJob.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is formatted using Uncrustify.
- [x] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.