### PR TITLE
Add more description on OtaAppCallback_t and remove const property on pData.

### DIFF
--- a/source/include/ota.h
+++ b/source/include/ota.h
@@ -226,9 +226,16 @@ typedef struct OtaJobDocument
  *
  * The callback function is called with one of the following arguments:
  *
- *      OtaJobEventActivate      OTA update is authenticated and ready to activate.
- *      OtaJobEventFail          OTA update failed. Unable to use this update.
- *      OtaJobEventStartTest     OTA job is now ready for optional user self tests.
+ *      OtaJobEventActivate           OTA update is authenticated and ready to activate.
+ *      OtaJobEventFail               OTA update failed. Unable to use this update.
+ *      OtaJobEventStartTest          OTA job is now ready for optional user self tests.
+ *      OtaJobEventProcessed          Event OTA got from user has been handled.
+ *      OtaJobEventSelfTestFailed     OTA update failed in self-test.
+ *      OtaJobEventParseCustomJob     OTA got an unknown job from cloud, need user to check
+ *                                    if it's a custom job.
+ *      OtaJobEventReceivedJob        OTA event when a new valid job is received.
+ *      OtaJobEventUpdateComplete     OTA event when the update is completed.
+ *      OtaJobEventNoActiveJob        OTA event when no active job is pending.
  *
  * When OtaJobEventActivate is received, the job status details have been updated with
  * the state as ready for Self Test. After reboot, the new firmware will (normally) be
@@ -238,12 +245,38 @@ typedef struct OtaJobDocument
  * If the callback function is called with a result of OtaJobEventFail, the OTA update
  * job has failed in some way and should be rejected.
  *
+ * When OtaJobEventStartTest is received, the load is first boot after OTA.
+ * Users can set the image state to OtaImageStateAccepted if the load is verified.
+ *
+ * When OtaJobEventProcessed is received, the event (OtaAgentEventReceivedJobDocument) sent
+ * from user has been handled. User can free the buffer when receiving this callback.
+ *
+ * When OtaJobEventSelfTestFailed is received, that means the load is failed on verification.
+ * And the device is going to reboot after this callback.
+ *
+ * When OtaJobEventParseCustomJob is received, that means OTA received an unknown job from cloud.
+ * User can parse the job by casting pData to OtaJobDocument_t, then check the pJobDocJson and
+ * pJobId in the document. User should set the result to parseErr if it's a custom job.
+ *
  * @param[in] eEvent An OTA update event from the OtaJobEvent_t enum.
  *
  * @param[in] pData Optional data related to the event.
+ *
+ * eEvent|Structure of pData|Variable in pData
+ * ------|-----|-----------
+ * OtaJobEventActivate|OtaJobDocument_t|status and reason
+ * OtaJobEventFail|OtaJobDocument_t|status, reason and subReason
+ * OtaJobEventStartTest|NULL|nothing
+ * OtaJobEventProcessed|OtaEventData_t|data buffer inputed from user by OTA_SignalEvent
+ * OtaJobEventSelfTestFailed|NULL|nothing
+ * OtaJobEventParseCustomJob|OtaJobDocument_t|pJobId, jobIdLength, pJobDocJson, and jobDocLength
+ * OtaJobEventReceivedJob|OtaJobDocument_t|pJobId, jobIdLength, pJobDocJson, jobDocLength, and fileTypeId
+ * OtaJobEventUpdateComplete|OtaJobDocument_t|status, reason and subReason
+ * OtaJobEventNoActiveJob|NULL|nothing
+ *
  */
 typedef void (* OtaAppCallback_t)( OtaJobEvent_t eEvent,
-                                   const void * pData );
+                                   void * pData );
 
 /*--------------------------- OTA structs ----------------------------*/
 

--- a/source/include/ota.h
+++ b/source/include/ota.h
@@ -258,6 +258,15 @@ typedef struct OtaJobDocument
  * User can parse the job by casting pData to OtaJobDocument_t, then check the pJobDocJson and
  * pJobId in the document. User should set the result to parseErr if it's a custom job.
  *
+ * When OtaJobEventReceivedJob is received, that means OTA has addressed the json file provided by
+ * user successfully. Let user know to handler the buffer.
+ *
+ * When OtaJobEventUpdateComplete is received, that means OTA has downloaded a full image for the
+ * file type which is differnt from configOTA_FIRMWARE_UPDATE_FILE_TYPE_ID.
+ *
+ * When OtaJobEventNoActiveJob is received, that means OTA has received a job document without valid
+ * job ID and job document key.
+ *
  * @param[in] eEvent An OTA update event from the OtaJobEvent_t enum.
  *
  * @param[in] pData Optional data related to the event.

--- a/source/include/ota.h
+++ b/source/include/ota.h
@@ -262,7 +262,7 @@ typedef struct OtaJobDocument
  * user successfully. Let user know to handler the buffer.
  *
  * When OtaJobEventUpdateComplete is received, that means OTA has downloaded a full image for the
- * file type which is differnt from configOTA_FIRMWARE_UPDATE_FILE_TYPE_ID.
+ * file type which is different from configOTA_FIRMWARE_UPDATE_FILE_TYPE_ID.
  *
  * When OtaJobEventNoActiveJob is received, that means OTA has received a job document without valid
  * job ID and job document key.

--- a/source/ota.c
+++ b/source/ota.c
@@ -2952,7 +2952,7 @@ static void receiveAndProcessOtaEvent( void )
 }
 
 static void callOtaCallback( OtaJobEvent_t eEvent,
-                             const void * pData )
+                             void * pData )
 {
     if( otaAgent.OtaAppCallback )
     {

--- a/source/ota.c
+++ b/source/ota.c
@@ -1008,7 +1008,7 @@ static OtaErr_t processJobHandler( const OtaEventData_t * pEventData )
     }
 
     /* Application callback for event processed. */
-    callOtaCallback( OtaJobEventProcessed, ( void * ) pEventData );
+    callOtaCallback( OtaJobEventProcessed, pEventData );
 
     return retVal;
 }
@@ -1279,7 +1279,7 @@ static OtaErr_t processDataHandler( const OtaEventData_t * pEventData )
     }
 
     /* Application callback for event processed. */
-    callOtaCallback( OtaJobEventProcessed, ( void * ) pEventData );
+    callOtaCallback( OtaJobEventProcessed, pEventData );
 
     if( err != OtaErrNone )
     {
@@ -2350,7 +2350,7 @@ static OtaFileContext_t * parseJobDoc( const JsonDocParam_t * pJsonExpectedParam
         jobDoc.fileTypeId = otaAgent.fileContext.fileType;
 
         /* Let the application know to release buffer.*/
-        callOtaCallback( OtaJobEventReceivedJob, ( void * ) &jobDoc );
+        callOtaCallback( OtaJobEventReceivedJob, &jobDoc );
     }
     else
     {
@@ -2829,14 +2829,14 @@ static void handleUnexpectedEvents( const OtaEventMsg_t * pEventMsg )
         case OtaAgentEventReceivedJobDocument:
 
             /* Let the application know to release buffer.*/
-            callOtaCallback( OtaJobEventProcessed, ( void * ) pEventMsg->pEventData );
+            callOtaCallback( OtaJobEventProcessed, pEventMsg->pEventData );
 
             break;
 
         case OtaAgentEventReceivedFileBlock:
 
             /* Let the application know to release buffer.*/
-            callOtaCallback( OtaJobEventProcessed, ( void * ) pEventMsg->pEventData );
+            callOtaCallback( OtaJobEventProcessed, pEventMsg->pEventData );
 
             /* File block was not processed, increment the statistics. */
             otaAgent.statistics.otaPacketsDropped++;

--- a/source/ota.c
+++ b/source/ota.c
@@ -472,7 +472,7 @@ static void receiveAndProcessOtaEvent( void );
  * @brief Call OTA callback function if it's registered.
  */
 static void callOtaCallback( OtaJobEvent_t eEvent,
-                             const void * pData );
+                             void * pData );
 
 /* OTA state event handler functions. */
 

--- a/source/ota.c
+++ b/source/ota.c
@@ -1008,7 +1008,7 @@ static OtaErr_t processJobHandler( const OtaEventData_t * pEventData )
     }
 
     /* Application callback for event processed. */
-    callOtaCallback( OtaJobEventProcessed, ( const void * ) pEventData );
+    callOtaCallback( OtaJobEventProcessed, ( void * ) pEventData );
 
     return retVal;
 }
@@ -1279,7 +1279,7 @@ static OtaErr_t processDataHandler( const OtaEventData_t * pEventData )
     }
 
     /* Application callback for event processed. */
-    callOtaCallback( OtaJobEventProcessed, ( const void * ) pEventData );
+    callOtaCallback( OtaJobEventProcessed, ( void * ) pEventData );
 
     if( err != OtaErrNone )
     {
@@ -2350,7 +2350,7 @@ static OtaFileContext_t * parseJobDoc( const JsonDocParam_t * pJsonExpectedParam
         jobDoc.fileTypeId = otaAgent.fileContext.fileType;
 
         /* Let the application know to release buffer.*/
-        callOtaCallback( OtaJobEventReceivedJob, ( const void * ) &jobDoc );
+        callOtaCallback( OtaJobEventReceivedJob, ( void * ) &jobDoc );
     }
     else
     {
@@ -2829,14 +2829,14 @@ static void handleUnexpectedEvents( const OtaEventMsg_t * pEventMsg )
         case OtaAgentEventReceivedJobDocument:
 
             /* Let the application know to release buffer.*/
-            callOtaCallback( OtaJobEventProcessed, ( const void * ) pEventMsg->pEventData );
+            callOtaCallback( OtaJobEventProcessed, ( void * ) pEventMsg->pEventData );
 
             break;
 
         case OtaAgentEventReceivedFileBlock:
 
             /* Let the application know to release buffer.*/
-            callOtaCallback( OtaJobEventProcessed, ( const void * ) pEventMsg->pEventData );
+            callOtaCallback( OtaJobEventProcessed, ( void * ) pEventMsg->pEventData );
 
             /* File block was not processed, increment the statistics. */
             otaAgent.statistics.otaPacketsDropped++;

--- a/source/ota.c
+++ b/source/ota.c
@@ -1008,7 +1008,7 @@ static OtaErr_t processJobHandler( const OtaEventData_t * pEventData )
     }
 
     /* Application callback for event processed. */
-    callOtaCallback( OtaJobEventProcessed, pEventData );
+    callOtaCallback( OtaJobEventProcessed, ( void * ) pEventData );
 
     return retVal;
 }
@@ -1279,7 +1279,7 @@ static OtaErr_t processDataHandler( const OtaEventData_t * pEventData )
     }
 
     /* Application callback for event processed. */
-    callOtaCallback( OtaJobEventProcessed, pEventData );
+    callOtaCallback( OtaJobEventProcessed, ( void * ) pEventData );
 
     if( err != OtaErrNone )
     {

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -703,7 +703,7 @@ OtaPalImageState_t mockPalGetPlatformImageStateAlwaysPendingCommit( OtaFileConte
 }
 
 static void mockAppCallback( OtaJobEvent_t event,
-                             const void * pData )
+                             void * pData )
 {
     OtaJobDocument_t * jobDoc = NULL;
 
@@ -722,7 +722,7 @@ static void mockAppCallback( OtaJobEvent_t event,
 }
 
 static void mockAppCallbackCustomParsingFails( OtaJobEvent_t event,
-                                               const void * pData )
+                                               void * pData )
 {
     OtaJobDocument_t * jobDoc = NULL;
 


### PR DESCRIPTION
<!--- Title -->
Add more description on OtaAppCallback_t to help user get familiar with it sooner, and remove const property on pData to avoid misunderstanding.

Description
-----------
<!--- Describe your changes in detail -->
- Add more description on OtaAppCallback_t to help user get familiar with it faster.
- Remove const property on pData to avoid misunderstanding.
  - As #220 mentioned, pData is used for memory management in demo, but we declared it as const may make users misunderstand it. So, remove the property.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [ ] I have tested my changes. No regression in existing tests.
- [x] My code is formatted using Uncrustify.
- [x] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.