### PR TITLE
change default signature size to 384 tto support RSA-3072

### DIFF
--- a/source/include/ota_private.h
+++ b/source/include/ota_private.h
@@ -369,7 +369,7 @@ typedef struct
 {
     uint16_t size;                         /*!< @brief Size, in bytes, of the signature. */
     uint8_t data[ kOTA_MaxSignatureSize ]; /*!< @brief The binary signature data. */
-} Sig256_t;
+} Sig_t;
 
 /**
  * @ingroup ota_struct_types
@@ -406,7 +406,7 @@ typedef struct OtaFileContext
     uint8_t * pDecodeMem;           /*!< @brief Decode memory. */
     uint32_t decodeMemMaxSize;      /*!< @brief Maximum size of the decode memory. */
     uint32_t fileType;              /*!< @brief The file type id set when creating the OTA job. */
-    Sig256_t * pSignature;          /*!< @brief Pointer to the file's signature structure. */
+    Sig_t * pSignature;             /*!< @brief Pointer to the file's signature structure. */
 } OtaFileContext_t;
 
 /**

--- a/source/include/ota_private.h
+++ b/source/include/ota_private.h
@@ -119,7 +119,7 @@
  * @brief A composite cryptographic signature structure able to hold our largest supported signature.
  */
 
-#define kOTA_MaxSignatureSize           256 /* Max bytes supported for a file signature (2048 bit RSA is 256 bytes). */
+#define kOTA_MaxSignatureSize           384 /* Max bytes supported for a file signature (3072 bit RSA is 384 bytes). */
 
 /**
  *

--- a/source/ota.c
+++ b/source/ota.c
@@ -610,7 +610,7 @@ static const JsonDocParam_t otaJobDocModelParamStructure[ OTA_NUM_JOB_PARAMS ] =
 
 static uint8_t pJobNameBuffer[ OTA_JOB_ID_MAX_SIZE ];       /*!< Buffer to store job name. */
 static uint8_t pProtocolBuffer[ OTA_PROTOCOL_BUFFER_SIZE ]; /*!< Buffer to store data protocol. */
-static Sig256_t sig256Buffer;                               /*!< Buffer to store key file signature. */
+static Sig_t sigBuffer;                                     /*!< Buffer to store key file signature. */
 
 static void otaTimerCallback( OtaTimerId_t otaTimerId )
 {
@@ -1551,13 +1551,13 @@ static DocParseErr_t decodeAndStoreKey( const char * pValueInJson,
     DocParseErr_t err = DocParseErrNone;
     size_t actualLen = 0;
     Base64Status_t base64Status = Base64Success;
-    Sig256_t ** pSig256 = pParamAdd;
+    Sig_t ** pSig = pParamAdd;
 
-    /* pSig256 should point to pSignature in OtaFileContext_t, which is statically allocated. */
-    assert( *pSig256 != NULL );
+    /* pSig should point to pSignature in OtaFileContext_t, which is statically allocated. */
+    assert( *pSig != NULL );
 
-    base64Status = base64Decode( ( *pSig256 )->data,
-                                 sizeof( ( *pSig256 )->data ),
+    base64Status = base64Decode( ( *pSig )->data,
+                                 sizeof( ( *pSig )->data ),
                                  &actualLen,
                                  ( const uint8_t * ) pValueInJson,
                                  valueLength );
@@ -1581,7 +1581,7 @@ static DocParseErr_t decodeAndStoreKey( const char * pValueInJson,
                    pLogBuffer ) );
 
 
-        ( *pSig256 )->size = ( uint16_t ) actualLen;
+        ( *pSig )->size = ( uint16_t ) actualLen;
     }
 
     return err;
@@ -3109,7 +3109,7 @@ static void initializeLocalBuffers( void )
     otaAgent.fileContext.pProtocols = pProtocolBuffer;
     otaAgent.fileContext.protocolMaxSize = ( uint16_t ) sizeof( pProtocolBuffer );
 
-    otaAgent.fileContext.pSignature = &sig256Buffer;
+    otaAgent.fileContext.pSignature = &sigBuffer;
 }
 
 /*

--- a/test/cbmc/proofs/decodeAndStoreKey/decodeAndStoreKey_harness.c
+++ b/test/cbmc/proofs/decodeAndStoreKey/decodeAndStoreKey_harness.c
@@ -39,7 +39,7 @@ void decodeAndStoreKey_harness()
     OtaFileContext_t * fileContext;
     const char pValueInJson[ OTA_FILE_BLOCK_SIZE ];
     size_t valueLength;
-    Sig256_t value;
+    Sig_t value;
     void * pParamAdd;
 
     /* Havoc otaAgent to non-deterministically set all the bytes in
@@ -50,7 +50,7 @@ void decodeAndStoreKey_harness()
     __CPROVER_assume( valueLength < OTA_FILE_BLOCK_SIZE );
 
     /* decodeAndStoreKey is called only when the value pointed in pValueInJson is of
-     * Sig256_t type. pParamAdd is a pointer to the pSignature in the fileContext and hence
+     * Sig_t type. pParamAdd is a pointer to the pSignature in the fileContext and hence
      * cannot be NULL. */
     otaAgent.fileContext.pSignature = &value;
     pParamAdd = &( otaAgent.fileContext.pSignature );

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -699,6 +699,7 @@ prvpal
 prxblockbitmap
 prxstreamtopic
 pserverinfo
+psig
 psignature
 psrckey
 pssl
@@ -777,6 +778,7 @@ setplatformimagestate
 shutdownhandler
 sig
 sigalrm
+sigbuffer
 sizeof
 sleeptimems
 sni


### PR DESCRIPTION
<!--- Title -->
change default signature size to 384 to support RSA-3072

Description
-----------
<!--- Describe your changes in detail -->
As mentioned in #238, change default signature size to 384 to support RSA-3072.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is formatted using Uncrustify.
- [x] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.