### PR TITLE
Feature: Add user callable agent cycler

### DIFF
--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -9,8 +9,8 @@
     </tr>
     <tr>
         <td>ota.c</td>
-        <td><center>8.1K</center></td>
-        <td><center>7.3K</center></td>
+        <td><center>8.2K</center></td>
+        <td><center>7.4K</center></td>
     </tr>
     <tr>
         <td>ota_interface.c</td>
@@ -39,7 +39,7 @@
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>12.3K</center></b></td>
-        <td><b><center>11.1K</center></b></td>
+        <td><b><center>12.4K</center></b></td>
+        <td><b><center>11.2K</center></b></td>
     </tr>
 </table>

--- a/source/include/ota.h
+++ b/source/include/ota.h
@@ -309,7 +309,6 @@ typedef struct OtaAgentContext
     const OtaInterfaces_t * pOtaInterface;                 /*!< Collection of all interfaces used by the agent. */
     OtaAppCallback_t OtaAppCallback;                       /*!< OTA App callback. */
     uint8_t unsubscribeOnShutdown;                         /*!< Flag to indicate if unsubscribe from job topics should be done at shutdown. */
-    bool agentStarted;                                     /*!< Flag indicating whether OTA agent has begun processing. */
 } OtaAgentContext_t;
 
 /*------------------------- OTA Public API --------------------------*/
@@ -681,13 +680,11 @@ void OTA_EventProcessingTask( void * pUnused );
  *
  * @note This is NOT thread safe with @ref OTA_EventProcessingTask and the two should never be used in conjunction.
  *
- * @param[in] pUnused Can be used to pass down functionality to the agent task, Unused for now.
- *
  * @return The state of the ota agent after this single event process cycle
  *
  */
 /* @[declare_ota_eventprocess] */
-OtaState_t OTA_EventProcess( void * pUnused );
+OtaState_t OTA_EventProcess( void );
 /* @[declare_ota_eventprocess] */
 
 /**

--- a/source/include/ota.h
+++ b/source/include/ota.h
@@ -309,6 +309,7 @@ typedef struct OtaAgentContext
     const OtaInterfaces_t * pOtaInterface;                 /*!< Collection of all interfaces used by the agent. */
     OtaAppCallback_t OtaAppCallback;                       /*!< OTA App callback. */
     uint8_t unsubscribeOnShutdown;                         /*!< Flag to indicate if unsubscribe from job topics should be done at shutdown. */
+    bool agentStarted;                                     /*!< Flag indicating whether OTA agent has begun processing. */
 } OtaAgentContext_t;
 
 /*------------------------- OTA Public API --------------------------*/
@@ -670,6 +671,24 @@ OtaErr_t OTA_Resume( void );
 void OTA_EventProcessingTask( void * pUnused );
 /* @[declare_ota_eventprocessingtask] */
 
+
+/**
+ * @brief OTA agent event process cycler.
+ *
+ * This is the main agent event handler for OTA update and needs to be called repeatedly
+ * by an application task. This is functionally equivalent to @ref OTA_EventProcessingTask, except
+ * instead of forever looping internally, the user is responsible for periodically calling this function.
+ *
+ * @note This is NOT thread safe with @ref OTA_EventProcessingTask and the two should never be used in conjuction.
+ *
+ * @param[in] pUnused Can be used to pass down functionality to the agent task, Unused for now.
+ *
+ * @return The state of the ota agent after this single event process cycle
+ *
+ */
+/* @[declare_ota_eventprocess] */
+OtaState_t OTA_EventProcess( void * pUnused );
+/* @[declare_ota_eventprocess] */
 
 /**
  * @brief Signal event to the OTA Agent task.

--- a/source/include/ota.h
+++ b/source/include/ota.h
@@ -679,7 +679,7 @@ void OTA_EventProcessingTask( void * pUnused );
  * by an application task. This is functionally equivalent to @ref OTA_EventProcessingTask, except
  * instead of forever looping internally, the user is responsible for periodically calling this function.
  *
- * @note This is NOT thread safe with @ref OTA_EventProcessingTask and the two should never be used in conjuction.
+ * @note This is NOT thread safe with @ref OTA_EventProcessingTask and the two should never be used in conjunction.
  *
  * @param[in] pUnused Can be used to pass down functionality to the agent task, Unused for now.
  *

--- a/source/ota.c
+++ b/source/ota.c
@@ -511,8 +511,7 @@ static OtaAgentContext_t otaAgent =
     0,                    /* requestMomentum */
     NULL,                 /* pOtaInterface */
     NULL,                 /* OtaAppCallback */
-    1,                    /* unsubscribe flag */
-    false                 /* agentStarted flag */
+    1                     /* unsubscribe flag */
 };
 
 /**
@@ -2973,7 +2972,6 @@ void OTA_EventProcessingTask( void * pUnused )
      * OTA Agent is ready to receive and process events so update the state to ready.
      */
     otaAgent.state = OtaAgentStateReady;
-    otaAgent.agentStarted = true;
 
     while( otaAgent.state != OtaAgentStateStopped )
     {
@@ -2981,16 +2979,15 @@ void OTA_EventProcessingTask( void * pUnused )
     }
 }
 
-OtaState_t OTA_EventProcess( void * pUnused )
+OtaState_t OTA_EventProcess( void )
 {
-    ( void ) pUnused;
-
-    /* Since user can single cycle the agent, we cannot repeatedly change state back to OtaAgentStateReady
-     * as it may interfere with an ongoing OTA. However, OtaAgentStateReady must still indicate agent readiness.*/
-    if( !otaAgent.agentStarted )
+    /* Technically, setting readiness on this condition does not match conditions which EventProcessingTask
+     * sets readiness, as this function only sets readiness with preceding call to OTA_Init, whereas
+     * EventProcessingTask does not, and sets readiness independent of OTA_Init.
+     */
+    if( otaAgent.state == OtaAgentStateInit )
     {
         otaAgent.state = OtaAgentStateReady;
-        otaAgent.agentStarted = true;
     }
 
     if( otaAgent.state != OtaAgentStateStopped )

--- a/source/ota.c
+++ b/source/ota.c
@@ -2981,9 +2981,9 @@ void OTA_EventProcessingTask( void * pUnused )
 
 OtaState_t OTA_EventProcess( void )
 {
-    /* Technically, setting readiness on this condition does not match conditions which EventProcessingTask
+    /* Technically, setting readiness on this condition does not match conditions which OTA_EventProcessingTask
      * sets readiness, as this function only sets readiness with preceding call to OTA_Init, whereas
-     * EventProcessingTask does not, and sets readiness independent of OTA_Init.
+     * OTA_EventProcessingTask does not, and sets readiness independent of OTA_Init.
      */
     if( otaAgent.state == OtaAgentStateInit )
     {

--- a/source/ota.c
+++ b/source/ota.c
@@ -2985,7 +2985,7 @@ OtaState_t OTA_EventProcess( void * pUnused )
 {
     ( void ) pUnused;
 
-     /* Since user can single cycle the agent, we cannot repeatedly change state back to OtaAgentStateReady
+    /* Since user can single cycle the agent, we cannot repeatedly change state back to OtaAgentStateReady
      * as it may interfere with an ongoing OTA. However, OtaAgentStateReady must still indicate agent readiness.*/
     if( !otaAgent.agentStarted )
     {

--- a/test/cbmc/proofs/OTA_EventProcess/Makefile
+++ b/test/cbmc/proofs/OTA_EventProcess/Makefile
@@ -1,0 +1,26 @@
+
+HARNESS_ENTRY = OTA_EventProcess_harness
+HARNESS_FILE = $(HARNESS_ENTRY)
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = OTA_EventProcess
+
+DEFINES += -Dstatic=""
+DEFINES += -D UNWINDING_UPPERBOUND=4
+
+INCLUDES += -I$(SRCDIR)/source/dependency/coreJSON/source/include/
+INCLUDES += -I$(SRCDIR)/source/
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/source/ota.c
+
+UNWINDSET += OTA_EventProcessTask.0:26
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+include ../Makefile.common

--- a/test/cbmc/proofs/OTA_EventProcess/OTA_EventProcess_harness.c
+++ b/test/cbmc/proofs/OTA_EventProcess/OTA_EventProcess_harness.c
@@ -1,0 +1,60 @@
+/*
+ * AWS IoT Over-the-air Update v3.3.0
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file OTA_EventProcess_harness.c
+ * @brief Implements the proof harness for OTA_EventProcess function.
+ */
+/* Include headers for ota agent. */
+#include "ota.h"
+
+extern OtaAgentContext_t otaAgent;
+
+int counter = 0;
+
+void receiveAndProcessOtaEvent( void )
+{
+    OtaState_t state;
+
+    /* state must only have values of OtaState_t enum type. */
+    __CPROVER_assume( state <= OtaAgentStateNoTransition && state >= OtaAgentStateAll );
+
+    if( counter++ == UNWINDING_UPPERBOUND )
+    {
+        otaAgent.state = OtaAgentStateStopped;
+    }
+    else
+    {
+        otaAgent.state = state;
+    }
+}
+
+void OTA_EventProcess_harness()
+{
+    OtaState_t state;
+    void * pUnused;
+
+    do
+    {
+        state = OTA_EventProcess( pUnused );
+    } while( state != OtaAgentStateStopped );
+}

--- a/test/cbmc/proofs/OTA_EventProcess/OTA_EventProcess_harness.c
+++ b/test/cbmc/proofs/OTA_EventProcess/OTA_EventProcess_harness.c
@@ -51,10 +51,9 @@ void receiveAndProcessOtaEvent( void )
 void OTA_EventProcess_harness()
 {
     OtaState_t state;
-    void * pUnused;
 
     do
     {
-        state = OTA_EventProcess( pUnused );
+        state = OTA_EventProcess();
     } while( state != OtaAgentStateStopped );
 }

--- a/test/cbmc/proofs/OTA_EventProcess/README.md
+++ b/test/cbmc/proofs/OTA_EventProcess/README.md
@@ -1,0 +1,20 @@
+OTA_EventProcess proof
+==============
+
+This directory contains a memory safety proof for OTA_EventProcess.
+
+To run the proof.
+-------------
+
+* Add `cbmc`, `goto-cc`, `goto-instrument`, `goto-analyzer`, and `cbmc-viewer`
+  to your path.
+* Run `make`.
+* Open html/index.html in a web browser.
+
+To use [`arpa`](https://github.com/awslabs/aws-proof-build-assistant) to simplify writing Makefiles.
+-------------
+
+* Run `make arpa` to generate a Makefile.arpa that contains relevant build information for the proof.
+* Use Makefile.arpa as the starting point for your proof Makefile by:
+  1. Modifying Makefile.arpa (if required).
+  2. Including Makefile.arpa into the existing proof Makefile (add `sinclude Makefile.arpa` at the bottom of the Makefile, right before `include ../Makefile.common`).

--- a/test/cbmc/proofs/OTA_EventProcess/cbmc-proof.txt
+++ b/test/cbmc/proofs/OTA_EventProcess/cbmc-proof.txt
@@ -1,0 +1,2 @@
+# This file marks this directory as containing a CBMC proof.
+# This file is required by the run-cbmc-proofs.py to differentiate between a proof directory from a normal directory.

--- a/test/cbmc/proofs/OTA_EventProcess/cbmc-viewer.json
+++ b/test/cbmc/proofs/OTA_EventProcess/cbmc-viewer.json
@@ -1,0 +1,6 @@
+{ "expected-missing-functions":
+  [
+  ],
+  "proof-name": "OTA_EventProcess",
+  "proof-root": "test/cbmc/proofs"
+}

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -2609,7 +2609,7 @@ void test_OTA_EventProcess_WhileStopped()
 {
     /* Reset to known state */
     OtaEventMsg_t otaEvent = { 0 };
-    OtaEventMsg_t * ulQueueEndBefore = NULL; //otaEventQueueEnd;
+    OtaEventMsg_t * ulQueueEndBefore = NULL; /*otaEventQueueEnd; */
 
     otaGoToState( OtaAgentStateReady );
     otaEvent.eventId = OtaAgentEventShutdown;
@@ -2633,8 +2633,6 @@ void test_OTA_EventProcess_WhileStopped()
 void test_OTA_EventProcess_AgentUpdatesReadiness()
 {
     /* Reset to known state */
-    OtaEventMsg_t otaEvent = { 0 };
-
     otaAgent.agentStarted = false;
     otaInterfaces.os.event.send = mockOSEventSend;
     otaInitDefault();

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -2609,7 +2609,7 @@ void test_OTA_EventProcess_WhileStopped()
 {
     /* Reset to known state */
     OtaEventMsg_t otaEvent = { 0 };
-    OtaEventMsg_t * ulQueueEndBefore = NULL; /*otaEventQueueEnd; */
+    OtaEventMsg_t * ulQueueEndBefore = NULL;
 
     otaGoToState( OtaAgentStateReady );
     otaEvent.eventId = OtaAgentEventShutdown;
@@ -2621,7 +2621,7 @@ void test_OTA_EventProcess_WhileStopped()
     otaAgent.pOtaInterface = &otaInterfaces;
     otaInterfaces.os.event.send = mockOSEventSend;
 
-    /* Agent is stopped so event shouldn't be processed and user callbacks/functions shouldn't be excercised. */
+    /* Agent is stopped so event should not be processed and user callbacks/functions should not be exercised. */
     otaEvent.eventId = OtaAgentEventReceivedJobDocument;
     OTA_SignalEvent( &otaEvent );
     ulQueueEndBefore = otaEventQueueEnd;
@@ -2643,8 +2643,8 @@ void test_OTA_EventProcess_AgentUpdatesReadiness()
     TEST_ASSERT_EQUAL( OtaAgentStateReady, OTA_EventProcess( NULL ) );
     TEST_ASSERT_TRUE( otaAgent.agentStarted );
 
-    /* Readiness only indicates when agent daemon has begun. Since EventProcess was called once,
-     * agent state shouldn't be updated to ready again. Only existing events can update state hereafter. */
+    /* Readiness only indicates when agent daemon has begun. Since agent was cycled once, agent state
+     * should not be updated to ready again. Only existing events can update state hereafter. */
     otaGoToState( OtaAgentStateRequestingFileBlock );
     TEST_ASSERT_EQUAL( OtaAgentStateRequestingFileBlock, OTA_EventProcess( NULL ) );
 }

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -2631,8 +2631,8 @@ void test_OTA_EventProcess_AgentUpdatesReadiness()
     otaInterfaces.os.event.send = mockOSEventSend;
     otaGoToState( OtaAgentStateStopped );
 
-    /* Internally calls OTA_Init which will set state to OtaAgentStateInit, which will allow 
-     * EventProcess to set state to OtaAgentStateReady */
+    /* Internally calls OTA_Init which will set state to initialized state, which will allow
+     * OTA_EventProcess to set state to OtaAgentStateReady */
     otaInitDefault();
     TEST_ASSERT_EQUAL( OtaAgentStateInit, OTA_GetState() );
 

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -7,7 +7,6 @@ addrinfo
 addtogroup
 afr
 agentshutdowncleanup
-agentstarted
 allocateaddrinfolinkedlist
 alpn
 alpnprotoslen

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -7,6 +7,7 @@ addrinfo
 addtogroup
 afr
 agentshutdowncleanup
+agentstarted
 allocateaddrinfolinkedlist
 alpn
 alpnprotoslen


### PR DESCRIPTION
Description
-----------
Some users may not want to spawn a new thread just to run ota agent. To accommodate, a single-cycle function has been added that effectively runs a single iteration of the loop in `OTA_EventProcessingTask`.

Currently `OtaAgentStateReady` is used by the library to know when the ota processor task has started. This notion of task readiness is retained with the new function, where the agent is not `OtaAgentStateReady` until the `OTA_EventProcess` has been called for the first time in it's new, user defined, daemon.

State is returned from `OTA_EventProcess` as a potential for users to react to, or perhaps log, the ota agent state upon `OTA_EventProcess` return. 

Caveats
-----------
Unfortunately, the library does not provide thread sync mechanisms in its PAL OSAL, so using both `OTA_EventProcess` and `OTA_EventProcessingTask`  in an application is _not thread safe_. Perhaps an OTA user config should be added to make the two mutually exclusive in builds?

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is formatted using Uncrustify.
- [x] ~~I have read and applied the rules stated in CONTRIBUTING.md.~~ n/a No such file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.