### PR TITLE
Make appFirmwareVersion const configurable

### DIFF
--- a/source/include/ota_appversion32.h
+++ b/source/include/ota_appversion32.h
@@ -70,7 +70,11 @@ typedef struct
     } u; /*!< @brief Version based on configuration in big endian or little endian. */
 } AppVersion32_t;
 
-extern const AppVersion32_t appFirmwareVersion; /*!< @brief Making the version number available globally through external linkage. */
+#if ( defined( USE_NONCONST_APPVERSION ) && ( USE_NONCONST_APPVERSION == 1 ) )
+    extern AppVersion32_t appFirmwareVersion;       /*!< @brief Making the version number available globally through external linkage, without const qualifier. */
+#else
+    extern const AppVersion32_t appFirmwareVersion; /*!< @brief Making the version number available globally through external linkage, with const qualifier. */
+#endif
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/ota_appversion32.h
+++ b/source/include/ota_appversion32.h
@@ -70,7 +70,7 @@ typedef struct
     } u; /*!< @brief Version based on configuration in big endian or little endian. */
 } AppVersion32_t;
 
-#if ( defined( USE_NONCONST_APPVERSION ) && ( USE_NONCONST_APPVERSION == 1 ) )
+#if ( defined( OTA_USE_NONCONST_APPVERSION ) && ( OTA_USE_NONCONST_APPVERSION == 1 ) )
     extern AppVersion32_t appFirmwareVersion;       /*!< @brief Making the version number available globally through external linkage, without const qualifier. */
 #else
     extern const AppVersion32_t appFirmwareVersion; /*!< @brief Making the version number available globally through external linkage, with const qualifier. */

--- a/source/include/ota_config_defaults.h
+++ b/source/include/ota_config_defaults.h
@@ -303,6 +303,21 @@
 #endif
 
 /**
+ * @brief Whether to use const qualifier for the appFirmwareVersion variable.
+ *
+ * @note In some cases the appFirmwareVersion variable cannot be declared as const
+ * because the version is read out during runtime.
+ *
+ * <b>Possible values:</b><br>
+ * appFirmwareVersion is const - ( 0 ) <br>
+ * appFirmwareVersion is non-const - ( 1 ) <br>
+ * <b>Default value:</b>  '0'
+ */
+#ifndef OTA_USE_NONCONST_APPVERSION
+    #define OTA_USE_NONCONST_APPVERSION    ( 0U )
+#endif
+
+/**
  * @brief Macro that is called in the OTA library for logging "Error" level
  * messages.
  *


### PR DESCRIPTION
Make appFirmwareVersion const configurable

Description
-----------
The appFirmwareVersion cannot be const in some cases when the version is stored in a secure element, for example, the PSA (Platform Security Architecture) API cannot be used for OTA if the appFirmwareVersion is declared as const. 
We propose to make it configurable with a define. The default case will be const, but if necessary it can be changed, without modifying the code. 

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is formatted using Uncrustify.
- [x] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.