### PR TITLE
Remove assertion check to make out-of-order packet work

### DIFF
--- a/source/ota.c
+++ b/source/ota.c
@@ -2571,7 +2571,6 @@ static IngestResult_t processDataBlock( OtaFileContext_t * pFileContext,
                                                                         ( uBlockIndex * OTA_FILE_BLOCK_SIZE ),
                                                                         pPayload,
                                                                         uBlockSize );
-        assert( ( OTA_FILE_BLOCK_SIZE == uBlockSize ) || ( pFileContext->blocksRemaining == 1 ) );
 
         if( ( iBytesWritten > 0 ) &&
             ( ( uint32_t ) iBytesWritten == uBlockSize ) )


### PR DESCRIPTION
<!--- Title -->
Remove assertion check to make out-of-order packet work

Description
-----------
<!--- Describe your changes in detail -->
Cloud may send the out-of-order (index) OTA packets.
Because we've checked the index in function validateDataBlock(), we don't need to check it again here.
And we shouldn't assume the lastest index packet must be the lastest coming packets.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is formatted using Uncrustify.
- [x] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.