### PR TITLE
Add new event for application callback when no active jobs are available

### DIFF
--- a/source/include/ota.h
+++ b/source/include/ota.h
@@ -172,6 +172,7 @@ typedef enum OtaJobEvent
     OtaJobEventParseCustomJob = 5, /*!< @brief OTA event for parsing custom job document. */
     OtaJobEventReceivedJob = 6,    /*!< @brief OTA event when a new valid AFT-OTA job is received. */
     OtaJobEventUpdateComplete = 7, /*!< @brief OTA event when the update is completed. */
+    OtaJobEventNoActiveJob = 8,    /*!< @brief OTA event when no active job is pending. */
     OtaLastJobEvent = OtaJobEventStartTest
 } OtaJobEvent_t;
 

--- a/source/ota.c
+++ b/source/ota.c
@@ -2238,6 +2238,10 @@ static void handleJobParsingError( const OtaFileContext_t * pFileContext,
             LogInfo( ( "No active job available in received job document: "
                        "OtaJobParseErr_t=%s",
                        OTA_JobParse_strerror( err ) ) );
+
+            /* Callback when no active job is available to be processed. */
+            otaAgent.OtaAppCallback( OtaJobEventNoActiveJob, NULL );
+
             break;
 
         default:

--- a/source/ota.c
+++ b/source/ota.c
@@ -468,6 +468,12 @@ static void handleJobParsingError( const OtaFileContext_t * pFileContext,
  */
 static void receiveAndProcessOtaEvent( void );
 
+/**
+ * @brief Call OTA callback function if it's registered.
+ */
+static void callOtaCallback( OtaJobEvent_t eEvent,
+                             const void * pData );
+
 /* OTA state event handler functions. */
 
 static OtaErr_t startHandler( const OtaEventData_t * pEventData );           /*!< Start timers and initiate request for job document. */
@@ -795,7 +801,7 @@ static OtaErr_t inSelfTestHandler( const OtaEventData_t * pEventData )
     if( platformInSelftest() == true )
     {
         /* Callback for application specific self-test. */
-        otaAgent.OtaAppCallback( OtaJobEventStartTest, NULL );
+        callOtaCallback( OtaJobEventStartTest, NULL );
 
         /* Clear self-test flag. */
         otaAgent.fileContext.isInSelfTest = false;
@@ -1002,7 +1008,7 @@ static OtaErr_t processJobHandler( const OtaEventData_t * pEventData )
     }
 
     /* Application callback for event processed. */
-    otaAgent.OtaAppCallback( OtaJobEventProcessed, ( const void * ) pEventData );
+    callOtaCallback( OtaJobEventProcessed, ( const void * ) pEventData );
 
     return retVal;
 }
@@ -1210,7 +1216,7 @@ static OtaErr_t processDataHandler( const OtaEventData_t * pEventData )
         }
 
         /* Let main application know that update is complete */
-        otaAgent.OtaAppCallback( otaJobEvent, &jobDoc );
+        callOtaCallback( otaJobEvent, &jobDoc );
 
         /* Clear any remaining string memory holding the job name since this job is done. */
         ( void ) memset( otaAgent.pActiveJobName, 0, OTA_JOB_ID_MAX_SIZE );
@@ -1232,7 +1238,7 @@ static OtaErr_t processDataHandler( const OtaEventData_t * pEventData )
         dataHandlerCleanup();
 
         /* Let main application know activate event. */
-        otaAgent.OtaAppCallback( OtaJobEventFail, &jobDoc );
+        callOtaCallback( OtaJobEventFail, &jobDoc );
 
         /* Clear any remaining string memory holding the job name since this job is done. */
         ( void ) memset( otaAgent.pActiveJobName, 0, OTA_JOB_ID_MAX_SIZE );
@@ -1272,7 +1278,7 @@ static OtaErr_t processDataHandler( const OtaEventData_t * pEventData )
     }
 
     /* Application callback for event processed. */
-    otaAgent.OtaAppCallback( OtaJobEventProcessed, ( const void * ) pEventData );
+    callOtaCallback( OtaJobEventProcessed, ( const void * ) pEventData );
 
     if( err != OtaErrNone )
     {
@@ -1983,7 +1989,7 @@ static OtaJobParseErr_t handleCustomJob( const char * pJson,
 
         /* We have an unknown job parser error. Check to see if we can pass control
          * to a callback for parsing */
-        otaAgent.OtaAppCallback( OtaJobEventParseCustomJob, &jobDoc );
+        callOtaCallback( OtaJobEventParseCustomJob, &jobDoc );
 
         if( jobDoc.parseErr == OtaJobParseErrNone )
         {
@@ -2139,7 +2145,7 @@ static void handleSelfTestJobDoc( OtaFileContext_t * pFileContext )
         }
 
         /* Application callback for self-test failure.*/
-        otaAgent.OtaAppCallback( OtaJobEventSelfTestFailed, NULL );
+        callOtaCallback( OtaJobEventSelfTestFailed, NULL );
 
         /* Handle self-test failure in the platform specific implementation,
          * example, reset the device in case of firmware upgrade. */
@@ -2240,7 +2246,7 @@ static void handleJobParsingError( const OtaFileContext_t * pFileContext,
                        OTA_JobParse_strerror( err ) ) );
 
             /* Callback when no active job is available to be processed. */
-            otaAgent.OtaAppCallback( OtaJobEventNoActiveJob, NULL );
+            callOtaCallback( OtaJobEventNoActiveJob, NULL );
 
             break;
 
@@ -2334,7 +2340,7 @@ static OtaFileContext_t * parseJobDoc( const JsonDocParam_t * pJsonExpectedParam
         jobDoc.fileTypeId = otaAgent.fileContext.fileType;
 
         /* Let the application know to release buffer.*/
-        otaAgent.OtaAppCallback( OtaJobEventReceivedJob, ( const void * ) &jobDoc );
+        callOtaCallback( OtaJobEventReceivedJob, ( const void * ) &jobDoc );
     }
     else
     {
@@ -2799,14 +2805,14 @@ static void handleUnexpectedEvents( const OtaEventMsg_t * pEventMsg )
         case OtaAgentEventReceivedJobDocument:
 
             /* Let the application know to release buffer.*/
-            otaAgent.OtaAppCallback( OtaJobEventProcessed, ( const void * ) pEventMsg->pEventData );
+            callOtaCallback( OtaJobEventProcessed, ( const void * ) pEventMsg->pEventData );
 
             break;
 
         case OtaAgentEventReceivedFileBlock:
 
             /* Let the application know to release buffer.*/
-            otaAgent.OtaAppCallback( OtaJobEventProcessed, ( const void * ) pEventMsg->pEventData );
+            callOtaCallback( OtaJobEventProcessed, ( const void * ) pEventMsg->pEventData );
 
             /* File block was not processed, increment the statistics. */
             otaAgent.statistics.otaPacketsDropped++;
@@ -2918,6 +2924,19 @@ static void receiveAndProcessOtaEvent( void )
                 handleUnexpectedEvents( &eventMsg );
             }
         }
+    }
+}
+
+static void callOtaCallback( OtaJobEvent_t eEvent,
+                             const void * pData )
+{
+    if( otaAgent.OtaAppCallback )
+    {
+        otaAgent.OtaAppCallback( eEvent, pData );
+    }
+    else
+    {
+        LogWarn( ( "OtaAppCallback is not registered, event=%d", eEvent ) );
     }
 }
 

--- a/test/cbmc/proofs/handleCustomJob/Makefile
+++ b/test/cbmc/proofs/handleCustomJob/Makefile
@@ -19,8 +19,8 @@ PROJECT_SOURCES += $(SRCDIR)/source/ota.c
 UNWINDSET += strlen.0:100
 UNWINDSET += strlen.1:100
 
-RESTRICT_FUNCTION_POINTER += handleCustomJob.function_pointer_call.1/otaAppCallbackStub
-RESTRICT_FUNCTION_POINTER += handleCustomJob.function_pointer_call.2/updateJobStatusStub
+RESTRICT_FUNCTION_POINTER += handleCustomJob.function_pointer_call.1/updateJobStatusStub
+RESTRICT_FUNCTION_POINTER += callOtaCallback.function_pointer_call.1/otaAppCallbackStub
 
 REMOVE_FUNCTION_BODY += JSON_SearchConst
 

--- a/test/cbmc/proofs/handleJobParsingError/Makefile
+++ b/test/cbmc/proofs/handleJobParsingError/Makefile
@@ -21,7 +21,8 @@ PROJECT_SOURCES += $(SRCDIR)/source/ota.c
 
 REMOVE_FUNCTION_BODY += otaClose
 
-RESTRICT_FUNCTION_POINTER = handleJobParsingError.function_pointer_call.1/updateJobStatusStub
+RESTRICT_FUNCTION_POINTER = handleJobParsingError.function_pointer_call.1/otaAppCallbackStub
+RESTRICT_FUNCTION_POINTER += handleJobParsingError.function_pointer_call.2/updateJobStatusStub
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/test/cbmc/proofs/handleJobParsingError/Makefile
+++ b/test/cbmc/proofs/handleJobParsingError/Makefile
@@ -21,8 +21,8 @@ PROJECT_SOURCES += $(SRCDIR)/source/ota.c
 
 REMOVE_FUNCTION_BODY += otaClose
 
-RESTRICT_FUNCTION_POINTER = handleJobParsingError.function_pointer_call.1/otaAppCallbackStub
-RESTRICT_FUNCTION_POINTER += handleJobParsingError.function_pointer_call.2/updateJobStatusStub
+RESTRICT_FUNCTION_POINTER += handleJobParsingError.function_pointer_call.1/updateJobStatusStub
+RESTRICT_FUNCTION_POINTER += callOtaCallback.function_pointer_call.1/otaAppCallbackStub
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/test/cbmc/proofs/handleJobParsingError/handleJobParsingError_harness.c
+++ b/test/cbmc/proofs/handleJobParsingError/handleJobParsingError_harness.c
@@ -61,6 +61,8 @@ void handleJobParsingError_harness()
     /* handleJobParsingError can never be called if the parsing err is OtaJobParseErrNone. */
     __CPROVER_assume( err != OtaJobParseErrNone );
 
+    /* Preconditions. */
+    otaAgent.OtaAppCallback = otaAppCallbackStub;
     otaControlInterface.updateJobStatus = updateJobStatusStub;
 
     handleJobParsingError( &fileContext, err );

--- a/test/cbmc/proofs/handleSelfTestJobDoc/Makefile
+++ b/test/cbmc/proofs/handleSelfTestJobDoc/Makefile
@@ -19,8 +19,8 @@ PROJECT_SOURCES += $(SRCDIR)/source/ota.c
 REMOVE_FUNCTION_BODY += validateUpdateVersion
 REMVOE_FUNCTION_BODY += setImageStateWithReason
 
-RESTRICT_FUNCTION_POINTER += handleSelfTestJobDoc.function_pointer_call.1/otaAppCallbackStub
-RESTRICT_FUNCTION_POINTER += handleSelfTestJobDoc.function_pointer_call.2/resetPalStub
+RESTRICT_FUNCTION_POINTER += handleSelfTestJobDoc.function_pointer_call.1/resetPalStub
+RESTRICT_FUNCTION_POINTER += callOtaCallback.function_pointer_call.1/otaAppCallbackStub
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/test/cbmc/proofs/handleUnexpectedEvents/Makefile
+++ b/test/cbmc/proofs/handleUnexpectedEvents/Makefile
@@ -15,8 +15,7 @@ PROOF_SOURCES += $(SRCDIR)/test/cbmc/source/stubs.c
 
 PROJECT_SOURCES += $(SRCDIR)/source/ota.c
 
-RESTRICT_FUNCTION_POINTER += handleUnexpectedEvents.function_pointer_call.1/otaAppCallbackStub
-RESTRICT_FUNCTION_POINTER += handleUnexpectedEvents.function_pointer_call.2/otaAppCallbackStub
+RESTRICT_FUNCTION_POINTER += callOtaCallback.function_pointer_call.1/otaAppCallbackStub
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/test/cbmc/proofs/inSelfTestHandler/Makefile
+++ b/test/cbmc/proofs/inSelfTestHandler/Makefile
@@ -22,9 +22,9 @@ NONDET_STATIC += "--nondet-static"
 REMOVE_FUNCTION_BODY += setImageStateWithReason
 
 RESTRICT_FUNCTION_POINTER += platformInSelftest.function_pointer_call.1/getPlatformImageStateStub
-RESTRICT_FUNCTION_POINTER += inSelfTestHandler.function_pointer_call.1/otaAppCallbackStub
-RESTRICT_FUNCTION_POINTER += inSelfTestHandler.function_pointer_call.2/stopTimerStub
-RESTRICT_FUNCTION_POINTER += inSelfTestHandler.function_pointer_call.3/resetPalStub
+RESTRICT_FUNCTION_POINTER += inSelfTestHandler.function_pointer_call.1/stopTimerStub
+RESTRICT_FUNCTION_POINTER += inSelfTestHandler.function_pointer_call.2/resetPalStub
+RESTRICT_FUNCTION_POINTER += callOtaCallback.function_pointer_call.1/otaAppCallbackStub
 
 
 

--- a/test/cbmc/proofs/parseJobDoc/Makefile
+++ b/test/cbmc/proofs/parseJobDoc/Makefile
@@ -20,7 +20,7 @@ UNWINDSET += strlen.0:74
 
 REMOVE_FUNCTION_BODY += handleCustomJob
 
-RESTRICT_FUNCTION_POINTER += parseJobDoc.function_pointer_call.1/otaAppCallbackStub
+RESTRICT_FUNCTION_POINTER += callOtaCallback.function_pointer_call.1/otaAppCallbackStub
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/test/cbmc/proofs/processDataHandler/Makefile
+++ b/test/cbmc/proofs/processDataHandler/Makefile
@@ -21,13 +21,11 @@ REMOVE_FUNCTION_BODY += dataHandlerCleanup
 REMOVE_FUNCTION_BODY += OTA_SignalEvent
 
 RESTRICT_FUNCTION_POINTER += processDataHandler.function_pointer_call.1/updateStatus 
-RESTRICT_FUNCTION_POINTER += processDataHandler.function_pointer_call.2/otaAppCallback
-RESTRICT_FUNCTION_POINTER += processDataHandler.function_pointer_call.3/setImageState
+RESTRICT_FUNCTION_POINTER += processDataHandler.function_pointer_call.2/setImageState
+RESTRICT_FUNCTION_POINTER += processDataHandler.function_pointer_call.3/updateStatus 
 RESTRICT_FUNCTION_POINTER += processDataHandler.function_pointer_call.4/updateStatus 
-RESTRICT_FUNCTION_POINTER += processDataHandler.function_pointer_call.5/otaAppCallback 
-RESTRICT_FUNCTION_POINTER += processDataHandler.function_pointer_call.6/updateStatus 
-RESTRICT_FUNCTION_POINTER += processDataHandler.function_pointer_call.7/start 
-RESTRICT_FUNCTION_POINTER += processDataHandler.function_pointer_call.8/otaAppCallback 
+RESTRICT_FUNCTION_POINTER += processDataHandler.function_pointer_call.5/start 
+RESTRICT_FUNCTION_POINTER += callOtaCallback.function_pointer_call.1/otaAppCallback
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/test/cbmc/proofs/processJobHandler/Makefile
+++ b/test/cbmc/proofs/processJobHandler/Makefile
@@ -21,7 +21,7 @@ REMOVE_FUNCTION_BODY += setDataInterface
 REMOVE_FUNCTION_BODY += setImageStateWithReason
 REMOVE_FUNCTION_BODY += getFileContextFromJob
 
-RESTRICT_FUNCTION_POINTER += processJobHandler.function_pointer_call.1/otaAppCallbackStub
+RESTRICT_FUNCTION_POINTER += callOtaCallback.function_pointer_call.1/otaAppCallbackStub
 RESTRICT_FUNCTION_POINTER += OTA_SignalEvent.function_pointer_call.1/sendEventStub
 RESTRICT_FUNCTION_POINTER += platformInSelftest.function_pointer_call.1/getPlatformImageStateStub
 RESTRICT_FUNCTION_POINTER += processValidFileContext.function_pointer_call.1/resetPalStub

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -1314,6 +1314,16 @@ void test_OTA_ImageStateAcceptWithActiveJob()
     TEST_ASSERT_EQUAL( OtaImageStateAccepted, OTA_GetImageState() );
 }
 
+void test_OTA_ImageStateAcceptWithActiveJobNullAppCallback()
+{
+    otaInit( pOtaDefaultClientId, NULL );
+
+    otaGoToState( OtaAgentStateWaitingForFileBlock );
+
+    TEST_ASSERT_EQUAL( OtaErrNone, OTA_SetImageState( OtaImageStateAccepted ) );
+    TEST_ASSERT_EQUAL( OtaImageStateAccepted, OTA_GetImageState() );
+}
+
 void test_OTA_ImageStateAcceptWithNoJob()
 {
     otaGoToState( OtaAgentStateReady );

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -453,6 +453,7 @@ otainterfaces
 otajobdocmodelparamstructure
 otajobeventactivate
 otajobeventfail
+otajobeventnoactivejob
 otajobeventparsecustomjob
 otajobeventprocessed
 otajobeventreceivedjob


### PR DESCRIPTION
<!--- Title -->
Add no active job event in application callback

Description
-----------
<!--- Describe your changes in detail -->
This change adds a new event in application callback. This provides a callback when no active job is available in service to process. Useful in cases where device needs to shutdown OTA agent if no active jobs are available to save power.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is formatted using Uncrustify.
- [x] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.