### PR TITLE
Fix breaking OTA CBMC proofs

### DIFF
--- a/test/cbmc/proofs/Posix_OtaReceiveEvent/Makefile
+++ b/test/cbmc/proofs/Posix_OtaReceiveEvent/Makefile
@@ -8,6 +8,8 @@ PROOF_UID = Posix_OtaReceiveEvent_harness
 
 INCLUDES += -I$(SRCDIR)/source/portable/os/
 
+DEFINES += -DBOUND=2
+
 UNWINDSET += Posix_OtaReceiveEvent.0:10
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c

--- a/test/cbmc/proofs/Posix_OtaReceiveEvent/Posix_OtaReceiveEvent_harness.c
+++ b/test/cbmc/proofs/Posix_OtaReceiveEvent/Posix_OtaReceiveEvent_harness.c
@@ -32,16 +32,17 @@
 #include "ota_private.h"
 #include <poll.h>
 
-int poll( struct pollfd *fds, nfds_t nfds, int timeout )
+int poll( struct pollfd * fds,
+          nfds_t nfds,
+          int timeout )
 {
     int returnVal;
 
     if( nondet_bool() )
     {
-        /* Case when timeout doesn't happen and data is present to be read. */
+        /* Case when timeout does not happen and data is present to be read. */
         __CPROVER_assume( returnVal > 0 );
         fds->revents = POLLIN;
-
     }
     else
     {
@@ -49,7 +50,6 @@ int poll( struct pollfd *fds, nfds_t nfds, int timeout )
         returnVal = 0;
         fds->revents = 0;
     }
-
 }
 
 void Posix_OtaReceiveEvent_harness()

--- a/test/cbmc/proofs/Posix_OtaReceiveEvent/Posix_OtaReceiveEvent_harness.c
+++ b/test/cbmc/proofs/Posix_OtaReceiveEvent/Posix_OtaReceiveEvent_harness.c
@@ -38,6 +38,9 @@ int poll( struct pollfd * fds,
 {
     int returnVal;
 
+    __CPROVER_assert( nfds > 0 );
+    __CPROVER_assert( fds != NULL );
+
     if( nondet_bool() )
     {
         /* Case when timeout does not happen and data is present to be read. */

--- a/test/cbmc/proofs/Posix_OtaReceiveEvent/Posix_OtaReceiveEvent_harness.c
+++ b/test/cbmc/proofs/Posix_OtaReceiveEvent/Posix_OtaReceiveEvent_harness.c
@@ -38,8 +38,7 @@ int poll( struct pollfd * fds,
 {
     int returnVal;
 
-    __CPROVER_assert( nfds > 0 );
-    __CPROVER_assert( fds != NULL );
+    __CPROVER_assert( fds != NULL, "fds pointer cannot be NULL" );
 
     if( nondet_bool() )
     {

--- a/test/cbmc/proofs/Posix_OtaReceiveEvent/Posix_OtaReceiveEvent_harness.c
+++ b/test/cbmc/proofs/Posix_OtaReceiveEvent/Posix_OtaReceiveEvent_harness.c
@@ -30,6 +30,27 @@
 
 /* Includes for ota private struct types. */
 #include "ota_private.h"
+#include <poll.h>
+
+int poll( struct pollfd *fds, nfds_t nfds, int timeout )
+{
+    int returnVal;
+
+    if( nondet_bool() )
+    {
+        /* Case when timeout doesn't happen and data is present to be read. */
+        __CPROVER_assume( returnVal > 0 );
+        fds->revents = POLLIN;
+
+    }
+    else
+    {
+        /* Case when timeout happens. */
+        returnVal = 0;
+        fds->revents = 0;
+    }
+
+}
 
 void Posix_OtaReceiveEvent_harness()
 {

--- a/test/cbmc/proofs/Posix_OtaSendEvent/Makefile
+++ b/test/cbmc/proofs/Posix_OtaSendEvent/Makefile
@@ -8,6 +8,8 @@ PROOF_UID = Posix_OtaSendEvent_harness
 
 INCLUDES += -I$(SRCDIR)/source/portable/os/
 
+DEFINES += -DBOUND=2
+
 UNWINDSET += Posix_OtaSendEvent.0:10
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c

--- a/test/cbmc/proofs/Posix_OtaSendEvent/Posix_OtaSendEvent_harness.c
+++ b/test/cbmc/proofs/Posix_OtaSendEvent/Posix_OtaSendEvent_harness.c
@@ -34,6 +34,9 @@ int poll( struct pollfd * fds,
 {
     int returnVal;
 
+    __CPROVER_assert( nfds > 0 );
+    __CPROVER_assert( fds != NULL );
+
     if( nondet_bool() )
     {
         /* Case when timeout does not happen and data is present to be read. */

--- a/test/cbmc/proofs/Posix_OtaSendEvent/Posix_OtaSendEvent_harness.c
+++ b/test/cbmc/proofs/Posix_OtaSendEvent/Posix_OtaSendEvent_harness.c
@@ -26,6 +26,27 @@
  */
 /*  POSIX includes for OTA library. */
 #include "ota_os_posix.h"
+#include <poll.h>
+
+int poll( struct pollfd *fds, nfds_t nfds, int timeout )
+{
+    int returnVal;
+
+    if( nondet_bool() )
+    {
+        /* Case when timeout doesn't happen and data is present to be read. */
+        __CPROVER_assume( returnVal > 0 );
+        fds->revents = POLLIN;
+
+    }
+    else
+    {
+        /* Case when timeout happens. */
+        returnVal = 0;
+        fds->revents = 0;
+    }
+
+}
 
 void Posix_OtaSendEvent_harness()
 {

--- a/test/cbmc/proofs/Posix_OtaSendEvent/Posix_OtaSendEvent_harness.c
+++ b/test/cbmc/proofs/Posix_OtaSendEvent/Posix_OtaSendEvent_harness.c
@@ -34,8 +34,7 @@ int poll( struct pollfd * fds,
 {
     int returnVal;
 
-    __CPROVER_assert( nfds > 0 );
-    __CPROVER_assert( fds != NULL );
+    __CPROVER_assert( fds != NULL, "fds pointer cannot be NULL" );
 
     if( nondet_bool() )
     {

--- a/test/cbmc/proofs/Posix_OtaSendEvent/Posix_OtaSendEvent_harness.c
+++ b/test/cbmc/proofs/Posix_OtaSendEvent/Posix_OtaSendEvent_harness.c
@@ -28,16 +28,17 @@
 #include "ota_os_posix.h"
 #include <poll.h>
 
-int poll( struct pollfd *fds, nfds_t nfds, int timeout )
+int poll( struct pollfd * fds,
+          nfds_t nfds,
+          int timeout )
 {
     int returnVal;
 
     if( nondet_bool() )
     {
-        /* Case when timeout doesn't happen and data is present to be read. */
+        /* Case when timeout does not happen and data is present to be read. */
         __CPROVER_assume( returnVal > 0 );
         fds->revents = POLLIN;
-
     }
     else
     {
@@ -45,7 +46,6 @@ int poll( struct pollfd *fds, nfds_t nfds, int timeout )
         returnVal = 0;
         fds->revents = 0;
     }
-
 }
 
 void Posix_OtaSendEvent_harness()


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR fixes the broken CBMC proofs for the below two functions.
- Posix_OtaReceiveEvent
- Posic_OtaSendEvent

It does so by introducing a stub for the use of `poll` function introduced with https://github.com/aws/ota-for-aws-iot-embedded-sdk/pull/433. The stub non-deterministically returns either a success or a failure along with corresponding flag(s) being set.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is formatted using Uncrustify.
- [x] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.