### PR TITLE
Decouple build dependency with coreJSON and tinyCBOR.

### DIFF
--- a/otaDependenyFilePaths.cmake
+++ b/otaDependenyFilePaths.cmake
@@ -1,0 +1,30 @@
+# This file is to add source files and include directories
+# into variables so that it can be reused from different repositories
+# in their Cmake based build system by including this file.
+#
+# Files specific to the repository such as test runner, platform tests
+# are not added to the variables.
+
+# 3rdparty source files.
+include( ${CMAKE_CURRENT_LIST_DIR}/source/dependency/coreJSON/jsonFilePaths.cmake )
+
+set( TINYCBOR_SOURCES
+    "${CMAKE_CURRENT_LIST_DIR}/source/dependency/3rdparty/tinycbor/src/cborpretty.c"
+    "${CMAKE_CURRENT_LIST_DIR}/source/dependency/3rdparty/tinycbor/src/cborpretty_stdio.c"
+    "${CMAKE_CURRENT_LIST_DIR}/source/dependency/3rdparty/tinycbor/src/cborencoder.c"
+    "${CMAKE_CURRENT_LIST_DIR}/source/dependency/3rdparty/tinycbor/src/cborencoder_close_container_checked.c"
+    "${CMAKE_CURRENT_LIST_DIR}/source/dependency/3rdparty/tinycbor/src/cborerrorstrings.c"
+    "${CMAKE_CURRENT_LIST_DIR}/source/dependency/3rdparty/tinycbor/src/cborparser.c"
+    "${CMAKE_CURRENT_LIST_DIR}/source/dependency/3rdparty/tinycbor/src/cborparser_dup_string.c"
+)
+set(TINYCBOR_INCLUDE_DIRS
+    "${CMAKE_CURRENT_LIST_DIR}/source/dependency/3rdparty/tinycbor/src"
+)
+# Use C99 for tinycbor as it is incompatible with C90
+if(CMAKE_C_STANDARD LESS 99)
+    set_source_files_properties(
+        ${TINYCBOR_SOURCES}
+        PROPERTIES
+        COMPILE_FLAGS "-std=gnu99"
+    )
+endif()

--- a/otaFilePaths.cmake
+++ b/otaFilePaths.cmake
@@ -5,30 +5,6 @@
 # Files specific to the repository such as test runner, platform tests
 # are not added to the variables.
 
-# 3rdparty source files.
-include( ${CMAKE_CURRENT_LIST_DIR}/source/dependency/coreJSON/jsonFilePaths.cmake )
-
-set( TINYCBOR_SOURCES
-    "${CMAKE_CURRENT_LIST_DIR}/source/dependency/3rdparty/tinycbor/src/cborpretty.c"
-    "${CMAKE_CURRENT_LIST_DIR}/source/dependency/3rdparty/tinycbor/src/cborpretty_stdio.c"
-    "${CMAKE_CURRENT_LIST_DIR}/source/dependency/3rdparty/tinycbor/src/cborencoder.c"
-    "${CMAKE_CURRENT_LIST_DIR}/source/dependency/3rdparty/tinycbor/src/cborencoder_close_container_checked.c"
-    "${CMAKE_CURRENT_LIST_DIR}/source/dependency/3rdparty/tinycbor/src/cborerrorstrings.c"
-    "${CMAKE_CURRENT_LIST_DIR}/source/dependency/3rdparty/tinycbor/src/cborparser.c"
-    "${CMAKE_CURRENT_LIST_DIR}/source/dependency/3rdparty/tinycbor/src/cborparser_dup_string.c"
-)
-set(TINYCBOR_INCLUDE_DIRS
-    "${CMAKE_CURRENT_LIST_DIR}/source/dependency/3rdparty/tinycbor/src"
-)
-# Use C99 for tinycbor as it is incompatible with C90
-if(CMAKE_C_STANDARD LESS 99)
-    set_source_files_properties(
-        ${TINYCBOR_SOURCES}
-        PROPERTIES
-        COMPILE_FLAGS "-std=gnu99"
-    )
-endif()
-
 # OTA library source files, including 3rdparties.
 set( OTA_SOURCES
     "${CMAKE_CURRENT_LIST_DIR}/source/include/ota.h"
@@ -40,8 +16,6 @@ set( OTA_SOURCES
     "${CMAKE_CURRENT_LIST_DIR}/source/ota.c"
     "${CMAKE_CURRENT_LIST_DIR}/source/ota_interface.c"
     "${CMAKE_CURRENT_LIST_DIR}/source/ota_base64.c"
-    ${JSON_SOURCES}
-    ${TINYCBOR_SOURCES}
 )
 
 # OTA library public include directories.
@@ -53,8 +27,6 @@ set( OTA_INCLUDE_PUBLIC_DIRS
 # OTA library private include directories.
 set( OTA_INCLUDE_PRIVATE_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/source"
-    ${JSON_INCLUDE_PUBLIC_DIRS}
-    ${TINYCBOR_INCLUDE_DIRS}
 )
 
 # OTA library POSIX OS porting source files.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,13 +37,16 @@ set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )
 
 # Include filepaths for source and include.
 include( ${MODULE_ROOT_DIR}/otaFilePaths.cmake )
+include( ${MODULE_ROOT_DIR}/otaDependenyFilePaths.cmake )
 
 # Target for Coverity analysis that builds the library.
 add_library( coverity_analysis
     ${OTA_SOURCES}
     ${OTA_OS_POSIX_SOURCES}
     ${OTA_MQTT_SOURCES}
-    ${OTA_HTTP_SOURCES} )
+    ${OTA_HTTP_SOURCES}
+    ${TINYCBOR_SOURCES}
+    ${JSON_SOURCES} )
 
 # Build OTA library target without custom config dependency
 target_compile_definitions( coverity_analysis PUBLIC OTA_DO_NOT_USE_CUSTOM_CONFIG=1 )
@@ -55,7 +58,9 @@ target_include_directories( coverity_analysis PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/unit-test
     ${CMAKE_CURRENT_LIST_DIR}/unit-test-http )
 target_include_directories( coverity_analysis PRIVATE
-    ${OTA_INCLUDE_PRIVATE_DIRS} )
+    ${OTA_INCLUDE_PRIVATE_DIRS}
+    ${JSON_INCLUDE_PUBLIC_DIRS}
+    ${TINYCBOR_INCLUDE_DIRS} )
 
 # ============================ Test configuration ==============================
 

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Include filepaths for source and include.
 include( ${MODULE_ROOT_DIR}/otaFilePaths.cmake )
+include( ${MODULE_ROOT_DIR}/otaDependenyFilePaths.cmake )
 
 # ====================  Define your project name (edit) ========================
 set(project_name "aws_ota")
@@ -35,6 +36,8 @@ list(APPEND real_include_directories
     ${OTA_INCLUDE_PUBLIC_DIRS}
     ${OTA_INCLUDE_PRIVATE_DIRS}
     ${OTA_INCLUDE_OS_POSIX_DIRS}
+    ${JSON_INCLUDE_PUBLIC_DIRS}
+    ${TINYCBOR_INCLUDE_DIRS}
 )
 
 # =====================  Create UnitTest Code here (edit)  =====================


### PR DESCRIPTION
<!--- Title -->
Decouple build dependency with coreJSON and tinyCBOR.

Description
-----------
<!--- Describe your changes in detail -->
Create otaDependenyFilePaths.cmake to handle dependency files path.
Seperate them to decouple OTA library dependency with TinyCBOR and coreJSON.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is formatted using Uncrustify.
- [x] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.