### PR TITLE
Bug Fix: OTA_Resume only restarts selftest timer while selftesting

### DIFF
--- a/source/ota.c
+++ b/source/ota.c
@@ -3478,10 +3478,13 @@ OtaErr_t OTA_Resume( void )
         /*
          * Resume timers.
          */
-        ( void ) otaAgent.pOtaInterface->os.timer.start( OtaSelfTestTimer,
-                                                         "OtaSelfTestTimer",
-                                                         otaconfigSELF_TEST_RESPONSE_WAIT_MS,
-                                                         otaTimerCallback );
+        if( platformInSelftest() )
+        {
+            ( void ) otaAgent.pOtaInterface->os.timer.start( OtaSelfTestTimer,
+                                                             "OtaSelfTestTimer",
+                                                             otaconfigSELF_TEST_RESPONSE_WAIT_MS,
+                                                             otaTimerCallback );
+        }
 
         ( void ) otaAgent.pOtaInterface->os.timer.start( OtaRequestTimer,
                                                          "OtaRequestTimer",

--- a/test/cbmc/proofs/OTA_Resume/Makefile
+++ b/test/cbmc/proofs/OTA_Resume/Makefile
@@ -21,6 +21,7 @@ REMOVE_FUNCTION_BODY += OTA_SignalEvent
 
 RESTRICT_FUNCTION_POINTER += OTA_Resume.function_pointer_call.1/startTimerStub
 RESTRICT_FUNCTION_POINTER += OTA_Resume.function_pointer_call.2/startTimerStub
+RESTRICT_FUNCTION_POINTER += platformInSelftest.function_pointer_call.1/getPlatformImageStateStub
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/test/cbmc/proofs/OTA_Resume/OTA_Resume_harness.c
+++ b/test/cbmc/proofs/OTA_Resume/OTA_Resume_harness.c
@@ -41,7 +41,8 @@ void OTA_Resume_harness()
 {
     OtaInterfaces_t otaInterface;
 
-    /* Initialize os timers. */
+    /* Initialize os timers and self-test state fetcher */
+    otaInterface.pal.getPlatformImageState = getPlatformImageStateStub;
     otaInterface.os.timer.start = startTimerStub;
     otaAgent.pOtaInterface = &otaInterface;
 

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -146,6 +146,12 @@ static uint8_t pLargerJobNameBuffer[ OTA_JOB_ID_MAX_SIZE * 2 ];
 /* A counter to record how many file blocks are received. */
 static int otaReceivedFileBlockNumber = 0;
 
+/* A boolean reflecting the state of the self-test timer. */
+static bool bSelfTestTimerIsActive = false;
+
+/* A boolean reflecting the state of the data request timer. */
+static bool bRequestTimerIsActive = false;
+
 /* ========================================================================== */
 
 /* Global static variable defined in ota.c for managing the state machine. */
@@ -346,6 +352,26 @@ static OtaOsStatus_t stubOSTimerStart( OtaTimerId_t timerId,
     return OtaOsSuccess;
 }
 
+static OtaOsStatus_t mockOSTimerStart( OtaTimerId_t timerId,
+                                       const char * const pTimerName,
+                                       const uint32_t timeout,
+                                       OtaTimerCallback_t callback )
+{
+    if( timerId == OtaRequestTimer )
+    {
+        bRequestTimerIsActive = true;
+    }
+    else if( timerId == OtaSelfTestTimer )
+    {
+        bSelfTestTimerIsActive = true;
+    }
+
+    ( void ) pTimerName;
+    ( void ) timeout;
+    ( void ) callback;
+    return OtaOsSuccess;
+}
+
 static OtaOsStatus_t mockOSTimerInvokeCallback( OtaTimerId_t timerId,
                                                 const char * const pTimerName,
                                                 const uint32_t timeout,
@@ -372,6 +398,20 @@ static OtaOsStatus_t mockOSTimerStartAlwaysFail( OtaTimerId_t unused_1,
 static OtaOsStatus_t stubOSTimerStop( OtaTimerId_t timerId )
 {
     ( void ) timerId;
+    return OtaOsSuccess;
+}
+
+static OtaOsStatus_t mockOSTimerStop( OtaTimerId_t timerId )
+{
+    if( timerId == OtaRequestTimer )
+    {
+        bRequestTimerIsActive = false;
+    }
+    else if( timerId == OtaSelfTestTimer )
+    {
+        bSelfTestTimerIsActive = false;
+    }
+
     return OtaOsSuccess;
 }
 
@@ -1195,6 +1235,56 @@ void test_OTA_ResumeFailedWhenSuspended()
     /* Resume should fail and OTA agent should remain in suspend state. */
     TEST_ASSERT_EQUAL( OtaErrSignalEventFailed, OTA_Resume() );
     TEST_ASSERT_EQUAL( OtaAgentStateSuspended, OTA_GetState() );
+}
+
+void test_OTA_ResumeSelfTestTimerRestart()
+{
+    otaGoToState( OtaAgentStateSuspended );
+    TEST_ASSERT_EQUAL( OtaAgentStateSuspended, OTA_GetState() );
+
+    /* Reset timer state and configure mocked timer function for tracking timer state */
+    bSelfTestTimerIsActive = false;
+    bRequestTimerIsActive = false;
+    otaInterfaces.os.timer.start = mockOSTimerStart;
+    otaInterfaces.os.timer.stop = mockOSTimerStop;
+    otaInterfaces.os.event.send = mockOSEventSend;
+
+    /* Let the PAL always says it's in self test. */
+    otaInterfaces.pal.getPlatformImageState = mockPalGetPlatformImageStateAlwaysPendingCommit;
+    TEST_ASSERT_EQUAL( OtaErrNone, OTA_Resume() );
+
+    /* Self test timer should be restarted if the device is self testing. */
+    TEST_ASSERT_TRUE( bSelfTestTimerIsActive );
+    TEST_ASSERT_TRUE( bRequestTimerIsActive );
+
+    /* As this was a nominal flow, OTA should resume without issue. */
+    receiveAndProcessOtaEvent();
+    TEST_ASSERT_EQUAL( OtaAgentStateRequestingJob, OTA_GetState() );
+}
+
+void test_OTA_ResumeNoSelfTestTimerRestart()
+{
+    otaGoToState( OtaAgentStateSuspended );
+    TEST_ASSERT_EQUAL( OtaAgentStateSuspended, OTA_GetState() );
+
+    /* Reset timer state and configure mocked timer function for tracking timer state */
+    bSelfTestTimerIsActive = false;
+    bRequestTimerIsActive = false;
+    otaInterfaces.os.timer.start = mockOSTimerStart;
+    otaInterfaces.os.timer.stop = mockOSTimerStop;
+    otaInterfaces.os.event.send = mockOSEventSend;
+
+    /* Let the PAL always says it's not in self test. */
+    otaInterfaces.pal.getPlatformImageState = mockPalGetPlatformImageStateAlwaysInvalid;
+    TEST_ASSERT_EQUAL( OtaErrNone, OTA_Resume() );
+
+    /* Self test timer should NOT be restarted if the device is not self testing. */
+    TEST_ASSERT_FALSE( bSelfTestTimerIsActive );
+    TEST_ASSERT_TRUE( bRequestTimerIsActive );
+
+    /* As this was a nominal flow, OTA should resume without issue. */
+    receiveAndProcessOtaEvent();
+    TEST_ASSERT_EQUAL( OtaAgentStateRequestingJob, OTA_GetState() );
 }
 
 void test_OTA_Statistics()


### PR DESCRIPTION
Description
-----------
Fix bug detailed in issue #421 and add test coverage for the changes.

Test Bed
-----------
| Component | Version |
| ------- | ----- |
| Platform | esp32-devkitc |
| OTA library | latest:main |
| CSDK | latest:main |

For integration tests, I modified the [OTA MQTT](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/main/demos/ota/ota_demo_core_mqtt) demo provided by the csdk. Test application initializes/starts OTA agent, then calls `OTA_Resume` while no OTAs are pending or in flight.

[Integration Test Logs (Before)](https://github.com/aws/ota-for-aws-iot-embedded-sdk/files/8875827/before.txt)
[Integration Test Logs (After)](https://github.com/aws/ota-for-aws-iot-embedded-sdk/files/8875867/after.txt)

Note my added logs containing "Int-Test". Before the fix, you'll notice the log indicating when `OTA_Resume` was called and the repeated cycles of self-test timer fire then reboot. With the fix, these app logs were retained, but not reported per the fix.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is formatted using Uncrustify.
- [x] ~~I have read and applied the rules stated in CONTRIBUTING.md.~~ There isn't one.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.