### PR TITLE
Keep event/callback functions pointer in OTA_Shutdown to avoid accessing NULL pointer.

### DIFF
--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -10,7 +10,7 @@
     <tr>
         <td>ota.c</td>
         <td><center>8.3K</center></td>
-        <td><center>7.4K</center></td>
+        <td><center>7.5K</center></td>
     </tr>
     <tr>
         <td>ota_interface.c</td>
@@ -40,6 +40,6 @@
     <tr>
         <td><b>Total estimates</b></td>
         <td><b><center>12.5K</center></b></td>
-        <td><b><center>11.2K</center></b></td>
+        <td><b><center>11.3K</center></b></td>
     </tr>
 </table>

--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -9,8 +9,8 @@
     </tr>
     <tr>
         <td>ota.c</td>
-        <td><center>8.1K</center></td>
-        <td><center>7.3K</center></td>
+        <td><center>8.3K</center></td>
+        <td><center>7.4K</center></td>
     </tr>
     <tr>
         <td>ota_interface.c</td>
@@ -39,7 +39,7 @@
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>12.3K</center></b></td>
-        <td><b><center>11.1K</center></b></td>
+        <td><b><center>12.5K</center></b></td>
+        <td><b><center>11.2K</center></b></td>
     </tr>
 </table>

--- a/source/include/ota.h
+++ b/source/include/ota.h
@@ -309,6 +309,7 @@ typedef struct OtaAgentContext
     const OtaInterfaces_t * pOtaInterface;                 /*!< Collection of all interfaces used by the agent. */
     OtaAppCallback_t OtaAppCallback;                       /*!< OTA App callback. */
     uint8_t unsubscribeOnShutdown;                         /*!< Flag to indicate if unsubscribe from job topics should be done at shutdown. */
+    uint8_t isOtaInterfaceInited;                          /*!< Flag to indicate if pOtaInterface is initialized. */
 } OtaAgentContext_t;
 
 /*------------------------- OTA Public API --------------------------*/

--- a/source/include/ota.h
+++ b/source/include/ota.h
@@ -407,6 +407,9 @@ OtaErr_t OTA_Init( OtaAppBuffer_t * pOtaBuffer,
  * Signals the OTA agent task to shut down. The OTA agent will unsubscribe from all MQTT job
  * notification topics, stop in progress OTA jobs, if any, and clear all resources.
  *
+ * OTA needs a processing task running OTA_EventProcessingTask to handle shutdown event, or
+ * OTA will shutdown after the processing task is created and scheduled.
+ *
  * @param[in] ticksToWait The number of ticks to wait for the OTA Agent to complete the shutdown process.
  * If this is set to zero, the function will return immediately without waiting. The actual state is
  * returned to the caller. The agent does not sleep for this while but used for busy looping.

--- a/source/include/ota_config_defaults.h
+++ b/source/include/ota_config_defaults.h
@@ -293,6 +293,16 @@
 #endif
 
 /**
+ * @brief The polling timeout (milliseconds) to receive messages from event queue.
+ *
+ * <b>Possible values:</b> Any unsigned 32 integer. <br>
+ * <b>Default value:</b> '1000'
+ */
+#ifndef configOTA_POLLING_EVENTS_TIMEOUT_MS
+    #define configOTA_POLLING_EVENTS_TIMEOUT_MS    ( 1000U )
+#endif
+
+/**
  * @brief Macro that is called in the OTA library for logging "Error" level
  * messages.
  *

--- a/source/ota.c
+++ b/source/ota.c
@@ -2831,20 +2831,6 @@ static void agentShutdownCleanup( void )
      * Clear active job name.
      */
     ( void ) memset( otaAgent.pActiveJobName, 0, OTA_JOB_ID_MAX_SIZE );
-
-    /* Clear the entire agent context except for pOtaInterface and OtaAppCallback
-     * to avoid accessing NULL function pointer if other task is running. Don't
-     * reset isOtaInterfaceInited to ensure os.event won't be created again in the
-     * next OTA_Init. */
-    ( void ) memset( &otaAgent.pThingName, 0, sizeof( otaAgent.pThingName ) );
-    ( void ) memset( &otaAgent.fileContext, 0, sizeof( otaAgent.fileContext ) );
-    otaAgent.fileIndex = 0;
-    otaAgent.serverFileID = 0;
-    otaAgent.imageState = OtaImageStateUnknown;
-    otaAgent.numOfBlocksToReceive = 0;
-    ( void ) memset( &otaAgent.statistics, 0, sizeof( otaAgent.statistics ) );
-    otaAgent.requestMomentum = 0;
-    otaAgent.unsubscribeOnShutdown = 0;
 }
 
 /*

--- a/source/ota.c
+++ b/source/ota.c
@@ -3080,6 +3080,7 @@ static void initializeAppBuffers( OtaAppBuffer_t * pOtaBuffer )
     }
     else
     {
+        otaAgent.fileContext.pFilePath = NULL;
         otaAgent.fileContext.filePathMaxSize = 0;
     }
 
@@ -3091,6 +3092,7 @@ static void initializeAppBuffers( OtaAppBuffer_t * pOtaBuffer )
     }
     else
     {
+        otaAgent.fileContext.pCertFilepath = NULL;
         otaAgent.fileContext.certFilePathMaxSize = 0;
     }
 
@@ -3102,6 +3104,7 @@ static void initializeAppBuffers( OtaAppBuffer_t * pOtaBuffer )
     }
     else
     {
+        otaAgent.fileContext.pStreamName = NULL;
         otaAgent.fileContext.streamNameMaxSize = 0;
     }
 
@@ -3113,6 +3116,7 @@ static void initializeAppBuffers( OtaAppBuffer_t * pOtaBuffer )
     }
     else
     {
+        otaAgent.fileContext.pDecodeMem = NULL;
         otaAgent.fileContext.decodeMemMaxSize = 0;
     }
 
@@ -3124,6 +3128,7 @@ static void initializeAppBuffers( OtaAppBuffer_t * pOtaBuffer )
     }
     else
     {
+        otaAgent.fileContext.pRxBlockBitmap = NULL;
         otaAgent.fileContext.blockBitmapMaxSize = 0;
     }
 
@@ -3135,6 +3140,7 @@ static void initializeAppBuffers( OtaAppBuffer_t * pOtaBuffer )
     }
     else
     {
+        otaAgent.fileContext.pUpdateUrlPath = NULL;
         otaAgent.fileContext.updateUrlMaxSize = 0;
     }
 
@@ -3146,6 +3152,7 @@ static void initializeAppBuffers( OtaAppBuffer_t * pOtaBuffer )
     }
     else
     {
+        otaAgent.fileContext.pAuthScheme = NULL;
         otaAgent.fileContext.authSchemeMaxSize = 0;
     }
 }
@@ -3288,13 +3295,7 @@ OtaState_t OTA_Shutdown( uint32_t ticksToWait,
                 "ticks=%u",
                 ticks ) );
 
-    if( otaAgent.state == OtaAgentStateInit )
-    {
-        /* When in init state, the OTA state machine is not running yet. So directly set state to
-         * stopped. */
-        otaAgent.state = OtaAgentStateStopped;
-    }
-    else if( ( otaAgent.state != OtaAgentStateStopped ) && ( otaAgent.state != OtaAgentStateShuttingDown ) ) /* LCOV_EXCL_BR_LINE */
+    if( ( otaAgent.state != OtaAgentStateStopped ) && ( otaAgent.state != OtaAgentStateShuttingDown ) ) /* LCOV_EXCL_BR_LINE */
     {
         otaAgent.unsubscribeOnShutdown = unsubscribeFlag;
 

--- a/source/ota.c
+++ b/source/ota.c
@@ -3168,6 +3168,9 @@ static void resetEventQueue( void )
     while( otaAgent.pOtaInterface->os.event.recv( NULL, &eventMsg, 0 ) == OtaOsSuccess )
     {
         LogWarn( ( "Event(%d) is dropped.\r\n", eventMsg.eventId ) );
+
+        /* Call handleUnexpectedEvents to notify user to release resources if neccessary. */
+        handleUnexpectedEvents( &eventMsg );
     }
 }
 

--- a/source/ota.c
+++ b/source/ota.c
@@ -1337,6 +1337,20 @@ static OtaErr_t shutdownHandler( const OtaEventData_t * pEventData )
     /* If we're here, we're shutting down the OTA agent. Free up all resources and quit. */
     agentShutdownCleanup();
 
+    /* Clear the entire agent context except for pOtaInterface and OtaAppCallback
+     * to avoid accessing NULL function pointer if other task is running. Don't
+     * reset isOtaInterfaceInited to ensure os.event won't be created again in the
+     * next OTA_Init. */
+    ( void ) memset( &otaAgent.pThingName, 0, sizeof( otaAgent.pThingName ) );
+    ( void ) memset( &otaAgent.fileContext, 0, sizeof( otaAgent.fileContext ) );
+    ( void ) memset( &otaAgent.fileIndex, 0, sizeof( otaAgent.fileIndex ) );
+    ( void ) memset( &otaAgent.serverFileID, 0, sizeof( otaAgent.serverFileID ) );
+    ( void ) memset( &otaAgent.numOfBlocksToReceive, 0, sizeof( otaAgent.numOfBlocksToReceive ) );
+    ( void ) memset( &otaAgent.statistics, 0, sizeof( otaAgent.statistics ) );
+    ( void ) memset( &otaAgent.requestMomentum, 0, sizeof( otaAgent.requestMomentum ) );
+    ( void ) memset( &otaAgent.unsubscribeOnShutdown, 0, sizeof( otaAgent.unsubscribeOnShutdown ) );
+    otaAgent.imageState = OtaImageStateUnknown;
+
     return OtaErrNone;
 }
 
@@ -3393,9 +3407,8 @@ OtaErr_t OTA_ActivateNewImage( void )
     LogError( ( "Failed to activate new image: "
                 "activateNewImage returned error: "
                 "Manual reset required: "
-                "OtaPalStatus_t=%s, %d",
-                OTA_PalStatus_strerror( OTA_PAL_MAIN_ERR( palStatus ) ),
-                OTA_PAL_MAIN_ERR( palStatus ) ) );
+                "OtaPalStatus_t=%s",
+                OTA_PalStatus_strerror( OTA_PAL_MAIN_ERR( palStatus ) ) ) );
 
     return OTA_PAL_MAIN_ERR( palStatus ) == OtaPalSuccess ? OtaErrNone : OtaErrActivateFailed;
 }

--- a/source/ota.c
+++ b/source/ota.c
@@ -3169,7 +3169,7 @@ static void resetEventQueue( void )
     {
         LogWarn( ( "Event(%d) is dropped.\r\n", eventMsg.eventId ) );
 
-        /* Call handleUnexpectedEvents to notify user to release resources if neccessary. */
+        /* Call handleUnexpectedEvents to notify user to release resources if necessary. */
         handleUnexpectedEvents( &eventMsg );
     }
 }

--- a/source/ota.c
+++ b/source/ota.c
@@ -3001,17 +3001,13 @@ static void callOtaCallback( OtaJobEvent_t eEvent,
 
 void OTA_EventProcessingTask( void * pUnused )
 {
-    bool retVal = true;
-
     ( void ) pUnused;
 
     if( otaAgent.state == OtaAgentStateStopped )
     {
-        retVal = false;
         LogWarn( ( "Run OTA_EventProcessingTask but OTA is stopped." ) );
     }
-
-    if( retVal )
+    else
     {
         /*
          * OTA Agent is ready to receive and process events so update the state to ready.
@@ -3027,18 +3023,18 @@ void OTA_EventProcessingTask( void * pUnused )
 
 bool OTA_SignalEvent( const OtaEventMsg_t * const pEventMsg )
 {
-    bool retVal = true;
+    bool retVal = false;
     OtaOsStatus_t err = OtaOsSuccess;
 
-    /* Check if OTA library is ready.*/
+    /* Check if OTA library is initialized. */
     if( otaAgent.state == OtaAgentStateStopped )
     {
         retVal = false;
+        LogDebug( ( "Send event failed, OTA is stopped." ) );
     }
-
-    if( retVal )
+    else
     {
-        /* Check if file block received and update statistics.*/
+        /* Check if file block received and update statistics. */
         if( pEventMsg->eventId == OtaAgentEventReceivedFileBlock )
         {
             otaAgent.statistics.otaPacketsReceived++;

--- a/source/ota.c
+++ b/source/ota.c
@@ -3229,7 +3229,7 @@ OtaErr_t OTA_Init( OtaAppBuffer_t * pOtaBuffer,
         }
         else
         {
-            /* Drop all msgs that created after OTA_Shutdown. */
+            /* Drop all events that created after OTA_Shutdown. */
             while( otaAgent.pOtaInterface->os.event.recv( NULL, &eventMsg, 0 ) == OtaOsSuccess )
             {
                 LogDebug( ( "Event(%d) is dropped.\r\n", eventMsg.eventId ) );

--- a/source/ota.c
+++ b/source/ota.c
@@ -2987,16 +2987,27 @@ static void callOtaCallback( OtaJobEvent_t eEvent,
 
 void OTA_EventProcessingTask( void * pUnused )
 {
+    bool retVal = true;
+
     ( void ) pUnused;
 
-    /*
-     * OTA Agent is ready to receive and process events so update the state to ready.
-     */
-    otaAgent.state = OtaAgentStateReady;
-
-    while( otaAgent.state != OtaAgentStateStopped )
+    if( otaAgent.state == OtaAgentStateStopped )
     {
-        receiveAndProcessOtaEvent();
+        retVal = false;
+        LogWarn( ( "Run OTA_EventProcessingTask but OTA is stopped." ) );
+    }
+
+    if( retVal )
+    {
+        /*
+         * OTA Agent is ready to receive and process events so update the state to ready.
+         */
+        otaAgent.state = OtaAgentStateReady;
+
+        while( otaAgent.state != OtaAgentStateStopped )
+        {
+            receiveAndProcessOtaEvent();
+        }
     }
 }
 

--- a/source/portable/os/ota_os_freertos.c
+++ b/source/portable/os/ota_os_freertos.c
@@ -144,10 +144,13 @@ OtaOsStatus_t OtaReceiveEvent_FreeRTOS( OtaEventContext_t * pEventCtx,
     {
         otaOsStatus = OtaOsEventQueueReceiveFailed;
 
-        LogError( ( "Failed to receive event from OTA Event Queue: "
-                    "xQueueReceive returned error: "
-                    "OtaOsStatus_t=%i ",
-                    otaOsStatus ) );
+        if( retVal != errQUEUE_EMPTY )
+        {
+            LogError( ( "Failed to receive event from OTA Event Queue: "
+                        "xQueueReceive returned error: "
+                        "OtaOsStatus_t=%i ",
+                        otaOsStatus ) );
+        }
     }
 
     return otaOsStatus;

--- a/source/portable/os/ota_os_freertos.c
+++ b/source/portable/os/ota_os_freertos.c
@@ -131,9 +131,8 @@ OtaOsStatus_t OtaReceiveEvent_FreeRTOS( OtaEventContext_t * pEventCtx,
     uint8_t buff[ sizeof( OtaEventMsg_t ) ];
 
     ( void ) pEventCtx;
-    ( void ) timeout;
 
-    retVal = xQueueReceive( otaEventQueue, &buff, portMAX_DELAY );
+    retVal = xQueueReceive( otaEventQueue, &buff, pdMS_TO_TICKS( timeout ) );
 
     if( retVal == pdTRUE )
     {

--- a/source/portable/os/ota_os_freertos.c
+++ b/source/portable/os/ota_os_freertos.c
@@ -144,13 +144,10 @@ OtaOsStatus_t OtaReceiveEvent_FreeRTOS( OtaEventContext_t * pEventCtx,
     {
         otaOsStatus = OtaOsEventQueueReceiveFailed;
 
-        if( retVal != errQUEUE_EMPTY )
-        {
-            LogError( ( "Failed to receive event from OTA Event Queue: "
-                        "xQueueReceive returned error: "
-                        "OtaOsStatus_t=%i ",
-                        otaOsStatus ) );
-        }
+        LogError( ( "Failed to receive event or timeout from OTA Event Queue: "
+                    "xQueueReceive returned error: "
+                    "OtaOsStatus_t=%i ",
+                    otaOsStatus ) );
     }
 
     return otaOsStatus;

--- a/source/portable/os/ota_os_freertos.c
+++ b/source/portable/os/ota_os_freertos.c
@@ -144,7 +144,7 @@ OtaOsStatus_t OtaReceiveEvent_FreeRTOS( OtaEventContext_t * pEventCtx,
     {
         otaOsStatus = OtaOsEventQueueReceiveFailed;
 
-        LogError( ( "Failed to receive event or timeout from OTA Event Queue: "
+        LogDebug( ( "Failed to receive event or timeout from OTA Event Queue: "
                     "xQueueReceive returned error: "
                     "OtaOsStatus_t=%i ",
                     otaOsStatus ) );

--- a/test/cbmc/proofs/OTA_Init/Makefile
+++ b/test/cbmc/proofs/OTA_Init/Makefile
@@ -5,8 +5,6 @@ HARNESS_FILE = $(HARNESS_ENTRY)
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
 PROOF_UID = OTA_Init
 
-DEFINES += -D UNWINDING_UPPERBOUND=10
-
 INCLUDES += -I$(SRCDIR)/source/dependency/coreJSON/source/include/
 INCLUDES += -I$(SRCDIR)/source/
 
@@ -16,6 +14,7 @@ PROJECT_SOURCES += $(SRCDIR)/source/ota.c
 NONDET_STATIC += "--nondet-static"
 
 UNWINDSET += strlen.0:66
+UNWINDSET += recv.0:10
 
 REMOVE_FUNCTION_BODY += setControlInterface
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_ota_c_initializeAppBuffers

--- a/test/cbmc/proofs/OTA_Init/Makefile
+++ b/test/cbmc/proofs/OTA_Init/Makefile
@@ -14,7 +14,7 @@ PROJECT_SOURCES += $(SRCDIR)/source/ota.c
 NONDET_STATIC += "--nondet-static"
 
 UNWINDSET += strlen.0:66
-UNWINDSET += recv.0:10
+UNWINDSET += OTA_Init.0:10
 
 REMOVE_FUNCTION_BODY += setControlInterface
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_ota_c_initializeAppBuffers

--- a/test/cbmc/proofs/OTA_Init/Makefile
+++ b/test/cbmc/proofs/OTA_Init/Makefile
@@ -5,6 +5,8 @@ HARNESS_FILE = $(HARNESS_ENTRY)
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
 PROOF_UID = OTA_Init
 
+DEFINES += -D UNWINDING_UPPERBOUND=10
+
 INCLUDES += -I$(SRCDIR)/source/dependency/coreJSON/source/include/
 INCLUDES += -I$(SRCDIR)/source/
 

--- a/test/cbmc/proofs/OTA_Init/OTA_Init_harness.c
+++ b/test/cbmc/proofs/OTA_Init/OTA_Init_harness.c
@@ -35,6 +35,15 @@ OtaOsStatus_t init( OtaEventContext_t * pEventCtx )
     return status;
 }
 
+OtaOsStatus_t recv( OtaEventContext_t * pEventCtx,
+                    void * pEventMsg,
+                    uint32_t timeout )
+{
+    OtaOsStatus_t status;
+
+    return status;
+}
+
 void OTA_Init_harness()
 {
     OtaErr_t err;
@@ -46,6 +55,9 @@ void OTA_Init_harness()
 
     /* Initialize the function pointer to a stub. */
     otaInterface.os.event.init = init;
+
+    /* Initialize the function pointer to a stub. */
+    otaInterface.os.event.recv = recv;
 
     /* The maximum size of a valid name of a thing is defined by otaconfigMAX_THINGNAME_LEN. The upper bound
      * of size is selected to consider the cases where size of the string is greater than maximum value. */

--- a/test/cbmc/proofs/OTA_Shutdown/Makefile
+++ b/test/cbmc/proofs/OTA_Shutdown/Makefile
@@ -18,11 +18,6 @@ PROJECT_SOURCES += $(SRCDIR)/source/ota.c
 
 REMOVE_FUNCTION_BODY += OTA_SignalEvent
 
-RESTRICT_FUNCTION_POINTER += OTA_Shutdown.function_pointer_call.1/stopTimerStub
-RESTRICT_FUNCTION_POINTER += OTA_Shutdown.function_pointer_call.2/deleteTimerStub
-RESTRICT_FUNCTION_POINTER += OTA_Shutdown.function_pointer_call.3/stopTimerStub
-RESTRICT_FUNCTION_POINTER += OTA_Shutdown.function_pointer_call.4/deleteTimerStub
-
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will
 # restrict the number of EXPENSIVE CBMC jobs running at once. See the

--- a/test/cbmc/proofs/OTA_Shutdown/OTA_Shutdown_harness.c
+++ b/test/cbmc/proofs/OTA_Shutdown/OTA_Shutdown_harness.c
@@ -39,10 +39,6 @@ void OTA_Shutdown_harness()
 
     otaAgent.state = state;
 
-    /* Initialize os timers functions. */
-    otaInterface.os.timer.stop = stopTimerStub;
-    otaInterface.os.timer.delete = deleteTimerStub;
-
     otaAgent.pOtaInterface = &otaInterface;
 
     /* This assumption is required to have an upper bound on the unwinding of while loop in

--- a/test/cbmc/proofs/OTA_Shutdown/OTA_Shutdown_harness.c
+++ b/test/cbmc/proofs/OTA_Shutdown/OTA_Shutdown_harness.c
@@ -39,8 +39,6 @@ void OTA_Shutdown_harness()
 
     otaAgent.state = state;
 
-    otaAgent.pOtaInterface = &otaInterface;
-
     /* This assumption is required to have an upper bound on the unwinding of while loop in
      * OTA_Shutdown. This does not model the exact behavior of the code since the limitation of CBMC
      * is that it checks concurrent code in sequential manner.*/

--- a/test/cbmc/proofs/OtaReceiveEvent_FreeRTOS/OtaReceiveEvent_FreeRTOS_harness.c
+++ b/test/cbmc/proofs/OtaReceiveEvent_FreeRTOS/OtaReceiveEvent_FreeRTOS_harness.c
@@ -27,6 +27,7 @@
 /*  FreeRTOS includes for OTA library. */
 #include "ota_os_freertos.h"
 #include "ota_private.h"
+#include "FreeRTOSConfig.h"
 
 void OtaReceiveEvent_FreeRTOS_harness()
 {

--- a/test/cbmc/proofs/OtaReceiveEvent_FreeRTOS/OtaReceiveEvent_FreeRTOS_harness.c
+++ b/test/cbmc/proofs/OtaReceiveEvent_FreeRTOS/OtaReceiveEvent_FreeRTOS_harness.c
@@ -40,6 +40,9 @@ void OtaReceiveEvent_FreeRTOS_harness()
     /* pEventMsg is statically declared before it is used in this function. */
     __CPROVER_assume( pEventMsg != NULL );
 
+    /* To avoid pdMS_TO_TICKS from integer overflow. */
+    __CPROVER_assume( timeout < ( UINT32_MAX / ( configTICK_RATE_HZ ) ) );
+
     osStatus = OtaReceiveEvent_FreeRTOS( pEventCtx, pEventMsg, timeout );
 
     __CPROVER_assert( osStatus == OtaOsSuccess || osStatus == OtaOsEventQueueReceiveFailed,

--- a/test/cbmc/proofs/agentShutdownCleanup/Makefile
+++ b/test/cbmc/proofs/agentShutdownCleanup/Makefile
@@ -21,8 +21,12 @@ REMOVE_FUNCTION_BODY += otaClose
 # The upper bound on the for loop in agentShutdownCLeanup is set by OTA_MAX_FILES.
 UNWINDSET += agentShutdownCleanup.0:2
 
-RESTRICT_FUNCTION_POINTER += agentShutdownCleanup.function_pointer_call.1/cleanupStub
-RESTRICT_FUNCTION_POINTER += agentShutdownCleanup.function_pointer_call.2/cleanupStub
+RESTRICT_FUNCTION_POINTER += agentShutdownCleanup.function_pointer_call.1/stopTimerStub
+RESTRICT_FUNCTION_POINTER += agentShutdownCleanup.function_pointer_call.2/deleteTimerStub
+RESTRICT_FUNCTION_POINTER += agentShutdownCleanup.function_pointer_call.3/stopTimerStub
+RESTRICT_FUNCTION_POINTER += agentShutdownCleanup.function_pointer_call.4/deleteTimerStub
+RESTRICT_FUNCTION_POINTER += agentShutdownCleanup.function_pointer_call.5/cleanupStub
+RESTRICT_FUNCTION_POINTER += agentShutdownCleanup.function_pointer_call.6/cleanupStub
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/test/cbmc/proofs/agentShutdownCleanup/agentShutdownCleanup_harness.c
+++ b/test/cbmc/proofs/agentShutdownCleanup/agentShutdownCleanup_harness.c
@@ -32,6 +32,7 @@
 /* Global static variable defined in ota.c for managing the state machine. */
 extern OtaControlInterface_t otaControlInterface;
 extern OtaDataInterface_t otaDataInterface;
+extern OtaAgentContext_t otaAgent;
 extern void agentShutdownCleanup( void );
 
 void agentShutdownCleanup_harness()
@@ -41,6 +42,8 @@ void agentShutdownCleanup_harness()
     /* Initialize os timers functions. */
     otaInterface.os.timer.stop = stopTimerStub;
     otaInterface.os.timer.delete = deleteTimerStub;
+
+    otaAgent.pOtaInterface = &otaInterface;
 
     /* Initialize the function pointers to stubs. */
     otaControlInterface.cleanup = cleanupStub;

--- a/test/cbmc/proofs/agentShutdownCleanup/agentShutdownCleanup_harness.c
+++ b/test/cbmc/proofs/agentShutdownCleanup/agentShutdownCleanup_harness.c
@@ -38,6 +38,10 @@ void agentShutdownCleanup_harness()
 {
     OtaInterfaces_t otaInterface;
 
+    /* Initialize os timers functions. */
+    otaInterface.os.timer.stop = stopTimerStub;
+    otaInterface.os.timer.delete = deleteTimerStub;
+
     /* Initialize the function pointers to stubs. */
     otaControlInterface.cleanup = cleanupStub;
     otaDataInterface.cleanup = cleanupStub;

--- a/test/cbmc/proofs/resetEventQueue/Makefile
+++ b/test/cbmc/proofs/resetEventQueue/Makefile
@@ -1,9 +1,9 @@
-HARNESS_ENTRY = OTA_Init_harness
+HARNESS_ENTRY = resetEventQueue_harness
 HARNESS_FILE = $(HARNESS_ENTRY)
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
-PROOF_UID = OTA_Init
+PROOF_UID = resetEventQueue
 
 INCLUDES += -I$(SRCDIR)/source/dependency/coreJSON/source/include/
 INCLUDES += -I$(SRCDIR)/source/
@@ -13,14 +13,7 @@ PROJECT_SOURCES += $(SRCDIR)/source/ota.c
 
 NONDET_STATIC += "--nondet-static"
 
-UNWINDSET += strlen.0:66
-
-REMOVE_FUNCTION_BODY += setControlInterface
-REMOVE_FUNCTION_BODY += __CPROVER_file_local_ota_c_initializeAppBuffers
-REMOVE_FUNCTION_BODY += __CPROVER_file_local_ota_c_initializeLocalBuffers
-REMOVE_FUNCTION_BODY += __CPROVER_file_local_ota_c_resetEventQueue
-
-RESTRICT_FUNCTION_POINTER += OTA_Init.function_pointer_call.1/init 
+UNWINDSET += recv.0:10
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/test/cbmc/proofs/resetEventQueue/README.md
+++ b/test/cbmc/proofs/resetEventQueue/README.md
@@ -1,0 +1,20 @@
+resetEventQueue proof
+==============
+
+This directory contains a memory safety proof for resetEventQueue.
+
+To run the proof.
+-------------
+
+* Add `cbmc`, `goto-cc`, `goto-instrument`, `goto-analyzer`, and `cbmc-viewer`
+  to your path.
+* Run `make`.
+* Open html/index.html in a web browser.
+
+To use [`arpa`](https://github.com/awslabs/aws-proof-build-assistant) to simplify writing Makefiles.
+-------------
+
+* Run `make arpa` to generate a Makefile.arpa that contains relevant build information for the proof.
+* Use Makefile.arpa as the starting point for your proof Makefile by:
+  1. Modifying Makefile.arpa (if required).
+  2. Including Makefile.arpa into the existing proof Makefile (add `sinclude Makefile.arpa` at the bottom of the Makefile, right before `include ../Makefile.common`).

--- a/test/cbmc/proofs/resetEventQueue/cbmc-proof.txt
+++ b/test/cbmc/proofs/resetEventQueue/cbmc-proof.txt
@@ -1,0 +1,2 @@
+# This file marks this directory as containing a CBMC proof.
+# This file is required by the run-cbmc-proofs.py to differentiate between a proof directory from a normal directory.

--- a/test/cbmc/proofs/resetEventQueue/cbmc-viewer.json
+++ b/test/cbmc/proofs/resetEventQueue/cbmc-viewer.json
@@ -1,0 +1,6 @@
+{ "expected-missing-functions":
+  [
+  ],
+  "proof-name": "resetEventQueue",
+  "proof-root": "test/cbmc/proofs"
+}

--- a/test/cbmc/proofs/resetEventQueue/resetEventQueue_harness.c
+++ b/test/cbmc/proofs/resetEventQueue/resetEventQueue_harness.c
@@ -21,48 +21,28 @@
  */
 
 /**
- * @file OTA_Init_harness.c
- * @brief Implements the proof harness for OTA_Init function.
+ * @file resetEventQueue_harness.c
+ * @brief Implements the proof harness for resetEventQueue function.
  */
 /* Include headers for ota agent. */
 #include "ota.h"
 #include <stdlib.h>
 
-OtaOsStatus_t init( OtaEventContext_t * pEventCtx )
+OtaOsStatus_t recv( OtaEventContext_t * pEventCtx,
+                    void * pEventMsg,
+                    uint32_t timeout )
 {
     OtaOsStatus_t status;
 
     return status;
 }
 
-void OTA_Init_harness()
+void resetEventQueue_harness()
 {
-    OtaErr_t err;
-    OtaAppBuffer_t otaBuffer;
     OtaInterfaces_t otaInterface;
-    uint8_t * pThingName;
-    OtaAppCallback_t otaAppCallback;
-    size_t size;
 
     /* Initialize the function pointer to a stub. */
-    otaInterface.os.event.init = init;
+    otaInterface.os.event.recv = recv;
 
-    /* The maximum size of a valid name of a thing is defined by otaconfigMAX_THINGNAME_LEN. The upper bound
-     * of size is selected to consider the cases where size of the string is greater than maximum value. */
-    __CPROVER_assume( size > 0 && size <= otaconfigMAX_THINGNAME_LEN + 1 );
-
-    pThingName = ( uint8_t * ) malloc( sizeof( uint8_t ) * size );
-
-    /* pThingName is a string and should end with a NULL character. */
-    if( pThingName != NULL )
-    {
-        pThingName[ size - 1 ] = '\0';
-    }
-
-    err = OTA_Init( &otaBuffer, &otaInterface, pThingName, otaAppCallback );
-
-    /* OTA_Init must always return either OtaErrNone or OtaErrUninitialized. */
-    __CPROVER_assert( ( err == OtaErrNone ) || ( err == OtaErrUninitialized ), "Invalid Return value: Expected OtaErrNone" );
-
-    free( pThingName );
+    resetEventQueue();
 }

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -96,6 +96,11 @@
 
 #define OTA_NUM_MSG_Q_ENTRIES    20
 
+/**
+ * @brief Offset helper.
+ */
+#define U16_OFFSET( type, member )    ( ( uint16_t ) offsetof( type, member ) )
+
 /* Firmware version. */
 const AppVersion32_t appFirmwareVersion =
 {
@@ -3282,7 +3287,7 @@ void test_OTA_extractParameterFailInvalidJobDocModel()
     bool updateJob = false;
     JsonDocParam_t otaCustomJobDocModelParamStructure[ 1 ] =
     {
-        { OTA_JSON_JOB_ID_KEY, OTA_JOB_PARAM_REQUIRED, *otaAgent.fileContext.pJobName, otaAgent.fileContext.jobNameMaxSize, UINT16_MAX },
+        { OTA_JSON_JOB_ID_KEY, OTA_JOB_PARAM_REQUIRED, U16_OFFSET( OtaFileContext_t, pJobName ), U16_OFFSET( OtaFileContext_t, jobNameMaxSize ), UINT16_MAX },
     };
 
     /* The document structure has an invalid value for ModelParamType_t. */

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -1347,7 +1347,7 @@ void test_OTA_ActivateNewImage()
  * should fail. */
 void test_OTA_ActivateNewImageWhenStopped()
 {
-    TEST_ASSERT_NOT_EQUAL( OtaErrNone, OTA_ActivateNewImage() );
+    TEST_ASSERT_NOT_EQUAL( OtaErrActivateFailed, OTA_ActivateNewImage() );
 }
 
 void test_OTA_ActivateNewImageNullPalActivate()

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -2513,6 +2513,11 @@ void test_OTA_EventProcessingTask_ExitOnAbort()
     /* Test that the OTA_EventProcessingTask aborts correctly after receiving
      * and event to shutdown the OTA Agent. */
     TEST_ASSERT_EQUAL( OtaAgentStateStopped, OTA_GetState() );
+
+    /* Run OTA_EventProcessingTask again and OTA state should keep in OtaAgentStateStopped. */
+    OTA_EventProcessingTask( NULL );
+
+    TEST_ASSERT_EQUAL( OtaAgentStateStopped, OTA_GetState() );
 }
 
 /* ========================================================================== */

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -1277,7 +1277,7 @@ void test_OTA_ActivateNewImageNullOtaInterface()
     otaInitDefault();
     TEST_ASSERT_EQUAL( OtaAgentStateInit, OTA_GetState() );
 
-    /* Set OTA interface to NULL.*/
+    /* Set OTA interface to NULL. */
     otaAgent.pOtaInterface = NULL;
 
     TEST_ASSERT_EQUAL( OtaErrActivateFailed, OTA_ActivateNewImage() );
@@ -3086,7 +3086,7 @@ void test_OTA_nullOtaInterfaceWhenProcessEvent()
     otaGoToState( OtaAgentStateReady );
     TEST_ASSERT_EQUAL( OtaAgentStateReady, OTA_GetState() );
 
-    /* Set OTA interface to NULL.*/
+    /* Set OTA interface to NULL. */
     otaAgent.pOtaInterface = NULL;
 
     receiveAndProcessOtaEvent();
@@ -3113,7 +3113,7 @@ void test_OTA_sendEventWhenStopped()
 /* Re-start OTA library after shutdown. */
 void test_OTA_restartOtaAfterShutdown()
 {
-    /* First initialize OTA library */
+    /* First initialize OTA library. */
     otaInitDefault();
     otaGoToState( OtaAgentStateReady );
     TEST_ASSERT_EQUAL( OtaAgentStateReady, OTA_GetState() );
@@ -3122,7 +3122,7 @@ void test_OTA_restartOtaAfterShutdown()
     tearDown();
     TEST_ASSERT_EQUAL( OtaAgentStateStopped, OTA_GetState() );
 
-    /* Second initialize OTA library */
+    /* Second initialize OTA library. */
     setUp();
     otaInitDefault();
     otaGoToState( OtaAgentStateReady );

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -750,6 +750,7 @@ requestjobhandler
 requestmomentum
 requesttimercallback
 resetdevice
+reseteventqueue 
 resumehandler
 retryutilsretriesexhausted
 retryutilssuccess

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -278,6 +278,7 @@ ip
 ip
 isinselftest
 iso
+isotainterfaceinited
 jobcallback
 jobdoc
 jobdoclength

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -750,7 +750,7 @@ requestjobhandler
 requestmomentum
 requesttimercallback
 resetdevice
-reseteventqueue 
+reseteventqueue
 resumehandler
 retryutilsretriesexhausted
 retryutilssuccess


### PR DESCRIPTION
<!--- Title -->
Keep event/callback functions pointer in OTA_Shutdown to avoid accessing NULL pointer.

Description
-----------
<!--- Describe your changes in detail -->
For #218 , we need a method to make sure there is no NULL function pointer.
1. Check if OTA initialized in public API OTA_SignalEvent and OTA_EventProcessingTask.
2. Do not erase the functions pointer, pOtaInterface and OtaAppCallback, in OTA_Shutdown.
3. Only create event queue in the first OTA_Init() --> so we don't need to deinit it for #217 
4. Only change the OTA state in task running OTA_EventProcessingTask. --> fix #219 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is formatted using Uncrustify.
- [x] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.