### PR TITLE
Ignore duplicate packet and wait for valid file blocks

### DIFF
--- a/source/ota.c
+++ b/source/ota.c
@@ -1237,21 +1237,20 @@ static OtaErr_t processDataHandler( const OtaEventData_t * pEventData )
         /* Clear any remaining string memory holding the job name since this job is done. */
         ( void ) memset( otaAgent.pActiveJobName, 0, OTA_JOB_ID_MAX_SIZE );
     }
-    else
+    else if( result == IngestResultAccepted_Continue )
     {
-        if( result == IngestResultAccepted_Continue )
-        {
-            if( otaAgent.statistics.otaPacketsProcessed < UINT32_MAX )
-            {
-                /* Last file block processed, increment the statistics. */
-                otaAgent.statistics.otaPacketsProcessed++;
-            }
+        /* Ignore duplicate packets and only count valid packets. */
 
-            /* Reset the momentum counter since we received a good block. */
-            otaAgent.requestMomentum = 0;
-            /* We're actively receiving a file so update the job status as needed. */
-            err = otaControlInterface.updateJobStatus( &otaAgent, JobStatusInProgress, JobReasonReceiving, 0 );
+        if( otaAgent.statistics.otaPacketsProcessed < UINT32_MAX )
+        {
+            /* Last file block processed, increment the statistics. */
+            otaAgent.statistics.otaPacketsProcessed++;
         }
+
+        /* Reset the momentum counter since we received a good block. */
+        otaAgent.requestMomentum = 0;
+        /* We're actively receiving a file so update the job status as needed. */
+        err = otaControlInterface.updateJobStatus( &otaAgent, JobStatusInProgress, JobReasonReceiving, 0 );
 
         if( otaAgent.numOfBlocksToReceive > 1U )
         {


### PR DESCRIPTION
<!--- Title -->
Ignore duplicate packet and wait for valid file blocks.

Description
-----------
Count valid file blocks only and ignore duplicate packets to avoid multiple file block requests.
Issue described at [amazon-freertos issue#3109](https://github.com/aws/amazon-freertos/issues/3109), duplicate packets cause continuous issue during OTA procedure.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is formatted using Uncrustify.
- [x] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.