### PR TITLE
Replace mq_send/mq_receive with mq_timedsend/mq_timedreceive

### DIFF
--- a/source/include/ota_os_interface.h
+++ b/source/include/ota_os_interface.h
@@ -148,7 +148,7 @@ typedef OtaOsStatus_t ( * OtaSendEvent_t )( OtaEventContext_t * pEventCtx,
  *
  * @param[pEventMsg]     Pointer to store message.
  *
- * @param[timeout]       The maximum amount of time the task should block.
+ * @param[timeout]       The maximum amount of time (msec) the task should block.
  *
  * @return               OtaOsStatus_t, OtaOsSuccess if success , other error code on failure.
  */

--- a/source/portable/os/ota_os_posix.c
+++ b/source/portable/os/ota_os_posix.c
@@ -53,6 +53,11 @@
 #define MAX_MESSAGES      10
 #define MAX_MSG_SIZE      sizeof( OtaEventMsg_t )
 
+/* Time conversion */
+#define OTA_TIME_MS_TO_S( ms )           ( ms / 1000 )
+#define OTA_TIME_MS_TO_NS( ms )          ( ms * 1000000 )
+#define OTA_TIME_MS_LESS_THAN_S( ms )    ( ms % 1000 )
+
 static void requestTimerCallback( union sigval arg );
 static void selfTestTimerCallback( union sigval arg );
 
@@ -117,6 +122,8 @@ OtaOsStatus_t Posix_OtaSendEvent( OtaEventContext_t * pEventCtx,
                                   unsigned int timeout )
 {
     OtaOsStatus_t otaOsStatus = OtaOsSuccess;
+    struct timespec ts = { 0 };
+    time_t currentTime = time( NULL );
 
     ( void ) pEventCtx;
     ( void ) timeout;
@@ -124,7 +131,17 @@ OtaOsStatus_t Posix_OtaSendEvent( OtaEventContext_t * pEventCtx,
     /* Send the event to OTA event queue.*/
     errno = 0;
 
-    if( mq_send( otaEventQueue, pEventMsg, MAX_MSG_SIZE, 0 ) == -1 )
+    /* Set send timeout. */
+    ts.tv_nsec = OTA_TIME_MS_TO_NS( OTA_TIME_MS_LESS_THAN_S( timeout ) );
+    ts.tv_sec = OTA_TIME_MS_TO_S( timeout );
+
+    /* Detect overflow. */
+    if( ( currentTime > 0 ) && ( ( int64_t ) ( INT32_MAX - ts.tv_sec ) >= ( int64_t ) currentTime ) )
+    {
+        ts.tv_sec += currentTime;
+    }
+
+    if( mq_timedsend( otaEventQueue, pEventMsg, MAX_MSG_SIZE, 0, &ts ) == -1 )
     {
         otaOsStatus = OtaOsEventQueueSendFailed;
 
@@ -150,6 +167,8 @@ OtaOsStatus_t Posix_OtaReceiveEvent( OtaEventContext_t * pEventCtx,
     OtaOsStatus_t otaOsStatus = OtaOsSuccess;
     char * pDst = pEventMsg;
     char buff[ MAX_MSG_SIZE ];
+    struct timespec ts = { 0 };
+    time_t currentTime = time( NULL );
 
     ( void ) pEventCtx;
     ( void ) timeout;
@@ -157,16 +176,33 @@ OtaOsStatus_t Posix_OtaReceiveEvent( OtaEventContext_t * pEventCtx,
     /* Receive the next event from OTA event queue.*/
     errno = 0;
 
-    if( mq_receive( otaEventQueue, buff, sizeof( buff ), NULL ) == -1 )
+    /* Set receive timeout. */
+    ts.tv_nsec = OTA_TIME_MS_TO_NS( OTA_TIME_MS_LESS_THAN_S( timeout ) );
+    ts.tv_sec = OTA_TIME_MS_TO_S( timeout );
+
+    /* Detect overflow. */
+    if( ( currentTime > 0 ) && ( ( int64_t ) ( INT32_MAX - ts.tv_sec ) >= ( int64_t ) currentTime ) )
+    {
+        ts.tv_sec += currentTime;
+    }
+
+    if( mq_timedreceive( otaEventQueue, buff, sizeof( buff ), NULL, &ts ) == -1 )
     {
         otaOsStatus = OtaOsEventQueueReceiveFailed;
 
-        LogError( ( "Failed to receive OTA Event: "
-                    "mq_reqeive returned error: "
-                    "OtaOsStatus_t=%i "
-                    ",errno=%s",
-                    otaOsStatus,
-                    strerror( errno ) ) );
+        if( errno == ETIMEDOUT )
+        {
+            LogDebug( ( "Failed to receive OTA Event before timeout" ) );
+        }
+        else
+        {
+            LogError( ( "Failed to receive OTA Event: "
+                        "mq_timedreceive returned error: "
+                        "OtaOsStatus_t=%i "
+                        ",errno=%s, errno=%d",
+                        otaOsStatus,
+                        strerror( errno ), errno ) );
+        }
     }
     else
     {

--- a/test/unit-test/ota_os_posix_utest.c
+++ b/test/unit-test/ota_os_posix_utest.c
@@ -194,3 +194,29 @@ void test_OTA_posix_MemoryAllocAndFree( void )
 
     STDC_Free( buffer );
 }
+
+/**
+ * @brief Test that the event queue receive timeout.
+ */
+void test_OTA_posix_RecvEventTimeout( void )
+{
+    OtaEventMsg_t otaEventToRecv = { 0 };
+    OtaErr_t result = OtaErrUninitialized;
+    time_t recvTimeoutMs = 3000;
+    time_t timeBeforeTestSec = 0;
+    time_t timeAfterTestSec = 0;
+
+    result = event.init( event.pEventContext );
+    TEST_ASSERT_EQUAL( OtaErrNone, result );
+
+    timeBeforeTestSec = time( NULL );
+    result = event.recv( event.pEventContext, &otaEventToRecv, recvTimeoutMs );
+    TEST_ASSERT_EQUAL( OtaOsEventQueueReceiveFailed, result );
+    timeAfterTestSec = time( NULL );
+
+    /* The time may not accurate enough, so - 1 as buffer. */
+    TEST_ASSERT_GREATER_OR_EQUAL( ( recvTimeoutMs / 1000 ) - 1, timeAfterTestSec - timeBeforeTestSec );
+
+    result = event.deinit( event.pEventContext );
+    TEST_ASSERT_EQUAL( OtaErrNone, result );
+}


### PR DESCRIPTION
<!--- Title -->
Replace mq_send/mq_receive with mq_timedsend/mq_timedreceive.

Description
-----------
<!--- Describe your changes in detail -->
To support timeout in posix, replace mq_send/mq_receive with mq_timedsend/mq_timedreceive.
Tested by merging changes to aws-iot-device-sdk-embedded-C, pass OTA job in ota_demo_core_mqtt.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is formatted using Uncrustify.
- [x] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.