### PR TITLE
Send status update on first block received.

### DIFF
--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -24,7 +24,7 @@
     </tr>
     <tr>
         <td>ota_mqtt.c</td>
-        <td><center>2.3K</center></td>
+        <td><center>2.4K</center></td>
         <td><center>2.2K</center></td>
     </tr>
     <tr>
@@ -39,7 +39,7 @@
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>12.2K</center></b></td>
+        <td><b><center>12.3K</center></b></td>
         <td><b><center>11.1K</center></b></td>
     </tr>
 </table>

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -627,7 +627,8 @@ static uint32_t buildStatusMessageReceiving( char * pMsgBuffer,
     numBlocks = ( pOTAFileCtx->fileSize + ( OTA_FILE_BLOCK_SIZE - 1U ) ) >> otaconfigLOG2_FILE_BLOCK_SIZE;
     received = numBlocks - pOTAFileCtx->blocksRemaining;
 
-    /* Output a status update once in a while. */
+    /* Output a status update when receiving first file block to let user know the OTA job status
+     * more clearly. Then output a status update once in a while. */
     if( ( received == 1 ) || ( ( received % otaconfigOTA_UPDATE_STATUS_FREQUENCY ) == 0U ) )
     {
         payloadStringParts[ 0 ] = pOtaJobStatusStrings[ status ];

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -628,7 +628,7 @@ static uint32_t buildStatusMessageReceiving( char * pMsgBuffer,
     received = numBlocks - pOTAFileCtx->blocksRemaining;
 
     /* Output a status update once in a while. */
-    if( ( received % otaconfigOTA_UPDATE_STATUS_FREQUENCY ) == 0U )
+    if( ( received == 1 ) || ( ( received % otaconfigOTA_UPDATE_STATUS_FREQUENCY ) == 0U ) )
     {
         payloadStringParts[ 0 ] = pOtaJobStatusStrings[ status ];
         payloadStringParts[ 3 ] = receivedString;


### PR DESCRIPTION
The change adds a condition to send status update when first block is received.

Description
-----------

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [X] I have tested my changes. No regression in existing tests.
- [X] My code is formatted using Uncrustify.
- [X] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.