### PR TITLE
Reduce verbosity of OTA update logs

### DIFF
--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -1163,9 +1163,9 @@ OtaErr_t requestFileBlock_Mqtt( OtaAgentContext_t * pAgentCtx )
 
         if( mqttStatus == OtaMqttSuccess )
         {
-            LogInfo( ( "Published to MQTT topic to request the next block: "
-                       "topic=%s",
-                       pTopicBuffer ) );
+            LogDebug( ( "Published to MQTT topic to request the next block: "
+                        "topic=%s",
+                        pTopicBuffer ) );
             result = OtaErrNone;
         }
         else


### PR DESCRIPTION
<!--- Title -->
# Reduce verbosity of OTA update logs

Description
-----------
<!--- Describe your changes in detail -->
A simple OTA update may produce hundreds of lines
of logs just for marking the progress of the update
stream, data block by data block.

All OTA stream data block LogInfo messages are
changed to LogDebug messages.

The OTA update stream still shows forward progress.
A LogInfo message is emitted for every 32 data blocks received.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is formatted using Uncrustify.
- [x] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.