### PR TITLE
Update ThingName to a maximum of 128 characters

### DIFF
--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -9,8 +9,8 @@
     </tr>
     <tr>
         <td>ota.c</td>
-        <td><center>8.3K</center></td>
-        <td><center>7.5K</center></td>
+        <td><center>8.5K</center></td>
+        <td><center>7.6K</center></td>
     </tr>
     <tr>
         <td>ota_interface.c</td>
@@ -25,7 +25,7 @@
     <tr>
         <td>ota_mqtt.c</td>
         <td><center>2.4K</center></td>
-        <td><center>2.2K</center></td>
+        <td><center>2.3K</center></td>
     </tr>
     <tr>
         <td>ota_cbor.c</td>
@@ -39,7 +39,7 @@
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>12.5K</center></b></td>
-        <td><b><center>11.3K</center></b></td>
+        <td><b><center>12.7K</center></b></td>
+        <td><b><center>11.5K</center></b></td>
     </tr>
 </table>

--- a/source/include/ota_config_defaults.h
+++ b/source/include/ota_config_defaults.h
@@ -132,12 +132,16 @@
  * construct and pass in the Thing name when initializing the OTA agent. The
  * agent uses this size to allocate static storage for the Thing name used in
  * all OTA base topics. Namely $aws/things/thingName
+ * 
+ * AWS IoT Core limits the ThingName length to 128 characters maximum. For more,
+ * see the AWS IoT Core Quotas here - 
+ * https://console.aws.amazon.com/servicequotas/home/services/iotcore/quotas/L-83BC2FA9
  *
- * <b>Possible values:</b> Any unsigned 32 integer. <br>
- * <b>Default value:</b> '64'
+ * <b>Possible values:</b> Any unsigned 32 integer - though practical limit is 128 <br>
+ * <b>Default value:</b> '128'
  */
 #ifndef otaconfigMAX_THINGNAME_LEN
-    #define otaconfigMAX_THINGNAME_LEN    64U
+    #define otaconfigMAX_THINGNAME_LEN    128U
 #endif
 
 /**

--- a/source/include/ota_config_defaults.h
+++ b/source/include/ota_config_defaults.h
@@ -132,9 +132,9 @@
  * construct and pass in the Thing name when initializing the OTA agent. The
  * agent uses this size to allocate static storage for the Thing name used in
  * all OTA base topics. Namely $aws/things/thingName
- * 
+ *
  * AWS IoT Core limits the ThingName length to 128 characters maximum. For more,
- * see the AWS IoT Core Quotas here - 
+ * see the AWS IoT Core Quotas here -
  * https://console.aws.amazon.com/servicequotas/home/services/iotcore/quotas/L-83BC2FA9
  *
  * <b>Possible values:</b> Any unsigned 32 integer - though practical limit is 128 <br>

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -901,7 +901,7 @@ OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
 
     /* Client token max length is 64. It is a combination of request counter (max 10 characters), a separator colon, and the ThingName. */
     xThingNameLength = strlen( ( const char * ) pAgentCtx->pThingName );
-    (void) strncpy( pcClientTokenThingName, ( const char * ) pAgentCtx->pThingName, ( xThingNameLength > OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN ) ? OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN : xThingNameLength );
+    ( void ) strncpy( pcClientTokenThingName, ( const char * ) pAgentCtx->pThingName, ( xThingNameLength > OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN ) ? OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN : xThingNameLength );
 
     pTopicParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
     pPayloadParts[ 1 ] = reqCounterString;

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -869,7 +869,8 @@ OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
     OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
     uint32_t msgSize = 0;
     uint16_t topicLen = 0;
-    size_t xThingNameLength = 0;
+    uint32_t xThingNameLength = 0;
+    uint32_t reqCounterStringLength = 0;
 
     /* NULL-terminated list of topic string parts. */
     const char * pTopicParts[] =
@@ -883,18 +884,18 @@ OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
 
     /* NULL-terminated list of payload parts */
 
-    assert( pAgentCtx != NULL );
+    assert( pAgentgit stCtx != NULL );
 
     /* Suppress warnings about unused variables. */
     ( void ) pOtaJobsGetNextTopicTemplate;
     ( void ) pOtaGetNextJobMsgTemplate;
 
     /* Client token max length is 64. It is a combination of request counter (max 10 characters), a separator colon, and the ThingName. */
-    xThingNameLength = strnlen( ( const char * ) pAgentCtx->pThingName, OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN );
+    xThingNameLength = ( uint32_t ) strnlen( ( const char * ) pAgentCtx->pThingName, OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN );
 
-    size_t reqCounterStringLength = stringBuilderUInt32Decimal( reqCounterString, sizeof( reqCounterString ), reqCounter );
+    reqCounterStringLength = ( uint32_t ) stringBuilderUInt32Decimal( reqCounterString, sizeof( reqCounterString ), reqCounter );
 
-    /* Assemble the string by copying the peices into the buffer. This is done manually since we know the size of the thingname. */
+    /* Assemble the string by copying the pieces into the buffer. This is done manually since we know the size of the thingname. */
     strcat( pMsg, "{\"clientToken\":\"" );
     msgSize = strlen( "{\"clientToken\":\"" );
     strncpy( &pMsg[ msgSize ], reqCounterString, reqCounterStringLength );
@@ -902,7 +903,7 @@ OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
     strcat( &pMsg[ msgSize ], ":" );
     msgSize++;
     strncpy( &pMsg[ msgSize ], ( const char * ) pAgentCtx->pThingName, xThingNameLength );
-    msgSize += xThingNameLength + 1;
+    msgSize += xThingNameLength + 1U;
     strcat( &pMsg[ msgSize ], "\"}" );
     msgSize += 2;
 

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -903,7 +903,7 @@ OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
     strcat( &pMsg[ msgSize ], ":" );
     msgSize++;
     strncpy( &pMsg[ msgSize ], ( const char * ) pAgentCtx->pThingName, xThingNameLength );
-    msgSize += xThingNameLength + 1U;
+    msgSize += xThingNameLength;
     strcat( &pMsg[ msgSize ], "\"}" );
     msgSize += 2;
 

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -95,11 +95,11 @@ static const char pOtaStringReceive[] = "\"receive\"";                          
  */
 static const char * pOtaJobStatusStrings[ NumJobStatusMappings ] =
 {
-    "{\"status\":\""JOBS_API_STATUS_IN_PROGRESS "\",\"statusDetails\":{",
-    "{\"status\":\""JOBS_API_STATUS_FAILED "\",\"statusDetails\":{",
-    "{\"status\":\""JOBS_API_STATUS_SUCCEEDED "\",\"statusDetails\":{",
-    "{\"status\":\""JOBS_API_STATUS_REJECTED "\",\"statusDetails\":{",
-    "{\"status\":\""JOBS_API_STATUS_FAILED "\",\"statusDetails\":{", /* eJobStatus_FailedWithVal */
+	"{\"status\":\""JOBS_API_STATUS_IN_PROGRESS "\",\"statusDetails\":{",
+	"{\"status\":\""JOBS_API_STATUS_FAILED "\",\"statusDetails\":{",
+	"{\"status\":\""JOBS_API_STATUS_SUCCEEDED "\",\"statusDetails\":{",
+	"{\"status\":\""JOBS_API_STATUS_REJECTED "\",\"statusDetails\":{",
+	"{\"status\":\""JOBS_API_STATUS_FAILED "\",\"statusDetails\":{", /* eJobStatus_FailedWithVal */
 };
 
 /**
@@ -115,10 +115,10 @@ static const char * pOtaJobReasonStrings[ NumJobReasons ] = { "", "ready", "acti
  */
 static const char asciiDigits[] =
 {
-    '0', '1', '2', '3',
-    '4', '5', '6', '7',
-    '8', '9', 'a', 'b',
-    'c', 'd', 'e', 'f',
+	'0', '1', '2', '3',
+	'4', '5', '6', '7',
+	'8', '9', 'a', 'b',
+	'c', 'd', 'e', 'f',
 };
 
 /* Maximum lengths for constants used in the ota_mqtt_topic_strings templates.
@@ -132,13 +132,13 @@ static const char asciiDigits[] =
 /* Pre-calculate max buffer size for mqtt topics and messages. We make sure the buffer size is large
  * enough to hold a dynamically constructed topic and message string.
  */
-#define TOPIC_PLUS_THINGNAME_LEN( topic )    ( CONST_STRLEN( topic ) + otaconfigMAX_THINGNAME_LEN + NULL_CHAR_LEN )              /*!< Calculate max buffer size based on topic template and thing name length. */
-#define TOPIC_GET_NEXT_BUFFER_SIZE       ( TOPIC_PLUS_THINGNAME_LEN( pOtaJobsGetNextTopicTemplate ) )                            /*!< Max buffer size for `jobs/$next/get` topic. */
-#define TOPIC_NOTIFY_NEXT_BUFFER_SIZE    ( TOPIC_PLUS_THINGNAME_LEN( pOtaJobsNotifyNextTopicTemplate ) )                         /*!< Max buffer size for `jobs/notify-next` topic. */
-#define TOPIC_JOB_STATUS_BUFFER_SIZE     ( TOPIC_PLUS_THINGNAME_LEN( pOtaJobStatusTopicTemplate ) + JOB_NAME_MAX_LEN )           /*!< Max buffer size for `jobs/<job_name>/update` topic. */
-#define TOPIC_STREAM_DATA_BUFFER_SIZE    ( TOPIC_PLUS_THINGNAME_LEN( pOtaStreamDataTopicTemplate ) + STREAM_NAME_MAX_LEN )       /*!< Max buffer size for `streams/<stream_name>/data/cbor` topic. */
-#define TOPIC_GET_STREAM_BUFFER_SIZE     ( TOPIC_PLUS_THINGNAME_LEN( pOtaGetStreamTopicTemplate ) + STREAM_NAME_MAX_LEN )        /*!< Max buffer size for `streams/<stream_name>/get/cbor` topic. */
-#define MSG_GET_NEXT_BUFFER_SIZE         ( TOPIC_PLUS_THINGNAME_LEN( pOtaGetNextJobMsgTemplate ) + U32_MAX_LEN )                 /*!< Max buffer size for message of `jobs/$next/get topic`. */
+#define TOPIC_PLUS_THINGNAME_LEN( topic )    ( CONST_STRLEN( topic ) + otaconfigMAX_THINGNAME_LEN + NULL_CHAR_LEN )                                                                     /*!< Calculate max buffer size based on topic template and thing name length. */
+#define TOPIC_GET_NEXT_BUFFER_SIZE       ( TOPIC_PLUS_THINGNAME_LEN( pOtaJobsGetNextTopicTemplate ) )                                                                                   /*!< Max buffer size for `jobs/$next/get` topic. */
+#define TOPIC_NOTIFY_NEXT_BUFFER_SIZE    ( TOPIC_PLUS_THINGNAME_LEN( pOtaJobsNotifyNextTopicTemplate ) )                                                                                /*!< Max buffer size for `jobs/notify-next` topic. */
+#define TOPIC_JOB_STATUS_BUFFER_SIZE     ( TOPIC_PLUS_THINGNAME_LEN( pOtaJobStatusTopicTemplate ) + JOB_NAME_MAX_LEN )                                                                  /*!< Max buffer size for `jobs/<job_name>/update` topic. */
+#define TOPIC_STREAM_DATA_BUFFER_SIZE    ( TOPIC_PLUS_THINGNAME_LEN( pOtaStreamDataTopicTemplate ) + STREAM_NAME_MAX_LEN )                                                              /*!< Max buffer size for `streams/<stream_name>/data/cbor` topic. */
+#define TOPIC_GET_STREAM_BUFFER_SIZE     ( TOPIC_PLUS_THINGNAME_LEN( pOtaGetStreamTopicTemplate ) + STREAM_NAME_MAX_LEN )                                                               /*!< Max buffer size for `streams/<stream_name>/get/cbor` topic. */
+#define MSG_GET_NEXT_BUFFER_SIZE         ( CONST_STRLEN( "{\"clientToken\":\"" ) + CONST_STRLEN( ":" ) + CONST_STRLEN( "\"}" ) + OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN + U32_MAX_LEN + 1 ) /*!< Max buffer size for message of `jobs/$next/get topic`. */
 
 /**
  * @brief Subscribe to the jobs notification topic (i.e. New file version available).
@@ -264,95 +264,95 @@ static size_t stringBuilder( char * pBuffer,
                              size_t bufferSizeBytes,
                              const char * const strings[] )
 {
-    size_t curLen = 0;
-    size_t i;
-    size_t thisLength = 0;
+	size_t curLen = 0;
+	size_t i;
+	size_t thisLength = 0;
 
-    pBuffer[ 0 ] = '\0';
+	pBuffer[ 0 ] = '\0';
 
-    for( i = 0; strings[ i ] != NULL; i++ )
-    {
-        thisLength = strlen( strings[ i ] );
+	for( i = 0; strings[ i ] != NULL; i++ )
+	{
+		thisLength = strlen( strings[ i ] );
 
-        /* Assert if there is not enough buffer space. */
+		/* Assert if there is not enough buffer space. */
 
-        assert( ( thisLength + curLen + 1U ) <= bufferSizeBytes );
+		assert( ( thisLength + curLen + 1U ) <= bufferSizeBytes );
 
-        ( void ) strncat( pBuffer, strings[ i ], bufferSizeBytes - curLen - 1U );
-        curLen += thisLength;
-    }
+		( void ) strncat( pBuffer, strings[ i ], bufferSizeBytes - curLen - 1U );
+		curLen += thisLength;
+	}
 
-    return curLen;
+	return curLen;
 }
 
 static size_t stringBuilderUInt32Decimal( char * pBuffer,
                                           size_t bufferSizeBytes,
                                           uint32_t value )
 {
-    char workBuf[ U32_MAX_LEN ];
-    char * pCur = workBuf;
-    char * pDest = pBuffer;
-    uint32_t valueCopy = value;
-    size_t size = 0;
+	char workBuf[ U32_MAX_LEN ];
+	char * pCur = workBuf;
+	char * pDest = pBuffer;
+	uint32_t valueCopy = value;
+	size_t size = 0;
 
-    /* Assert if there is not enough buffer space. */
+	/* Assert if there is not enough buffer space. */
 
-    assert( bufferSizeBytes >= U32_MAX_LEN );
-    ( void ) bufferSizeBytes;
+	assert( bufferSizeBytes >= U32_MAX_LEN );
+	( void ) bufferSizeBytes;
 
-    while( valueCopy > 0U )
-    {
-        *pCur = asciiDigits[ ( valueCopy % 10U ) ];
-        pCur++;
-        valueCopy /= 10U;
-    }
+	while( valueCopy > 0U )
+	{
+		*pCur = asciiDigits[ ( valueCopy % 10U ) ];
+		pCur++;
+		valueCopy /= 10U;
+	}
 
-    while( pCur > workBuf )
-    {
-        pCur--;
-        pDest[ size ] = *pCur;
-        size++;
-    }
+	while( pCur > workBuf )
+	{
+		pCur--;
+		pDest[ size ] = *pCur;
+		size++;
+	}
 
-    pDest[ size ] = '\0';
-    size++;
-    return size;
+	pDest[ size ] = '\0';
+	size++;
+	return size;
 }
 
 static size_t stringBuilderUInt32Hex( char * pBuffer,
                                       size_t bufferSizeBytes,
                                       uint32_t value )
 {
-    char workBuf[ U32_MAX_LEN ];
-    char * pCur = workBuf;
-    char * pDest = pBuffer;
-    size_t size = 0;
-    uint32_t valueCopy = value;
-    size_t i;
+	char workBuf[ U32_MAX_LEN ];
+	char * pCur = workBuf;
+	char * pDest = pBuffer;
+	size_t size = 0;
+	uint32_t valueCopy = value;
+	size_t i;
 
-    /* Assert if there is not enough buffer space. */
+	/* Assert if there is not enough buffer space. */
 
-    assert( bufferSizeBytes >= U32_MAX_LEN );
-    ( void ) bufferSizeBytes;
+	assert( bufferSizeBytes >= U32_MAX_LEN );
+	( void ) bufferSizeBytes;
 
-    /* Render all 8 digits, including leading zeros. */
-    for( i = 0U; i < 8U; i++ )
-    {
-        *pCur = asciiDigits[ valueCopy & 15U ]; /* 15U = 0xF*/
-        pCur++;
-        valueCopy >>= 4;
-    }
+	/* Render all 8 digits, including leading zeros. */
+	for( i = 0U; i < 8U; i++ )
+	{
+		*pCur = asciiDigits[ valueCopy & 15U ]; /* 15U = 0xF*/
+		pCur++;
+		valueCopy >>= 4;
+	}
 
-    while( pCur > workBuf )
-    {
-        pCur--;
-        pDest[ size ] = *pCur;
-        size++;
-    }
+	while( pCur > workBuf )
+	{
+		pCur--;
+		pDest[ size ] = *pCur;
+		size++;
+	}
 
-    pDest[ size ] = '\0';
-    size++;
-    return size;
+	pDest[ size ] = '\0';
+	size++;
+	return size;
 }
 
 /*
@@ -360,57 +360,57 @@ static size_t stringBuilderUInt32Hex( char * pBuffer,
  */
 static OtaMqttStatus_t subscribeToJobNotificationTopics( const OtaAgentContext_t * pAgentCtx )
 {
-    OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
+	OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
 
-    uint16_t topicLen = 0;
+	uint16_t topicLen = 0;
 
-    /* This buffer is used to store generated MQTT topics. The static size
-     * are calculated from the templates and the corresponding parameters. */
-    static char pJobTopicNotifyNext[ TOPIC_NOTIFY_NEXT_BUFFER_SIZE ];
+	/* This buffer is used to store generated MQTT topics. The static size
+	 * are calculated from the templates and the corresponding parameters. */
+	static char pJobTopicNotifyNext[ TOPIC_NOTIFY_NEXT_BUFFER_SIZE ];
 
-    /* NULL-terminated list of topic string components */
-    const char * topicStringParts[] =
-    {
-        MQTT_API_THINGS,
-        NULL, /* Thing Name not available at compile time, initialized below */
-        MQTT_API_JOBS_NOTIFY_NEXT,
-        NULL
-    };
+	/* NULL-terminated list of topic string components */
+	const char * topicStringParts[] =
+	{
+		MQTT_API_THINGS,
+		NULL, /* Thing Name not available at compile time, initialized below */
+		MQTT_API_JOBS_NOTIFY_NEXT,
+		NULL
+	};
 
-    assert( pAgentCtx != NULL );
+	assert( pAgentCtx != NULL );
 
-    /* Suppress warnings about unused variables. */
-    ( void ) pOtaJobsNotifyNextTopicTemplate;
+	/* Suppress warnings about unused variables. */
+	( void ) pOtaJobsNotifyNextTopicTemplate;
 
-    topicStringParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
+	topicStringParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
 
-    topicLen = ( uint16_t ) stringBuilder(
-        pJobTopicNotifyNext,
-        sizeof( pJobTopicNotifyNext ),
-        topicStringParts );
+	topicLen = ( uint16_t ) stringBuilder(
+		pJobTopicNotifyNext,
+		sizeof( pJobTopicNotifyNext ),
+		topicStringParts );
 
-    /* The buffer is static and the size is calculated to fit. */
-    assert( ( topicLen > 0U ) && ( topicLen < sizeof( pJobTopicNotifyNext ) ) );
+	/* The buffer is static and the size is calculated to fit. */
+	assert( ( topicLen > 0U ) && ( topicLen < sizeof( pJobTopicNotifyNext ) ) );
 
-    mqttStatus = pAgentCtx->pOtaInterface->mqtt.subscribe( pJobTopicNotifyNext,
-                                                           topicLen,
-                                                           1 );
+	mqttStatus = pAgentCtx->pOtaInterface->mqtt.subscribe( pJobTopicNotifyNext,
+	                                                       topicLen,
+	                                                       1 );
 
-    if( mqttStatus == OtaMqttSuccess )
-    {
-        LogInfo( ( "Subscribed to MQTT topic: %s", pJobTopicNotifyNext ) );
-    }
-    else
-    {
-        LogError( ( "Failed to subscribe to MQTT topic: "
-                    "subscribe returned error: "
-                    "OtaMqttStatus_t=%s"
-                    ", topic=%s",
-                    OTA_MQTT_strerror( mqttStatus ),
-                    pJobTopicNotifyNext ) );
-    }
+	if( mqttStatus == OtaMqttSuccess )
+	{
+		LogInfo( ( "Subscribed to MQTT topic: %s", pJobTopicNotifyNext ) );
+	}
+	else
+	{
+		LogError( ( "Failed to subscribe to MQTT topic: "
+		            "subscribe returned error: "
+		            "OtaMqttStatus_t=%s"
+		            ", topic=%s",
+		            OTA_MQTT_strerror( mqttStatus ),
+		            pJobTopicNotifyNext ) );
+	}
 
-    return mqttStatus;
+	return mqttStatus;
 }
 
 /*
@@ -418,60 +418,60 @@ static OtaMqttStatus_t subscribeToJobNotificationTopics( const OtaAgentContext_t
  */
 static OtaMqttStatus_t unsubscribeFromDataStream( const OtaAgentContext_t * pAgentCtx )
 {
-    OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
+	OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
 
-    /* This buffer is used to store the generated MQTT topic. The static size
-     * is calculated from the template and the corresponding parameters. */
-    char pOtaRxStreamTopic[ TOPIC_STREAM_DATA_BUFFER_SIZE ];
-    uint16_t topicLen = 0;
-    const OtaFileContext_t * pFileContext = NULL;
+	/* This buffer is used to store the generated MQTT topic. The static size
+	 * is calculated from the template and the corresponding parameters. */
+	char pOtaRxStreamTopic[ TOPIC_STREAM_DATA_BUFFER_SIZE ];
+	uint16_t topicLen = 0;
+	const OtaFileContext_t * pFileContext = NULL;
 
-    /* NULL-terminated list of topic string parts. */
-    const char * topicStringParts[] =
-    {
-        MQTT_API_THINGS,
-        NULL, /* Thing Name not available at compile time, initialized below. */
-        MQTT_API_STREAMS,
-        NULL, /* Stream Name not available at compile time, initialized below. */
-        MQTT_API_DATA_CBOR,
-        NULL
-    };
+	/* NULL-terminated list of topic string parts. */
+	const char * topicStringParts[] =
+	{
+		MQTT_API_THINGS,
+		NULL, /* Thing Name not available at compile time, initialized below. */
+		MQTT_API_STREAMS,
+		NULL, /* Stream Name not available at compile time, initialized below. */
+		MQTT_API_DATA_CBOR,
+		NULL
+	};
 
-    assert( pAgentCtx != NULL );
+	assert( pAgentCtx != NULL );
 
-    pFileContext = &( pAgentCtx->fileContext );
+	pFileContext = &( pAgentCtx->fileContext );
 
-    topicStringParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
-    topicStringParts[ 3 ] = ( const char * ) pFileContext->pStreamName;
+	topicStringParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
+	topicStringParts[ 3 ] = ( const char * ) pFileContext->pStreamName;
 
-    /* Try to build the dynamic data stream topic and unsubscribe from it. */
-    topicLen = ( uint16_t ) stringBuilder(
-        pOtaRxStreamTopic,
-        sizeof( pOtaRxStreamTopic ),
-        topicStringParts );
+	/* Try to build the dynamic data stream topic and unsubscribe from it. */
+	topicLen = ( uint16_t ) stringBuilder(
+		pOtaRxStreamTopic,
+		sizeof( pOtaRxStreamTopic ),
+		topicStringParts );
 
-    /* The buffer is static and the size is calculated to fit. */
-    assert( ( topicLen > 0U ) && ( topicLen < sizeof( pOtaRxStreamTopic ) ) );
+	/* The buffer is static and the size is calculated to fit. */
+	assert( ( topicLen > 0U ) && ( topicLen < sizeof( pOtaRxStreamTopic ) ) );
 
-    mqttStatus = pAgentCtx->pOtaInterface->mqtt.unsubscribe( pOtaRxStreamTopic,
-                                                             topicLen,
-                                                             1 );
+	mqttStatus = pAgentCtx->pOtaInterface->mqtt.unsubscribe( pOtaRxStreamTopic,
+	                                                         topicLen,
+	                                                         1 );
 
-    if( mqttStatus == OtaMqttSuccess )
-    {
-        LogInfo( ( "Unsubscribed to MQTT topic: %s", pOtaRxStreamTopic ) );
-    }
-    else
-    {
-        LogError( ( "Failed to unsubscribe to MQTT topic: "
-                    "unsubscribe returned error: "
-                    "OtaMqttStatus_t=%s"
-                    ", topic=%s",
-                    OTA_MQTT_strerror( mqttStatus ),
-                    pOtaRxStreamTopic ) );
-    }
+	if( mqttStatus == OtaMqttSuccess )
+	{
+		LogInfo( ( "Unsubscribed to MQTT topic: %s", pOtaRxStreamTopic ) );
+	}
+	else
+	{
+		LogError( ( "Failed to unsubscribe to MQTT topic: "
+		            "unsubscribe returned error: "
+		            "OtaMqttStatus_t=%s"
+		            ", topic=%s",
+		            OTA_MQTT_strerror( mqttStatus ),
+		            pOtaRxStreamTopic ) );
+	}
 
-    return mqttStatus;
+	return mqttStatus;
 }
 
 /*
@@ -479,58 +479,58 @@ static OtaMqttStatus_t unsubscribeFromDataStream( const OtaAgentContext_t * pAge
  */
 static OtaMqttStatus_t unsubscribeFromJobNotificationTopic( const OtaAgentContext_t * pAgentCtx )
 {
-    OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
+	OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
 
-    /* This buffer is used to store the generated MQTT topic. The static size
-     * is calculated from the template and the corresponding parameters. This
-     * buffer is used with two separate templates and its size is set fit the
-     * larger of the two. */
-    char pJobTopic[ TOPIC_NOTIFY_NEXT_BUFFER_SIZE ];
-    uint16_t topicLen = 0;
+	/* This buffer is used to store the generated MQTT topic. The static size
+	 * is calculated from the template and the corresponding parameters. This
+	 * buffer is used with two separate templates and its size is set fit the
+	 * larger of the two. */
+	char pJobTopic[ TOPIC_NOTIFY_NEXT_BUFFER_SIZE ];
+	uint16_t topicLen = 0;
 
-    /* NULL-terminated list of topic string parts. */
-    const char * topicStringParts[] =
-    {
-        MQTT_API_THINGS,
-        NULL, /* Thing Name not available at compile time, initialized below. */
-        MQTT_API_JOBS_NOTIFY_NEXT,
-        NULL
-    };
+	/* NULL-terminated list of topic string parts. */
+	const char * topicStringParts[] =
+	{
+		MQTT_API_THINGS,
+		NULL, /* Thing Name not available at compile time, initialized below. */
+		MQTT_API_JOBS_NOTIFY_NEXT,
+		NULL
+	};
 
-    assert( pAgentCtx != NULL );
-    assert( pAgentCtx->pOtaInterface != NULL );
-    assert( pAgentCtx->pOtaInterface->mqtt.unsubscribe != NULL );
+	assert( pAgentCtx != NULL );
+	assert( pAgentCtx->pOtaInterface != NULL );
+	assert( pAgentCtx->pOtaInterface->mqtt.unsubscribe != NULL );
 
-    /* Try to unsubscribe from the first of two job topics. */
+	/* Try to unsubscribe from the first of two job topics. */
 
-    topicStringParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
-    topicLen = ( uint16_t ) stringBuilder(
-        pJobTopic,
-        sizeof( pJobTopic ),
-        topicStringParts );
+	topicStringParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
+	topicLen = ( uint16_t ) stringBuilder(
+		pJobTopic,
+		sizeof( pJobTopic ),
+		topicStringParts );
 
-    /* The buffer is static and the size is calculated to fit. */
-    assert( ( topicLen > 0U ) && ( topicLen < sizeof( pJobTopic ) ) );
+	/* The buffer is static and the size is calculated to fit. */
+	assert( ( topicLen > 0U ) && ( topicLen < sizeof( pJobTopic ) ) );
 
-    mqttStatus = pAgentCtx->pOtaInterface->mqtt.unsubscribe( pJobTopic,
-                                                             topicLen,
-                                                             0 );
+	mqttStatus = pAgentCtx->pOtaInterface->mqtt.unsubscribe( pJobTopic,
+	                                                         topicLen,
+	                                                         0 );
 
-    if( mqttStatus == OtaMqttSuccess )
-    {
-        LogInfo( ( "Unsubscribed to MQTT topic: %s", pJobTopic ) );
-    }
-    else
-    {
-        LogError( ( "Failed to unsubscribe to MQTT topic: "
-                    "unsubscribe returned error: "
-                    "OtaMqttStatus_t=%s"
-                    ", topic=%s",
-                    OTA_MQTT_strerror( mqttStatus ),
-                    pJobTopic ) );
-    }
+	if( mqttStatus == OtaMqttSuccess )
+	{
+		LogInfo( ( "Unsubscribed to MQTT topic: %s", pJobTopic ) );
+	}
+	else
+	{
+		LogError( ( "Failed to unsubscribe to MQTT topic: "
+		            "unsubscribe returned error: "
+		            "OtaMqttStatus_t=%s"
+		            ", topic=%s",
+		            OTA_MQTT_strerror( mqttStatus ),
+		            pJobTopic ) );
+	}
 
-    return mqttStatus;
+	return mqttStatus;
 }
 
 /*
@@ -541,71 +541,71 @@ static OtaMqttStatus_t publishStatusMessage( const OtaAgentContext_t * pAgentCtx
                                              uint32_t msgSize,
                                              uint8_t qos )
 {
-    OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
-    size_t topicLen = 0;
+	OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
+	size_t topicLen = 0;
 
-    /* This buffer is used to store the generated MQTT topic. The static size
-     * is calculated from the template and the corresponding parameters. */
-    char pTopicBuffer[ TOPIC_JOB_STATUS_BUFFER_SIZE ];
-    /* NULL-terminated list of topic string parts. */
-    const char * topicStringParts[] =
-    {
-        MQTT_API_THINGS,
-        NULL, /* Thing Name not available at compile time, initialized below. */
-        MQTT_API_JOBS,
-        NULL, /* Active Job Name not available at compile time, initialized below. */
-        MQTT_API_UPDATE,
-        NULL
-    };
+	/* This buffer is used to store the generated MQTT topic. The static size
+	 * is calculated from the template and the corresponding parameters. */
+	char pTopicBuffer[ TOPIC_JOB_STATUS_BUFFER_SIZE ];
+	/* NULL-terminated list of topic string parts. */
+	const char * topicStringParts[] =
+	{
+		MQTT_API_THINGS,
+		NULL, /* Thing Name not available at compile time, initialized below. */
+		MQTT_API_JOBS,
+		NULL, /* Active Job Name not available at compile time, initialized below. */
+		MQTT_API_UPDATE,
+		NULL
+	};
 
-    assert( pAgentCtx != NULL );
-    /* pMsg is a static buffer of size "OTA_STATUS_MSG_MAX_SIZE". */
-    assert( pMsg != NULL );
+	assert( pAgentCtx != NULL );
+	/* pMsg is a static buffer of size "OTA_STATUS_MSG_MAX_SIZE". */
+	assert( pMsg != NULL );
 
-    /* Suppress warnings about unused variables. */
-    ( void ) pOtaJobStatusTopicTemplate;
+	/* Suppress warnings about unused variables. */
+	( void ) pOtaJobStatusTopicTemplate;
 
-    /* Build the dynamic job status topic . */
+	/* Build the dynamic job status topic . */
 
-    topicStringParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
-    topicStringParts[ 3 ] = ( const char * ) pAgentCtx->pActiveJobName;
+	topicStringParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
+	topicStringParts[ 3 ] = ( const char * ) pAgentCtx->pActiveJobName;
 
-    topicLen = stringBuilder(
-        pTopicBuffer,
-        sizeof( pTopicBuffer ),
-        topicStringParts );
+	topicLen = stringBuilder(
+		pTopicBuffer,
+		sizeof( pTopicBuffer ),
+		topicStringParts );
 
-    /* The buffer is static and the size is calculated to fit. */
-    assert( ( topicLen > 0U ) && ( topicLen < sizeof( pTopicBuffer ) ) );
+	/* The buffer is static and the size is calculated to fit. */
+	assert( ( topicLen > 0U ) && ( topicLen < sizeof( pTopicBuffer ) ) );
 
-    /* Publish the status message. */
-    LogDebug( ( "Attempting to publish MQTT status message: "
-                "message=%s",
-                pMsg ) );
+	/* Publish the status message. */
+	LogDebug( ( "Attempting to publish MQTT status message: "
+	            "message=%s",
+	            pMsg ) );
 
-    mqttStatus = pAgentCtx->pOtaInterface->mqtt.publish( pTopicBuffer,
-                                                         ( uint16_t ) topicLen,
-                                                         &pMsg[ 0 ],
-                                                         msgSize,
-                                                         qos );
+	mqttStatus = pAgentCtx->pOtaInterface->mqtt.publish( pTopicBuffer,
+	                                                     ( uint16_t ) topicLen,
+	                                                     &pMsg[ 0 ],
+	                                                     msgSize,
+	                                                     qos );
 
-    if( mqttStatus == OtaMqttSuccess )
-    {
-        LogDebug( ( "Published to MQTT topic: "
-                    "topic=%s",
-                    pTopicBuffer ) );
-    }
-    else
-    {
-        LogError( ( "Failed to publish MQTT message: "
-                    "publish returned error: "
-                    "OtaMqttStatus_t=%s"
-                    ", topic=%s",
-                    OTA_MQTT_strerror( mqttStatus ),
-                    pTopicBuffer ) );
-    }
+	if( mqttStatus == OtaMqttSuccess )
+	{
+		LogDebug( ( "Published to MQTT topic: "
+		            "topic=%s",
+		            pTopicBuffer ) );
+	}
+	else
+	{
+		LogError( ( "Failed to publish MQTT message: "
+		            "publish returned error: "
+		            "OtaMqttStatus_t=%s"
+		            ", topic=%s",
+		            OTA_MQTT_strerror( mqttStatus ),
+		            pTopicBuffer ) );
+	}
 
-    return mqttStatus;
+	return mqttStatus;
 }
 
 static uint32_t buildStatusMessageReceiving( char * pMsgBuffer,
@@ -613,57 +613,57 @@ static uint32_t buildStatusMessageReceiving( char * pMsgBuffer,
                                              OtaJobStatus_t status,
                                              const OtaFileContext_t * pOTAFileCtx )
 {
-    char receivedString[ U32_MAX_LEN + 1 ];
-    char numBlocksString[ U32_MAX_LEN + 1 ];
-    uint32_t numBlocks = 0;
-    uint32_t received = 0;
-    uint32_t msgSize = 0;
-    /* NULL-terminated list of JSON payload components */
-    /* NOTE: this must conform to the following format, do not add spaces, etc. */
-    /*       "\"%s\":\"%u/%u\"}}" */
+	char receivedString[ U32_MAX_LEN + 1 ];
+	char numBlocksString[ U32_MAX_LEN + 1 ];
+	uint32_t numBlocks = 0;
+	uint32_t received = 0;
+	uint32_t msgSize = 0;
+	/* NULL-terminated list of JSON payload components */
+	/* NOTE: this must conform to the following format, do not add spaces, etc. */
+	/*       "\"%s\":\"%u/%u\"}}" */
 
-    const char * payloadStringParts[] =
-    {
-        NULL, /* Job status is not available at compile time, initialized below. */
-        pOtaStringReceive,
-        ":\"",
-        NULL, /* Received string is not available at compile time, initialized below. */
-        "/",
-        NULL, /* # blocks string is not available at compile time, initialized below. */
-        "\"}}",
-        NULL
-    };
+	const char * payloadStringParts[] =
+	{
+		NULL, /* Job status is not available at compile time, initialized below. */
+		pOtaStringReceive,
+		":\"",
+		NULL, /* Received string is not available at compile time, initialized below. */
+		"/",
+		NULL, /* # blocks string is not available at compile time, initialized below. */
+		"\"}}",
+		NULL
+	};
 
-    assert( pMsgBuffer != NULL );
-    /* This function is only called when a file is received, so it can't be NULL. */
-    assert( pOTAFileCtx != NULL );
+	assert( pMsgBuffer != NULL );
+	/* This function is only called when a file is received, so it can't be NULL. */
+	assert( pOTAFileCtx != NULL );
 
-    numBlocks = ( pOTAFileCtx->fileSize + ( OTA_FILE_BLOCK_SIZE - 1U ) ) >> otaconfigLOG2_FILE_BLOCK_SIZE;
-    received = numBlocks - pOTAFileCtx->blocksRemaining;
+	numBlocks = ( pOTAFileCtx->fileSize + ( OTA_FILE_BLOCK_SIZE - 1U ) ) >> otaconfigLOG2_FILE_BLOCK_SIZE;
+	received = numBlocks - pOTAFileCtx->blocksRemaining;
 
-    /* Output a status update when receiving first file block to let user know the OTA job status
-     * more clearly. Then output a status update once in a while. */
+	/* Output a status update when receiving first file block to let user know the OTA job status
+	 * more clearly. Then output a status update once in a while. */
 
-    if( ( received == 1U ) || ( ( received % ( uint32_t ) otaconfigOTA_UPDATE_STATUS_FREQUENCY ) == 0U ) )
-    {
-        payloadStringParts[ 0 ] = pOtaJobStatusStrings[ status ];
-        payloadStringParts[ 3 ] = receivedString;
-        payloadStringParts[ 5 ] = numBlocksString;
+	if( ( received == 1U ) || ( ( received % ( uint32_t ) otaconfigOTA_UPDATE_STATUS_FREQUENCY ) == 0U ) )
+	{
+		payloadStringParts[ 0 ] = pOtaJobStatusStrings[ status ];
+		payloadStringParts[ 3 ] = receivedString;
+		payloadStringParts[ 5 ] = numBlocksString;
 
-        ( void ) stringBuilderUInt32Decimal( receivedString, sizeof( receivedString ), received );
-        ( void ) stringBuilderUInt32Decimal( numBlocksString, sizeof( numBlocksString ), numBlocks );
+		( void ) stringBuilderUInt32Decimal( receivedString, sizeof( receivedString ), received );
+		( void ) stringBuilderUInt32Decimal( numBlocksString, sizeof( numBlocksString ), numBlocks );
 
 
-        msgSize = ( uint32_t ) stringBuilder(
-            pMsgBuffer,
-            msgBufferSize,
-            payloadStringParts );
+		msgSize = ( uint32_t ) stringBuilder(
+			pMsgBuffer,
+			msgBufferSize,
+			payloadStringParts );
 
-        /* The buffer is static and the size is calculated to fit. */
-        assert( ( msgSize > 0U ) && ( msgSize < msgBufferSize ) );
-    }
+		/* The buffer is static and the size is calculated to fit. */
+		assert( ( msgSize > 0U ) && ( msgSize < msgBufferSize ) );
+	}
 
-    return msgSize;
+	return msgSize;
 }
 
 static uint32_t prvBuildStatusMessageSelfTest( char * pMsgBuffer,
@@ -671,42 +671,42 @@ static uint32_t prvBuildStatusMessageSelfTest( char * pMsgBuffer,
                                                OtaJobStatus_t status,
                                                int32_t reason )
 {
-    uint32_t msgSize = 0;
+	uint32_t msgSize = 0;
 
-    /* NULL-terminated list of JSON payload components */
-    /* NOTE: this must agree with the following format, do not add spaces, etc. */
-    /*       "\"%s\":\"%s\",\"" OTA_JSON_UPDATED_BY_KEY_ONLY "\":\"0x%x\"}}" */
-    char versionString[ U32_MAX_LEN + 1 ];
-    const char * pPayloadStringParts[] =
-    {
-        NULL, /* Job status string not available at compile time, initialized below. */
-        "\"",
-        OTA_JSON_SELF_TEST_KEY_ONLY,
-        "\":\"",
-        NULL, /* Job reason string not available at compile time, initialized below. */
-        "\",\"" OTA_JSON_UPDATED_BY_KEY_ONLY "\":\"0x",
-        NULL, /* Version string not available at compile time, initialized below. */
-        "\"}}",
-        NULL
-    };
+	/* NULL-terminated list of JSON payload components */
+	/* NOTE: this must agree with the following format, do not add spaces, etc. */
+	/*       "\"%s\":\"%s\",\"" OTA_JSON_UPDATED_BY_KEY_ONLY "\":\"0x%x\"}}" */
+	char versionString[ U32_MAX_LEN + 1 ];
+	const char * pPayloadStringParts[] =
+	{
+		NULL, /* Job status string not available at compile time, initialized below. */
+		"\"",
+		OTA_JSON_SELF_TEST_KEY_ONLY,
+		"\":\"",
+		NULL, /* Job reason string not available at compile time, initialized below. */
+		"\",\"" OTA_JSON_UPDATED_BY_KEY_ONLY "\":\"0x",
+		NULL, /* Version string not available at compile time, initialized below. */
+		"\"}}",
+		NULL
+	};
 
-    assert( pMsgBuffer != NULL );
+	assert( pMsgBuffer != NULL );
 
-    ( void ) stringBuilderUInt32Hex( versionString, sizeof( versionString ), appFirmwareVersion.u.unsignedVersion32 );
-    pPayloadStringParts[ 0 ] = pOtaJobStatusStrings[ status ];
-    pPayloadStringParts[ 4 ] = pOtaJobReasonStrings[ reason ];
-    pPayloadStringParts[ 6 ] = versionString;
+	( void ) stringBuilderUInt32Hex( versionString, sizeof( versionString ), appFirmwareVersion.u.unsignedVersion32 );
+	pPayloadStringParts[ 0 ] = pOtaJobStatusStrings[ status ];
+	pPayloadStringParts[ 4 ] = pOtaJobReasonStrings[ reason ];
+	pPayloadStringParts[ 6 ] = versionString;
 
-    msgSize = ( uint32_t ) stringBuilder(
-        pMsgBuffer,
-        msgBufferSize,
-        pPayloadStringParts );
+	msgSize = ( uint32_t ) stringBuilder(
+		pMsgBuffer,
+		msgBufferSize,
+		pPayloadStringParts );
 
-    assert( ( msgSize > 0U ) && ( msgSize < msgBufferSize ) );
+	assert( ( msgSize > 0U ) && ( msgSize < msgBufferSize ) );
 
-    LogDebug( ( "Created self test update: %s", pMsgBuffer ) );
+	LogDebug( ( "Created self test update: %s", pMsgBuffer ) );
 
-    return msgSize;
+	return msgSize;
 }
 
 static uint32_t prvBuildStatusMessageFinish( char * pMsgBuffer,
@@ -716,136 +716,136 @@ static uint32_t prvBuildStatusMessageFinish( char * pMsgBuffer,
                                              int32_t subReason,
                                              uint32_t previousVersion )
 {
-    uint32_t msgSize = 0;
-    char reasonString[ U32_MAX_LEN + 1 ];
-    char subReasonString[ U32_MAX_LEN + 1 ];
-    char newVersionMajorString[ U32_MAX_LEN + 1 ];
-    char newVersionMinorString[ U32_MAX_LEN + 1 ];
-    char newVersionBuildString[ U32_MAX_LEN + 1 ];
-    char prevVersionMajorString[ U32_MAX_LEN + 1 ];
-    char prevVersionMinorString[ U32_MAX_LEN + 1 ];
-    char prevVersionBuildString[ U32_MAX_LEN + 1 ];
+	uint32_t msgSize = 0;
+	char reasonString[ U32_MAX_LEN + 1 ];
+	char subReasonString[ U32_MAX_LEN + 1 ];
+	char newVersionMajorString[ U32_MAX_LEN + 1 ];
+	char newVersionMinorString[ U32_MAX_LEN + 1 ];
+	char newVersionBuildString[ U32_MAX_LEN + 1 ];
+	char prevVersionMajorString[ U32_MAX_LEN + 1 ];
+	char prevVersionMinorString[ U32_MAX_LEN + 1 ];
+	char prevVersionBuildString[ U32_MAX_LEN + 1 ];
 
-    AppVersion32_t newVersion = { 0 }, prevVersion = { 0 };
+	AppVersion32_t newVersion = { 0 }, prevVersion = { 0 };
 
-    /* NULL-terminated list of payload string parts */
-    /* NOTE: this must conform to the following format, do not add spaces, etc. */
-    /*       "\"reason\":\"0x%08x: 0x%08x\"}}" */
+	/* NULL-terminated list of payload string parts */
+	/* NOTE: this must conform to the following format, do not add spaces, etc. */
+	/*       "\"reason\":\"0x%08x: 0x%08x\"}}" */
 
-    const char * pPayloadPartsStatusFailedWithValue[] =
-    {
-        NULL, /* Job status string not available at compile time, initialized below. */
-        "\"reason\":\"0x",
-        NULL, /* Reason string not available at compile time, initialized below. */
-        ": 0x",
-        NULL, /* Sub-Reason string not available at compile time, initialized below. */
-        "\"}}",
-        NULL
-    };
-    /* NULL-terminated list of payload string parts */
-    /* NOTE: this must agree with the following format, do not add spaces, etc. */
-    /*       "\"reason\":\"%s v%u.%u.%u\"}}" */
-    const char * pPayloadPartsStatusSucceeded[] =
-    {
-        NULL,                                         /* Job status string not available at compile time, initialized below. */
-        "\"reason\":\"",
-        NULL,                                         /*  Reason string not available at compile time, initialized below. */
-        "  v",
-        NULL,                                         /* Version major string not available at compile time, initialized below. */
-        ".",
-        NULL,                                         /* Version minor string not available at compile time, initialized below. */
-        ".",
-        NULL,                                         /* Version build string not available at compile time, initialized below. */
-        "\",\"" OTA_JSON_UPDATED_BY_KEY_ONLY "\":\"", /* Expands to `","updatedBy":` */
-        "  v",
-        NULL,                                         /* Previous version major string not available at compile time, initialized below. */
-        ".",
-        NULL,                                         /* Previous version minor string not available at compile time, initialized below. */
-        ".",
-        NULL,                                         /* Previous version build string not available at compile time, initialized below. */
-        "\"}}",
-        NULL
-    };
+	const char * pPayloadPartsStatusFailedWithValue[] =
+	{
+		NULL, /* Job status string not available at compile time, initialized below. */
+		"\"reason\":\"0x",
+		NULL, /* Reason string not available at compile time, initialized below. */
+		": 0x",
+		NULL, /* Sub-Reason string not available at compile time, initialized below. */
+		"\"}}",
+		NULL
+	};
+	/* NULL-terminated list of payload string parts */
+	/* NOTE: this must agree with the following format, do not add spaces, etc. */
+	/*       "\"reason\":\"%s v%u.%u.%u\"}}" */
+	const char * pPayloadPartsStatusSucceeded[] =
+	{
+		NULL,                                 /* Job status string not available at compile time, initialized below. */
+		"\"reason\":\"",
+		NULL,                                 /*  Reason string not available at compile time, initialized below. */
+		"  v",
+		NULL,                                 /* Version major string not available at compile time, initialized below. */
+		".",
+		NULL,                                 /* Version minor string not available at compile time, initialized below. */
+		".",
+		NULL,                                 /* Version build string not available at compile time, initialized below. */
+		"\",\"" OTA_JSON_UPDATED_BY_KEY_ONLY "\":\"", /* Expands to `","updatedBy":` */
+		"  v",
+		NULL,                                 /* Previous version major string not available at compile time, initialized below. */
+		".",
+		NULL,                                 /* Previous version minor string not available at compile time, initialized below. */
+		".",
+		NULL,                                 /* Previous version build string not available at compile time, initialized below. */
+		"\"}}",
+		NULL
+	};
 
-    /* NULL-terminated list of payload string parts */
-    /* NOTE: this must agree with the following format, do not add spaces, etc. */
-    /*       "\"reason\":\"%s: 0x%08x\"}}" */
-    const char * pPayloadPartsStatusOther[] =
-    {
-        NULL, /* Job status string not available at compile time, initialized below. */
-        "\"reason\":\"",
-        NULL, /*  Reason string not available at compile time, initialized below. */
-        ": 0x",
-        NULL, /* Sub-Reason string not available at compile time, initialized below. */
-        "\"}}",
-        NULL
-    };
-    const char ** pPayloadParts;
+	/* NULL-terminated list of payload string parts */
+	/* NOTE: this must agree with the following format, do not add spaces, etc. */
+	/*       "\"reason\":\"%s: 0x%08x\"}}" */
+	const char * pPayloadPartsStatusOther[] =
+	{
+		NULL, /* Job status string not available at compile time, initialized below. */
+		"\"reason\":\"",
+		NULL, /*  Reason string not available at compile time, initialized below. */
+		": 0x",
+		NULL, /* Sub-Reason string not available at compile time, initialized below. */
+		"\"}}",
+		NULL
+	};
+	const char ** pPayloadParts;
 
-    assert( pMsgBuffer != NULL );
+	assert( pMsgBuffer != NULL );
 
-    newVersion.u.signedVersion32 = subReason;
-    prevVersion.u.signedVersion32 = ( int32_t ) previousVersion;
+	newVersion.u.signedVersion32 = subReason;
+	prevVersion.u.signedVersion32 = ( int32_t ) previousVersion;
 
-    ( void ) stringBuilderUInt32Hex( reasonString, sizeof( reasonString ), ( uint32_t ) reason );
-    ( void ) stringBuilderUInt32Hex( subReasonString, sizeof( subReasonString ), ( uint32_t ) subReason );
+	( void ) stringBuilderUInt32Hex( reasonString, sizeof( reasonString ), ( uint32_t ) reason );
+	( void ) stringBuilderUInt32Hex( subReasonString, sizeof( subReasonString ), ( uint32_t ) subReason );
 
-    /* FailedWithVal uses a numeric OTA error code and sub-reason code to cover
-     * the case where there may be too many description strings to reasonably
-     * include in the code.
-     */
-    if( status == JobStatusFailedWithVal )
-    {
-        pPayloadParts = pPayloadPartsStatusFailedWithValue;
-        pPayloadParts[ 0 ] = pOtaJobStatusStrings[ status ];
-        pPayloadParts[ 2 ] = reasonString;
-        pPayloadParts[ 4 ] = subReasonString;
-    }
+	/* FailedWithVal uses a numeric OTA error code and sub-reason code to cover
+	 * the case where there may be too many description strings to reasonably
+	 * include in the code.
+	 */
+	if( status == JobStatusFailedWithVal )
+	{
+		pPayloadParts = pPayloadPartsStatusFailedWithValue;
+		pPayloadParts[ 0 ] = pOtaJobStatusStrings[ status ];
+		pPayloadParts[ 2 ] = reasonString;
+		pPayloadParts[ 4 ] = subReasonString;
+	}
 
-    /* If the status update is for "Succeeded," we are identifying the version
-     * of firmware that has been accepted. This makes it easy to find the
-     * version associated with each device (Thing) when examining the OTA jobs
-     * on the service side via the CLI or possibly with some console tool.
-     */
-    else if( status == JobStatusSucceeded )
-    {
-        /* New version string.*/
-        ( void ) stringBuilderUInt32Decimal( newVersionMajorString, sizeof( newVersionMajorString ), newVersion.u.x.major );
-        ( void ) stringBuilderUInt32Decimal( newVersionMinorString, sizeof( newVersionMinorString ), newVersion.u.x.minor );
-        ( void ) stringBuilderUInt32Decimal( newVersionBuildString, sizeof( newVersionBuildString ), newVersion.u.x.build );
+	/* If the status update is for "Succeeded," we are identifying the version
+	 * of firmware that has been accepted. This makes it easy to find the
+	 * version associated with each device (Thing) when examining the OTA jobs
+	 * on the service side via the CLI or possibly with some console tool.
+	 */
+	else if( status == JobStatusSucceeded )
+	{
+		/* New version string.*/
+		( void ) stringBuilderUInt32Decimal( newVersionMajorString, sizeof( newVersionMajorString ), newVersion.u.x.major );
+		( void ) stringBuilderUInt32Decimal( newVersionMinorString, sizeof( newVersionMinorString ), newVersion.u.x.minor );
+		( void ) stringBuilderUInt32Decimal( newVersionBuildString, sizeof( newVersionBuildString ), newVersion.u.x.build );
 
-        /* Updater version string.*/
-        ( void ) stringBuilderUInt32Decimal( prevVersionMajorString, sizeof( prevVersionMajorString ), prevVersion.u.x.major );
-        ( void ) stringBuilderUInt32Decimal( prevVersionMinorString, sizeof( prevVersionMinorString ), prevVersion.u.x.minor );
-        ( void ) stringBuilderUInt32Decimal( prevVersionBuildString, sizeof( prevVersionMinorString ), prevVersion.u.x.build );
+		/* Updater version string.*/
+		( void ) stringBuilderUInt32Decimal( prevVersionMajorString, sizeof( prevVersionMajorString ), prevVersion.u.x.major );
+		( void ) stringBuilderUInt32Decimal( prevVersionMinorString, sizeof( prevVersionMinorString ), prevVersion.u.x.minor );
+		( void ) stringBuilderUInt32Decimal( prevVersionBuildString, sizeof( prevVersionMinorString ), prevVersion.u.x.build );
 
-        pPayloadParts = pPayloadPartsStatusSucceeded;
-        pPayloadParts[ 0 ] = pOtaJobStatusStrings[ status ];
-        pPayloadParts[ 2 ] = pOtaJobReasonStrings[ reason ];
-        pPayloadParts[ 4 ] = newVersionMajorString;
-        pPayloadParts[ 6 ] = newVersionMinorString;
-        pPayloadParts[ 8 ] = newVersionBuildString;
-        pPayloadParts[ 11 ] = prevVersionMajorString;
-        pPayloadParts[ 13 ] = prevVersionMinorString;
-        pPayloadParts[ 15 ] = prevVersionBuildString;
-    }
-    else
-    {
-        pPayloadParts = pPayloadPartsStatusOther;
-        pPayloadParts[ 0 ] = pOtaJobStatusStrings[ status ];
-        pPayloadParts[ 2 ] = pOtaJobReasonStrings[ reason ];
-        pPayloadParts[ 4 ] = subReasonString;
-    }
+		pPayloadParts = pPayloadPartsStatusSucceeded;
+		pPayloadParts[ 0 ] = pOtaJobStatusStrings[ status ];
+		pPayloadParts[ 2 ] = pOtaJobReasonStrings[ reason ];
+		pPayloadParts[ 4 ] = newVersionMajorString;
+		pPayloadParts[ 6 ] = newVersionMinorString;
+		pPayloadParts[ 8 ] = newVersionBuildString;
+		pPayloadParts[ 11 ] = prevVersionMajorString;
+		pPayloadParts[ 13 ] = prevVersionMinorString;
+		pPayloadParts[ 15 ] = prevVersionBuildString;
+	}
+	else
+	{
+		pPayloadParts = pPayloadPartsStatusOther;
+		pPayloadParts[ 0 ] = pOtaJobStatusStrings[ status ];
+		pPayloadParts[ 2 ] = pOtaJobReasonStrings[ reason ];
+		pPayloadParts[ 4 ] = subReasonString;
+	}
 
-    msgSize = ( uint32_t ) stringBuilder(
-        pMsgBuffer,
-        msgBufferSize,
-        pPayloadParts );
+	msgSize = ( uint32_t ) stringBuilder(
+		pMsgBuffer,
+		msgBufferSize,
+		pPayloadParts );
 
-    /* The buffer is static and the size is calculated to fit. */
-    assert( ( msgSize > 0U ) && ( msgSize < msgBufferSize ) );
+	/* The buffer is static and the size is calculated to fit. */
+	assert( ( msgSize > 0U ) && ( msgSize < msgBufferSize ) );
 
-    return msgSize;
+	return msgSize;
 }
 
 /*
@@ -855,97 +855,98 @@ static uint32_t prvBuildStatusMessageFinish( char * pMsgBuffer,
 
 OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
 {
-    /* This buffer is used to store the generated MQTT topic. The static size
-     * is calculated from the template and the corresponding parameters. */
-    char pJobTopic[ TOPIC_GET_NEXT_BUFFER_SIZE ];
+	/* This buffer is used to store the generated MQTT topic. The static size
+	 * is calculated from the template and the corresponding parameters. */
+	char pJobTopic[ TOPIC_GET_NEXT_BUFFER_SIZE ];
 
-    /* The following buffer is big enough to hold a dynamically constructed
-     * $next/get job message. It contains a client token that is used to track
-     * how many requests have been made. */
-    char pMsg[ MSG_GET_NEXT_BUFFER_SIZE ] = { '\0' };
+	/* The following buffer is big enough to hold a dynamically constructed
+	 * $next/get job message. It contains a client token that is used to track
+	 * how many requests have been made. */
+	char pMsg[ MSG_GET_NEXT_BUFFER_SIZE ] = { '\0' };
 
-    static uint32_t reqCounter = 0;
-    OtaErr_t otaError = OtaErrRequestJobFailed;
-    OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
-    uint32_t msgSize = 0;
-    uint16_t topicLen = 0;
-    uint32_t xThingNameLength = 0;
-    uint32_t reqCounterStringLength = 0;
+	static uint32_t reqCounter = 0;
+	OtaErr_t otaError = OtaErrRequestJobFailed;
+	OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
+	uint32_t msgSize = 0;
+	uint16_t topicLen = 0;
+	uint32_t xThingNameLength = 0;
+	uint32_t reqCounterStringLength = 0;
 
-    /* NULL-terminated list of topic string parts. */
-    const char * pTopicParts[] =
-    {
-        MQTT_API_THINGS,
-        NULL, /* Thing Name not available at compile time, initialized below. */
-        MQTT_API_JOBS_NEXT_GET,
-        NULL
-    };
-    char reqCounterString[ U32_MAX_LEN + 1 ];
+	/* NULL-terminated list of topic string parts. */
+	const char * pTopicParts[] =
+	{
+		MQTT_API_THINGS,
+		NULL, /* Thing Name not available at compile time, initialized below. */
+		MQTT_API_JOBS_NEXT_GET,
+		NULL
+	};
+	char reqCounterString[ U32_MAX_LEN + 1 ];
 
-    /* NULL-terminated list of payload parts */
+	/* NULL-terminated list of payload parts */
 
-    assert( pAgentCtx != NULL );
+	assert( pAgentCtx != NULL );
 
-    /* Suppress warnings about unused variables. */
-    ( void ) pOtaJobsGetNextTopicTemplate;
-    ( void ) pOtaGetNextJobMsgTemplate;
+	/* Suppress warnings about unused variables. */
+	( void ) pOtaJobsGetNextTopicTemplate;
+	( void ) pOtaGetNextJobMsgTemplate;
 
-    /* Client token max length is 64. It is a combination of request counter (max 10 characters), a separator colon, and the ThingName. */
-    xThingNameLength = ( uint32_t ) strnlen( ( const char * ) pAgentCtx->pThingName, OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN );
+	/* Client token max length is 64. It is a combination of request counter (max 10 characters), a separator colon, and the ThingName. */
+	xThingNameLength = ( uint32_t ) strnlen( ( const char * ) pAgentCtx->pThingName, OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN );
 
-    reqCounterStringLength = ( uint32_t ) stringBuilderUInt32Decimal( reqCounterString, sizeof( reqCounterString ), reqCounter );
+	reqCounterStringLength = ( uint32_t ) stringBuilderUInt32Decimal( reqCounterString, sizeof( reqCounterString ), reqCounter );
 
-    /* Assemble the string by copying the pieces into the buffer. This is done manually since we know the size of the thingname. */
-    strcat( &pMsg[ msgSize ], "{\"clientToken\":\"" );
-    msgSize = 17U;
-    strncpy( &pMsg[ msgSize ], reqCounterString, reqCounterStringLength );
-    msgSize += reqCounterStringLength;
-    strcat( &pMsg[ msgSize ], ":" );
-    msgSize++;
-    strncpy( &pMsg[ msgSize ], ( const char * ) pAgentCtx->pThingName, xThingNameLength );
-    msgSize += xThingNameLength;
-    strcat( &pMsg[ msgSize ], "\"}" );
-    msgSize += 2U;
+	/* Assemble the string by copying the pieces into the buffer. This is done manually since we know the size of the thingname. */
+	strncpy( &pMsg[ msgSize ], "{\"clientToken\":\"", MSG_GET_NEXT_BUFFER_SIZE );
+	msgSize = 16U;
+	strncpy( &pMsg[ msgSize ], reqCounterString, reqCounterStringLength );
+	/* Do not count the terminating null byte on the request counter string */
+	msgSize += reqCounterStringLength-1;
+	strncpy( &pMsg[ msgSize ], ":", MSG_GET_NEXT_BUFFER_SIZE - msgSize );
+	msgSize++;
+	strncpy( &pMsg[ msgSize ], ( const char * ) pAgentCtx->pThingName, xThingNameLength );
+	msgSize += xThingNameLength;
+	strncpy( &pMsg[ msgSize ], "\"}", MSG_GET_NEXT_BUFFER_SIZE - msgSize );
+	msgSize += 2U;
 
-    /* Subscribe to the OTA job notification topic. */
-    mqttStatus = subscribeToJobNotificationTopics( pAgentCtx );
+	/* Subscribe to the OTA job notification topic. */
+	mqttStatus = subscribeToJobNotificationTopics( pAgentCtx );
 
-    if( mqttStatus == OtaMqttSuccess )
-    {
-        LogDebug( ( "MQTT job request number: counter=%u", reqCounter ) );
+	if( mqttStatus == OtaMqttSuccess )
+	{
+		LogDebug( ( "MQTT job request number: counter=%u", reqCounter ) );
 
-        /* The buffer is static and the size is calculated to fit. */
-        assert( ( msgSize > 0U ) && ( msgSize < sizeof( pMsg ) ) );
+		/* The buffer is static and the size is calculated to fit. */
+		assert( ( msgSize > 0U ) && ( msgSize < sizeof( pMsg ) ) );
 
-        reqCounter++;
+		reqCounter++;
 
-        topicLen = ( uint16_t ) stringBuilder(
-            pJobTopic,
-            sizeof( pJobTopic ),
-            pTopicParts );
+		topicLen = ( uint16_t ) stringBuilder(
+			pJobTopic,
+			sizeof( pJobTopic ),
+			pTopicParts );
 
-        /* The buffer is static and the size is calculated to fit. */
-        assert( ( topicLen > 0U ) && ( topicLen < sizeof( pJobTopic ) ) );
+		/* The buffer is static and the size is calculated to fit. */
+		assert( ( topicLen > 0U ) && ( topicLen < sizeof( pJobTopic ) ) );
 
-        mqttStatus = pAgentCtx->pOtaInterface->mqtt.publish( pJobTopic, topicLen, pMsg, msgSize, 1 );
+		mqttStatus = pAgentCtx->pOtaInterface->mqtt.publish( pJobTopic, topicLen, pMsg, msgSize, 1 );
 
-        if( mqttStatus == OtaMqttSuccess )
-        {
-            LogDebug( ( "Published MQTT request to get the next job: "
-                        "topic=%s",
-                        pJobTopic ) );
-            otaError = OtaErrNone;
-        }
-        else
-        {
-            LogError( ( "Failed to publish MQTT message:"
-                        "publish returned error: "
-                        "OtaMqttStatus_t=%s",
-                        OTA_MQTT_strerror( mqttStatus ) ) );
-        }
-    }
+		if( mqttStatus == OtaMqttSuccess )
+		{
+			LogDebug( ( "Published MQTT request to get the next job: "
+			            "topic=%s",
+			            pJobTopic ) );
+			otaError = OtaErrNone;
+		}
+		else
+		{
+			LogError( ( "Failed to publish MQTT message:"
+			            "publish returned error: "
+			            "OtaMqttStatus_t=%s",
+			            OTA_MQTT_strerror( mqttStatus ) ) );
+		}
+	}
 
-    return otaError;
+	return otaError;
 }
 
 
@@ -957,64 +958,64 @@ OtaErr_t updateJobStatus_Mqtt( const OtaAgentContext_t * pAgentCtx,
                                int32_t reason,
                                int32_t subReason )
 {
-    OtaErr_t result = OtaErrNone;
-    OtaMqttStatus_t mqttStatus = OtaMqttPublishFailed;
-    /* A message size of zero means don't publish anything. */
-    uint32_t msgSize = 0U;
-    /* All job state transitions except streaming progress use QOS 1 since it is required to have status in the job document. */
-    char pMsg[ OTA_STATUS_MSG_MAX_SIZE ];
-    uint8_t qos = 1;
-    const OtaFileContext_t * pFileContext = NULL;
+	OtaErr_t result = OtaErrNone;
+	OtaMqttStatus_t mqttStatus = OtaMqttPublishFailed;
+	/* A message size of zero means don't publish anything. */
+	uint32_t msgSize = 0U;
+	/* All job state transitions except streaming progress use QOS 1 since it is required to have status in the job document. */
+	char pMsg[ OTA_STATUS_MSG_MAX_SIZE ];
+	uint8_t qos = 1;
+	const OtaFileContext_t * pFileContext = NULL;
 
-    assert( pAgentCtx != NULL );
+	assert( pAgentCtx != NULL );
 
-    /* Get the current file context. */
-    pFileContext = &( pAgentCtx->fileContext );
+	/* Get the current file context. */
+	pFileContext = &( pAgentCtx->fileContext );
 
-    if( status == JobStatusInProgress )
-    {
-        if( reason == ( int32_t ) JobReasonReceiving )
-        {
-            msgSize = buildStatusMessageReceiving( pMsg, sizeof( pMsg ), status, pFileContext );
+	if( status == JobStatusInProgress )
+	{
+		if( reason == ( int32_t ) JobReasonReceiving )
+		{
+			msgSize = buildStatusMessageReceiving( pMsg, sizeof( pMsg ), status, pFileContext );
 
-            /* Downgrade Progress updates to QOS 0 to avoid overloading MQTT buffers during active streaming. */
-            qos = 0;
-        }
-        else
-        {
-            /* We're no longer receiving but we're still In Progress so we are implicitly in the Self
-             * Test phase. Prepare to update the job status with the self_test phase (ready or active). */
-            msgSize = prvBuildStatusMessageSelfTest( pMsg, sizeof( pMsg ), status, reason );
-        }
-    }
-    else
-    {
-        /* The potential values for status are constant at compile time. */
-        assert( status < NumJobStatusMappings );
-        msgSize = prvBuildStatusMessageFinish( pMsg, sizeof( pMsg ), status, reason, subReason, pAgentCtx->fileContext.updaterVersion );
-    }
+			/* Downgrade Progress updates to QOS 0 to avoid overloading MQTT buffers during active streaming. */
+			qos = 0;
+		}
+		else
+		{
+			/* We're no longer receiving but we're still In Progress so we are implicitly in the Self
+			 * Test phase. Prepare to update the job status with the self_test phase (ready or active). */
+			msgSize = prvBuildStatusMessageSelfTest( pMsg, sizeof( pMsg ), status, reason );
+		}
+	}
+	else
+	{
+		/* The potential values for status are constant at compile time. */
+		assert( status < NumJobStatusMappings );
+		msgSize = prvBuildStatusMessageFinish( pMsg, sizeof( pMsg ), status, reason, subReason, pAgentCtx->fileContext.updaterVersion );
+	}
 
-    if( msgSize > 0U )
-    {
-        /* Publish the string created above. */
-        mqttStatus = publishStatusMessage( pAgentCtx, pMsg, msgSize, qos );
+	if( msgSize > 0U )
+	{
+		/* Publish the string created above. */
+		mqttStatus = publishStatusMessage( pAgentCtx, pMsg, msgSize, qos );
 
-        if( mqttStatus == OtaMqttSuccess )
-        {
-            LogDebug( ( "Published update to the job status." ) );
-        }
-        else
-        {
-            LogError( ( "Failed to publish MQTT status message: "
-                        "publishStatusMessage returned error: "
-                        "OtaMqttStatus_t=%s",
-                        OTA_MQTT_strerror( mqttStatus ) ) );
+		if( mqttStatus == OtaMqttSuccess )
+		{
+			LogDebug( ( "Published update to the job status." ) );
+		}
+		else
+		{
+			LogError( ( "Failed to publish MQTT status message: "
+			            "publishStatusMessage returned error: "
+			            "OtaMqttStatus_t=%s",
+			            OTA_MQTT_strerror( mqttStatus ) ) );
 
-            result = OtaErrUpdateJobStatusFailed;
-        }
-    }
+			result = OtaErrUpdateJobStatusFailed;
+		}
+	}
 
-    return result;
+	return result;
 }
 
 /*
@@ -1022,65 +1023,65 @@ OtaErr_t updateJobStatus_Mqtt( const OtaAgentContext_t * pAgentCtx,
  */
 OtaErr_t initFileTransfer_Mqtt( const OtaAgentContext_t * pAgentCtx )
 {
-    OtaErr_t result = OtaErrInitFileTransferFailed;
-    OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
+	OtaErr_t result = OtaErrInitFileTransferFailed;
+	OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
 
-    /* This buffer is used to store the generated MQTT topic. The static size
-     * is calculated from the template and the corresponding parameters. */
-    static char pRxStreamTopic[ TOPIC_STREAM_DATA_BUFFER_SIZE ]; /*!< Buffer to store the topic generated for requesting data stream. */
-    uint16_t topicLen = 0;
-    const OtaFileContext_t * pFileContext = NULL;
+	/* This buffer is used to store the generated MQTT topic. The static size
+	 * is calculated from the template and the corresponding parameters. */
+	static char pRxStreamTopic[ TOPIC_STREAM_DATA_BUFFER_SIZE ]; /*!< Buffer to store the topic generated for requesting data stream. */
+	uint16_t topicLen = 0;
+	const OtaFileContext_t * pFileContext = NULL;
 
-    /* NULL-terminated list of topic string parts. */
-    const char * pTopicParts[] =
-    {
-        MQTT_API_THINGS,
-        NULL, /* Thing Name not available at compile time, initialized below. */
-        MQTT_API_STREAMS,
-        NULL, /* Stream Name not available at compile time, initialized below. */
-        MQTT_API_DATA_CBOR,
-        NULL
-    };
+	/* NULL-terminated list of topic string parts. */
+	const char * pTopicParts[] =
+	{
+		MQTT_API_THINGS,
+		NULL, /* Thing Name not available at compile time, initialized below. */
+		MQTT_API_STREAMS,
+		NULL, /* Stream Name not available at compile time, initialized below. */
+		MQTT_API_DATA_CBOR,
+		NULL
+	};
 
-    assert( pAgentCtx != NULL );
+	assert( pAgentCtx != NULL );
 
-    /* Suppress warnings about unused variables. */
-    ( void ) pOtaStreamDataTopicTemplate;
+	/* Suppress warnings about unused variables. */
+	( void ) pOtaStreamDataTopicTemplate;
 
-    pFileContext = &( pAgentCtx->fileContext );
-    pTopicParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
-    pTopicParts[ 3 ] = ( const char * ) pFileContext->pStreamName;
+	pFileContext = &( pAgentCtx->fileContext );
+	pTopicParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
+	pTopicParts[ 3 ] = ( const char * ) pFileContext->pStreamName;
 
-    topicLen = ( uint16_t ) stringBuilder(
-        pRxStreamTopic,
-        sizeof( pRxStreamTopic ),
-        pTopicParts );
+	topicLen = ( uint16_t ) stringBuilder(
+		pRxStreamTopic,
+		sizeof( pRxStreamTopic ),
+		pTopicParts );
 
-    /* The buffer is static and the size is calculated to fit. */
-    assert( ( topicLen > 0U ) && ( topicLen < sizeof( pRxStreamTopic ) ) );
+	/* The buffer is static and the size is calculated to fit. */
+	assert( ( topicLen > 0U ) && ( topicLen < sizeof( pRxStreamTopic ) ) );
 
-    mqttStatus = pAgentCtx->pOtaInterface->mqtt.subscribe( pRxStreamTopic,
-                                                           topicLen,
-                                                           0 );
+	mqttStatus = pAgentCtx->pOtaInterface->mqtt.subscribe( pRxStreamTopic,
+	                                                       topicLen,
+	                                                       0 );
 
-    if( mqttStatus == OtaMqttSuccess )
-    {
-        LogDebug( ( "Subscribed to the OTA data stream topic: "
-                    "topic=%s",
-                    pRxStreamTopic ) );
-        result = OtaErrNone;
-    }
-    else
-    {
-        LogError( ( "Failed to subscribe to MQTT topic: "
-                    "subscribe returned error: "
-                    "OtaMqttStatus_t=%s"
-                    ", topic=%s",
-                    OTA_MQTT_strerror( mqttStatus ),
-                    pRxStreamTopic ) );
-    }
+	if( mqttStatus == OtaMqttSuccess )
+	{
+		LogDebug( ( "Subscribed to the OTA data stream topic: "
+		            "topic=%s",
+		            pRxStreamTopic ) );
+		result = OtaErrNone;
+	}
+	else
+	{
+		LogError( ( "Failed to subscribe to MQTT topic: "
+		            "subscribe returned error: "
+		            "OtaMqttStatus_t=%s"
+		            ", topic=%s",
+		            OTA_MQTT_strerror( mqttStatus ),
+		            pRxStreamTopic ) );
+	}
 
-    return result;
+	return result;
 }
 
 /*
@@ -1088,104 +1089,104 @@ OtaErr_t initFileTransfer_Mqtt( const OtaAgentContext_t * pAgentCtx )
  */
 OtaErr_t requestFileBlock_Mqtt( OtaAgentContext_t * pAgentCtx )
 {
-    OtaErr_t result = OtaErrRequestFileBlockFailed;
-    OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
-    size_t msgSizeFromStream = 0;
-    uint32_t blockSize = OTA_FILE_BLOCK_SIZE;
-    uint32_t numBlocks = 0;
-    uint32_t bitmapLen = 0;
-    uint32_t msgSizeToPublish = 0;
-    uint32_t topicLen = 0;
-    bool cborEncodeRet = false;
-    char pMsg[ OTA_REQUEST_MSG_MAX_SIZE ];
+	OtaErr_t result = OtaErrRequestFileBlockFailed;
+	OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
+	size_t msgSizeFromStream = 0;
+	uint32_t blockSize = OTA_FILE_BLOCK_SIZE;
+	uint32_t numBlocks = 0;
+	uint32_t bitmapLen = 0;
+	uint32_t msgSizeToPublish = 0;
+	uint32_t topicLen = 0;
+	bool cborEncodeRet = false;
+	char pMsg[ OTA_REQUEST_MSG_MAX_SIZE ];
 
-    /* This buffer is used to store the generated MQTT topic. The static size
-     * is calculated from the template and the corresponding parameters. */
-    char pTopicBuffer[ TOPIC_GET_STREAM_BUFFER_SIZE ];
-    const OtaFileContext_t * pFileContext = NULL;
+	/* This buffer is used to store the generated MQTT topic. The static size
+	 * is calculated from the template and the corresponding parameters. */
+	char pTopicBuffer[ TOPIC_GET_STREAM_BUFFER_SIZE ];
+	const OtaFileContext_t * pFileContext = NULL;
 
-    /* NULL-terminated list of topic string parts. */
-    const char * pTopicParts[] =
-    {
-        MQTT_API_THINGS,
-        NULL, /* Thing Name not available at compile time, initialized below. */
-        MQTT_API_STREAMS,
-        NULL, /* Stream Name not available at compile time, initialized below. */
-        MQTT_API_GET_CBOR,
-        NULL
-    };
+	/* NULL-terminated list of topic string parts. */
+	const char * pTopicParts[] =
+	{
+		MQTT_API_THINGS,
+		NULL, /* Thing Name not available at compile time, initialized below. */
+		MQTT_API_STREAMS,
+		NULL, /* Stream Name not available at compile time, initialized below. */
+		MQTT_API_GET_CBOR,
+		NULL
+	};
 
-    assert( pAgentCtx != NULL );
+	assert( pAgentCtx != NULL );
 
-    /* Suppress warnings about unused variables. */
-    ( void ) pOtaGetStreamTopicTemplate;
+	/* Suppress warnings about unused variables. */
+	( void ) pOtaGetStreamTopicTemplate;
 
-    /* Get the current file context. */
-    pFileContext = &( pAgentCtx->fileContext );
+	/* Get the current file context. */
+	pFileContext = &( pAgentCtx->fileContext );
 
-    pTopicParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
-    pTopicParts[ 3 ] = ( const char * ) pFileContext->pStreamName;
+	pTopicParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
+	pTopicParts[ 3 ] = ( const char * ) pFileContext->pStreamName;
 
-    /* Reset number of blocks requested. */
-    pAgentCtx->numOfBlocksToReceive = otaconfigMAX_NUM_BLOCKS_REQUEST;
+	/* Reset number of blocks requested. */
+	pAgentCtx->numOfBlocksToReceive = otaconfigMAX_NUM_BLOCKS_REQUEST;
 
-    numBlocks = ( pFileContext->fileSize + ( OTA_FILE_BLOCK_SIZE - 1U ) ) >> otaconfigLOG2_FILE_BLOCK_SIZE;
-    bitmapLen = ( numBlocks + ( BITS_PER_BYTE - 1U ) ) >> LOG2_BITS_PER_BYTE;
+	numBlocks = ( pFileContext->fileSize + ( OTA_FILE_BLOCK_SIZE - 1U ) ) >> otaconfigLOG2_FILE_BLOCK_SIZE;
+	bitmapLen = ( numBlocks + ( BITS_PER_BYTE - 1U ) ) >> LOG2_BITS_PER_BYTE;
 
-    cborEncodeRet = OTA_CBOR_Encode_GetStreamRequestMessage( ( uint8_t * ) pMsg,
-                                                             sizeof( pMsg ),
-                                                             &msgSizeFromStream,
-                                                             OTA_CLIENT_TOKEN,
-                                                             ( int32_t ) pFileContext->serverFileID,
-                                                             ( int32_t ) blockSize,
-                                                             0,
-                                                             pFileContext->pRxBlockBitmap,
-                                                             bitmapLen,
-                                                             ( int32_t ) otaconfigMAX_NUM_BLOCKS_REQUEST );
+	cborEncodeRet = OTA_CBOR_Encode_GetStreamRequestMessage( ( uint8_t * ) pMsg,
+	                                                         sizeof( pMsg ),
+	                                                         &msgSizeFromStream,
+	                                                         OTA_CLIENT_TOKEN,
+	                                                         ( int32_t ) pFileContext->serverFileID,
+	                                                         ( int32_t ) blockSize,
+	                                                         0,
+	                                                         pFileContext->pRxBlockBitmap,
+	                                                         bitmapLen,
+	                                                         ( int32_t ) otaconfigMAX_NUM_BLOCKS_REQUEST );
 
-    if( cborEncodeRet == true )
-    {
-        msgSizeToPublish = ( uint32_t ) msgSizeFromStream;
+	if( cborEncodeRet == true )
+	{
+		msgSizeToPublish = ( uint32_t ) msgSizeFromStream;
 
-        /* Try to build the dynamic data REQUEST topic to publish to. */
+		/* Try to build the dynamic data REQUEST topic to publish to. */
 
-        topicLen = ( uint32_t ) stringBuilder(
-            pTopicBuffer,
-            sizeof( pTopicBuffer ),
-            pTopicParts );
+		topicLen = ( uint32_t ) stringBuilder(
+			pTopicBuffer,
+			sizeof( pTopicBuffer ),
+			pTopicParts );
 
-        /* The buffer is static and the size is calculated to fit. */
-        assert( ( topicLen > 0U ) && ( topicLen < sizeof( pTopicBuffer ) ) );
+		/* The buffer is static and the size is calculated to fit. */
+		assert( ( topicLen > 0U ) && ( topicLen < sizeof( pTopicBuffer ) ) );
 
-        mqttStatus = pAgentCtx->pOtaInterface->mqtt.publish( pTopicBuffer,
-                                                             ( uint16_t ) topicLen,
-                                                             &pMsg[ 0 ],
-                                                             msgSizeToPublish,
-                                                             0 );
+		mqttStatus = pAgentCtx->pOtaInterface->mqtt.publish( pTopicBuffer,
+		                                                     ( uint16_t ) topicLen,
+		                                                     &pMsg[ 0 ],
+		                                                     msgSizeToPublish,
+		                                                     0 );
 
-        if( mqttStatus == OtaMqttSuccess )
-        {
-            LogDebug( ( "Published to MQTT topic to request the next block: "
-                        "topic=%s",
-                        pTopicBuffer ) );
-            result = OtaErrNone;
-        }
-        else
-        {
-            LogError( ( "Failed to publish MQTT message: "
-                        "publish returned error: "
-                        "OtaMqttStatus_t=%s",
-                        OTA_MQTT_strerror( mqttStatus ) ) );
-        }
-    }
-    else
-    {
-        result = OtaErrFailedToEncodeCbor;
-        LogError( ( "Failed to CBOR encode stream request message: "
-                    "OTA_CBOR_Encode_GetStreamRequestMessage returned error." ) );
-    }
+		if( mqttStatus == OtaMqttSuccess )
+		{
+			LogDebug( ( "Published to MQTT topic to request the next block: "
+			            "topic=%s",
+			            pTopicBuffer ) );
+			result = OtaErrNone;
+		}
+		else
+		{
+			LogError( ( "Failed to publish MQTT message: "
+			            "publish returned error: "
+			            "OtaMqttStatus_t=%s",
+			            OTA_MQTT_strerror( mqttStatus ) ) );
+		}
+	}
+	else
+	{
+		result = OtaErrFailedToEncodeCbor;
+		LogError( ( "Failed to CBOR encode stream request message: "
+		            "OTA_CBOR_Encode_GetStreamRequestMessage returned error." ) );
+	}
 
-    return result;
+	return result;
 }
 
 /*
@@ -1199,32 +1200,32 @@ OtaErr_t decodeFileBlock_Mqtt( const uint8_t * pMessageBuffer,
                                uint8_t * const * pPayload,
                                size_t * pPayloadSize )
 {
-    OtaErr_t result = OtaErrFailedToDecodeCbor;
-    bool cborDecodeRet = false;
+	OtaErr_t result = OtaErrFailedToDecodeCbor;
+	bool cborDecodeRet = false;
 
-    /* Decode the CBOR content. */
-    cborDecodeRet = OTA_CBOR_Decode_GetStreamResponseMessage( pMessageBuffer,
-                                                              messageSize,
-                                                              pFileId,
-                                                              pBlockId,   /* CBOR requires pointer to int and our block indices never exceed 31 bits. */
-                                                              pBlockSize, /* CBOR requires pointer to int and our block sizes never exceed 31 bits. */
-                                                              pPayload,   /* This payload gets malloc'd by OTA_CBOR_Decode_GetStreamResponseMessage(). We must free it. */
-                                                              pPayloadSize );
+	/* Decode the CBOR content. */
+	cborDecodeRet = OTA_CBOR_Decode_GetStreamResponseMessage( pMessageBuffer,
+	                                                          messageSize,
+	                                                          pFileId,
+	                                                          pBlockId, /* CBOR requires pointer to int and our block indices never exceed 31 bits. */
+	                                                          pBlockSize, /* CBOR requires pointer to int and our block sizes never exceed 31 bits. */
+	                                                          pPayload, /* This payload gets malloc'd by OTA_CBOR_Decode_GetStreamResponseMessage(). We must free it. */
+	                                                          pPayloadSize );
 
-    if( cborDecodeRet == true )
-    {
-        /* pPayload and pPayloadSize is allocated by the caller. */
-        assert( ( pPayload != NULL ) && ( pPayloadSize != NULL ) );
+	if( cborDecodeRet == true )
+	{
+		/* pPayload and pPayloadSize is allocated by the caller. */
+		assert( ( pPayload != NULL ) && ( pPayloadSize != NULL ) );
 
-        result = OtaErrNone;
-    }
-    else
-    {
-        LogError( ( "Failed to decode MQTT file block: "
-                    "OTA_CBOR_Decode_GetStreamResponseMessage returned error." ) );
-    }
+		result = OtaErrNone;
+	}
+	else
+	{
+		LogError( ( "Failed to decode MQTT file block: "
+		            "OTA_CBOR_Decode_GetStreamResponseMessage returned error." ) );
+	}
 
-    return result;
+	return result;
 }
 
 /*
@@ -1232,27 +1233,27 @@ OtaErr_t decodeFileBlock_Mqtt( const uint8_t * pMessageBuffer,
  */
 OtaErr_t cleanupControl_Mqtt( const OtaAgentContext_t * pAgentCtx )
 {
-    OtaErr_t result = OtaErrNone;
-    OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
+	OtaErr_t result = OtaErrNone;
+	OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
 
-    assert( pAgentCtx != NULL );
+	assert( pAgentCtx != NULL );
 
-    if( pAgentCtx->unsubscribeOnShutdown != 0U )
-    {
-        /* Unsubscribe from job notification topics. */
-        mqttStatus = unsubscribeFromJobNotificationTopic( pAgentCtx );
+	if( pAgentCtx->unsubscribeOnShutdown != 0U )
+	{
+		/* Unsubscribe from job notification topics. */
+		mqttStatus = unsubscribeFromJobNotificationTopic( pAgentCtx );
 
-        if( mqttStatus != OtaMqttSuccess )
-        {
-            LogWarn( ( "Failed cleanup for MQTT control plane: "
-                       "unsubscribeFromJobNotificationTopic returned error: "
-                       "OtaMqttStatus_t=%s",
-                       OTA_MQTT_strerror( mqttStatus ) ) );
-            result = OtaErrCleanupControlFailed;
-        }
-    }
+		if( mqttStatus != OtaMqttSuccess )
+		{
+			LogWarn( ( "Failed cleanup for MQTT control plane: "
+			           "unsubscribeFromJobNotificationTopic returned error: "
+			           "OtaMqttStatus_t=%s",
+			           OTA_MQTT_strerror( mqttStatus ) ) );
+			result = OtaErrCleanupControlFailed;
+		}
+	}
 
-    return result;
+	return result;
 }
 
 /*
@@ -1260,55 +1261,55 @@ OtaErr_t cleanupControl_Mqtt( const OtaAgentContext_t * pAgentCtx )
  */
 OtaErr_t cleanupData_Mqtt( const OtaAgentContext_t * pAgentCtx )
 {
-    OtaErr_t result = OtaErrNone;
-    OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
+	OtaErr_t result = OtaErrNone;
+	OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
 
-    assert( pAgentCtx != NULL );
+	assert( pAgentCtx != NULL );
 
-    if( pAgentCtx->unsubscribeOnShutdown != 0U )
-    {
-        /* Unsubscribe from data stream topics. */
-        mqttStatus = unsubscribeFromDataStream( pAgentCtx );
+	if( pAgentCtx->unsubscribeOnShutdown != 0U )
+	{
+		/* Unsubscribe from data stream topics. */
+		mqttStatus = unsubscribeFromDataStream( pAgentCtx );
 
-        if( mqttStatus != OtaMqttSuccess )
-        {
-            LogWarn( ( "Failed cleanup for MQTT data plane: "
-                       "unsubscribeFromDataStream returned error: "
-                       "OtaMqttStatus_t=%s",
-                       OTA_MQTT_strerror( mqttStatus ) ) );
-            result = OtaErrCleanupDataFailed;
-        }
-    }
+		if( mqttStatus != OtaMqttSuccess )
+		{
+			LogWarn( ( "Failed cleanup for MQTT data plane: "
+			           "unsubscribeFromDataStream returned error: "
+			           "OtaMqttStatus_t=%s",
+			           OTA_MQTT_strerror( mqttStatus ) ) );
+			result = OtaErrCleanupDataFailed;
+		}
+	}
 
-    return result;
+	return result;
 }
 
 const char * OTA_MQTT_strerror( OtaMqttStatus_t status )
 {
-    const char * str = NULL;
+	const char * str = NULL;
 
-    switch( status )
-    {
-        case OtaMqttSuccess:
-            str = "OtaMqttSuccess";
-            break;
+	switch( status )
+	{
+	case OtaMqttSuccess:
+		str = "OtaMqttSuccess";
+		break;
 
-        case OtaMqttPublishFailed:
-            str = "OtaMqttPublishFailed";
-            break;
+	case OtaMqttPublishFailed:
+		str = "OtaMqttPublishFailed";
+		break;
 
-        case OtaMqttSubscribeFailed:
-            str = "OtaMqttSubscribeFailed";
-            break;
+	case OtaMqttSubscribeFailed:
+		str = "OtaMqttSubscribeFailed";
+		break;
 
-        case OtaMqttUnsubscribeFailed:
-            str = "OtaMqttUnsubscribeFailed";
-            break;
+	case OtaMqttUnsubscribeFailed:
+		str = "OtaMqttUnsubscribeFailed";
+		break;
 
-        default:
-            str = "InvalidErrorCode";
-            break;
-    }
+	default:
+		str = "InvalidErrorCode";
+		break;
+	}
 
-    return str;
+	return str;
 }

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -901,7 +901,7 @@ OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
 
     /* Client token max length is 64. It is a combination of request counter (max 10 characters), a separator colon, and the ThingName. */
     xThingNameLength = strlen( ( const char * ) pAgentCtx->pThingName );
-    strncpy( pcClientTokenThingName, ( const char * ) pAgentCtx->pThingName, ( xThingNameLength > OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN ) ? OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN : xThingNameLength );
+    (void) strncpy( pcClientTokenThingName, ( const char * ) pAgentCtx->pThingName, ( xThingNameLength > OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN ) ? OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN : xThingNameLength );
 
     pTopicParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
     pPayloadParts[ 1 ] = reqCounterString;

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -896,7 +896,7 @@ OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
     ( void ) pOtaJobsGetNextTopicTemplate;
     ( void ) pOtaGetNextJobMsgTemplate;
 
-    /* Client token max length is 64. It is a combination of request counter (max 10 characters), a seperator colon, and the ThingName. */
+    /* Client token max length is 64. It is a combination of request counter (max 10 characters), a separator colon, and the ThingName. */
     xThingNameLength = strlen((const char *) pAgentCtx->pThingName);
     strncpy(pcClientTokenThingName, (const char *) pAgentCtx->pThingName, (xThingNameLength > 53) ? 53 : xThingNameLength);
 

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -894,9 +894,14 @@ OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
     ( void ) pOtaJobsGetNextTopicTemplate;
     ( void ) pOtaGetNextJobMsgTemplate;
 
+    /* Client token max length is 64. It is a combination of request counter (max 10 characters), a seperator colon, and the ThingName. */
+    size_t xThingNameLength = strlen(pAgentCtx->pThingName);
+    char pcClientTokenThingName[54] = { '\0' };
+    strncpy(pcClientTokenThingName, pAgentCtx->pThingName, (xThingNameLength > 53) ? 53 : xThingNameLength);
+
     pTopicParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
     pPayloadParts[ 1 ] = reqCounterString;
-    pPayloadParts[ 3 ] = ( const char * ) pAgentCtx->pThingName;
+    pPayloadParts[ 3 ] = (const char *) pcClientTokenThingName;
 
     ( void ) stringBuilderUInt32Decimal( reqCounterString, sizeof( reqCounterString ), reqCounter );
 

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -896,8 +896,8 @@ OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
     reqCounterStringLength = ( uint32_t ) stringBuilderUInt32Decimal( reqCounterString, sizeof( reqCounterString ), reqCounter );
 
     /* Assemble the string by copying the pieces into the buffer. This is done manually since we know the size of the thingname. */
-    strcat( pMsg, "{\"clientToken\":\"" );
-    msgSize = strlen( "{\"clientToken\":\"" );
+    strcat( &pMsg[ msgSize ], "{\"clientToken\":\"" );
+    msgSize = 17U;
     strncpy( &pMsg[ msgSize ], reqCounterString, reqCounterStringLength );
     msgSize += reqCounterStringLength;
     strcat( &pMsg[ msgSize ], ":" );

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -900,12 +900,12 @@ OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
     ( void ) pOtaGetNextJobMsgTemplate;
 
     /* Client token max length is 64. It is a combination of request counter (max 10 characters), a separator colon, and the ThingName. */
-    xThingNameLength = strlen( ( const char * ) pAgentCtx->pThingName );
-    ( void ) strncpy( pcClientTokenThingName, ( const char * ) pAgentCtx->pThingName, ( xThingNameLength > OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN ) ? OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN : xThingNameLength );
+    xThingNameLength = strnlen( ( const char * ) pAgentCtx->pThingName, OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN );
+    ( void ) strncpy( pcClientTokenThingName, ( const char * ) pAgentCtx->pThingName, xThingNameLength );
 
     pTopicParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
     pPayloadParts[ 1 ] = reqCounterString;
-    pPayloadParts[ 3 ] = ( const char * ) pcClientTokenThingName;
+    pPayloadParts[ 3 ] = pcClientTokenThingName;
 
     ( void ) stringBuilderUInt32Decimal( reqCounterString, sizeof( reqCounterString ), reqCounter );
 

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -880,6 +880,7 @@ OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
         NULL
     };
     char reqCounterString[ U32_MAX_LEN + 1 ];
+
     /* NULL-terminated list of payload parts */
 
     assert( pAgentCtx != NULL );
@@ -891,17 +892,18 @@ OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
     /* Client token max length is 64. It is a combination of request counter (max 10 characters), a separator colon, and the ThingName. */
     xThingNameLength = strnlen( ( const char * ) pAgentCtx->pThingName, OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN );
 
-    size_t reqCounterStringLength =  stringBuilderUInt32Decimal( reqCounterString, sizeof( reqCounterString ), reqCounter );
+    size_t reqCounterStringLength = stringBuilderUInt32Decimal( reqCounterString, sizeof( reqCounterString ), reqCounter );
 
-    strncpy(pMsg, "{\"clientToken\":\"", strlen("{\"clientToken\":\"")); 
-    msgSize = strlen("{\"clientToken\":\"");
-    strncpy(&pMsg[msgSize], reqCounterString, reqCounterStringLength);
+    /* Assemble the string by copying the peices into the buffer. This is done manually since we know the size of the thingname. */
+    strcat( pMsg, "{\"clientToken\":\"" );
+    msgSize = strlen( "{\"clientToken\":\"" );
+    strncpy( &pMsg[ msgSize ], reqCounterString, reqCounterStringLength );
     msgSize += reqCounterStringLength;
-    strncpy(&pMsg[msgSize], ":", 1U);
+    strcat( &pMsg[ msgSize ], ":" );
     msgSize++;
-    strncpy(&pMsg[msgSize], ( const char * ) pAgentCtx->pThingName, xThingNameLength);
-    msgSize += xThingNameLength;
-    strncpy(&pMsg[msgSize], "\"}", 2U);
+    strncpy( &pMsg[ msgSize ], ( const char * ) pAgentCtx->pThingName, xThingNameLength );
+    msgSize += xThingNameLength + 1;
+    strcat( &pMsg[ msgSize ], "\"}" );
     msgSize += 2;
 
     /* Subscribe to the OTA job notification topic. */

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -95,11 +95,11 @@ static const char pOtaStringReceive[] = "\"receive\"";                          
  */
 static const char * pOtaJobStatusStrings[ NumJobStatusMappings ] =
 {
-	"{\"status\":\""JOBS_API_STATUS_IN_PROGRESS "\",\"statusDetails\":{",
-	"{\"status\":\""JOBS_API_STATUS_FAILED "\",\"statusDetails\":{",
-	"{\"status\":\""JOBS_API_STATUS_SUCCEEDED "\",\"statusDetails\":{",
-	"{\"status\":\""JOBS_API_STATUS_REJECTED "\",\"statusDetails\":{",
-	"{\"status\":\""JOBS_API_STATUS_FAILED "\",\"statusDetails\":{", /* eJobStatus_FailedWithVal */
+    "{\"status\":\""JOBS_API_STATUS_IN_PROGRESS "\",\"statusDetails\":{",
+    "{\"status\":\""JOBS_API_STATUS_FAILED "\",\"statusDetails\":{",
+    "{\"status\":\""JOBS_API_STATUS_SUCCEEDED "\",\"statusDetails\":{",
+    "{\"status\":\""JOBS_API_STATUS_REJECTED "\",\"statusDetails\":{",
+    "{\"status\":\""JOBS_API_STATUS_FAILED "\",\"statusDetails\":{", /* eJobStatus_FailedWithVal */
 };
 
 /**
@@ -115,10 +115,10 @@ static const char * pOtaJobReasonStrings[ NumJobReasons ] = { "", "ready", "acti
  */
 static const char asciiDigits[] =
 {
-	'0', '1', '2', '3',
-	'4', '5', '6', '7',
-	'8', '9', 'a', 'b',
-	'c', 'd', 'e', 'f',
+    '0', '1', '2', '3',
+    '4', '5', '6', '7',
+    '8', '9', 'a', 'b',
+    'c', 'd', 'e', 'f',
 };
 
 /* Maximum lengths for constants used in the ota_mqtt_topic_strings templates.
@@ -264,95 +264,95 @@ static size_t stringBuilder( char * pBuffer,
                              size_t bufferSizeBytes,
                              const char * const strings[] )
 {
-	size_t curLen = 0;
-	size_t i;
-	size_t thisLength = 0;
+    size_t curLen = 0;
+    size_t i;
+    size_t thisLength = 0;
 
-	pBuffer[ 0 ] = '\0';
+    pBuffer[ 0 ] = '\0';
 
-	for( i = 0; strings[ i ] != NULL; i++ )
-	{
-		thisLength = strlen( strings[ i ] );
+    for( i = 0; strings[ i ] != NULL; i++ )
+    {
+        thisLength = strlen( strings[ i ] );
 
-		/* Assert if there is not enough buffer space. */
+        /* Assert if there is not enough buffer space. */
 
-		assert( ( thisLength + curLen + 1U ) <= bufferSizeBytes );
+        assert( ( thisLength + curLen + 1U ) <= bufferSizeBytes );
 
-		( void ) strncat( pBuffer, strings[ i ], bufferSizeBytes - curLen - 1U );
-		curLen += thisLength;
-	}
+        ( void ) strncat( pBuffer, strings[ i ], bufferSizeBytes - curLen - 1U );
+        curLen += thisLength;
+    }
 
-	return curLen;
+    return curLen;
 }
 
 static size_t stringBuilderUInt32Decimal( char * pBuffer,
                                           size_t bufferSizeBytes,
                                           uint32_t value )
 {
-	char workBuf[ U32_MAX_LEN ];
-	char * pCur = workBuf;
-	char * pDest = pBuffer;
-	uint32_t valueCopy = value;
-	size_t size = 0;
+    char workBuf[ U32_MAX_LEN ];
+    char * pCur = workBuf;
+    char * pDest = pBuffer;
+    uint32_t valueCopy = value;
+    size_t size = 0;
 
-	/* Assert if there is not enough buffer space. */
+    /* Assert if there is not enough buffer space. */
 
-	assert( bufferSizeBytes >= U32_MAX_LEN );
-	( void ) bufferSizeBytes;
+    assert( bufferSizeBytes >= U32_MAX_LEN );
+    ( void ) bufferSizeBytes;
 
-	while( valueCopy > 0U )
-	{
-		*pCur = asciiDigits[ ( valueCopy % 10U ) ];
-		pCur++;
-		valueCopy /= 10U;
-	}
+    while( valueCopy > 0U )
+    {
+        *pCur = asciiDigits[ ( valueCopy % 10U ) ];
+        pCur++;
+        valueCopy /= 10U;
+    }
 
-	while( pCur > workBuf )
-	{
-		pCur--;
-		pDest[ size ] = *pCur;
-		size++;
-	}
+    while( pCur > workBuf )
+    {
+        pCur--;
+        pDest[ size ] = *pCur;
+        size++;
+    }
 
-	pDest[ size ] = '\0';
-	size++;
-	return size;
+    pDest[ size ] = '\0';
+    size++;
+    return size;
 }
 
 static size_t stringBuilderUInt32Hex( char * pBuffer,
                                       size_t bufferSizeBytes,
                                       uint32_t value )
 {
-	char workBuf[ U32_MAX_LEN ];
-	char * pCur = workBuf;
-	char * pDest = pBuffer;
-	size_t size = 0;
-	uint32_t valueCopy = value;
-	size_t i;
+    char workBuf[ U32_MAX_LEN ];
+    char * pCur = workBuf;
+    char * pDest = pBuffer;
+    size_t size = 0;
+    uint32_t valueCopy = value;
+    size_t i;
 
-	/* Assert if there is not enough buffer space. */
+    /* Assert if there is not enough buffer space. */
 
-	assert( bufferSizeBytes >= U32_MAX_LEN );
-	( void ) bufferSizeBytes;
+    assert( bufferSizeBytes >= U32_MAX_LEN );
+    ( void ) bufferSizeBytes;
 
-	/* Render all 8 digits, including leading zeros. */
-	for( i = 0U; i < 8U; i++ )
-	{
-		*pCur = asciiDigits[ valueCopy & 15U ]; /* 15U = 0xF*/
-		pCur++;
-		valueCopy >>= 4;
-	}
+    /* Render all 8 digits, including leading zeros. */
+    for( i = 0U; i < 8U; i++ )
+    {
+        *pCur = asciiDigits[ valueCopy & 15U ]; /* 15U = 0xF*/
+        pCur++;
+        valueCopy >>= 4;
+    }
 
-	while( pCur > workBuf )
-	{
-		pCur--;
-		pDest[ size ] = *pCur;
-		size++;
-	}
+    while( pCur > workBuf )
+    {
+        pCur--;
+        pDest[ size ] = *pCur;
+        size++;
+    }
 
-	pDest[ size ] = '\0';
-	size++;
-	return size;
+    pDest[ size ] = '\0';
+    size++;
+    return size;
 }
 
 /*
@@ -360,57 +360,57 @@ static size_t stringBuilderUInt32Hex( char * pBuffer,
  */
 static OtaMqttStatus_t subscribeToJobNotificationTopics( const OtaAgentContext_t * pAgentCtx )
 {
-	OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
+    OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
 
-	uint16_t topicLen = 0;
+    uint16_t topicLen = 0;
 
-	/* This buffer is used to store generated MQTT topics. The static size
-	 * are calculated from the templates and the corresponding parameters. */
-	static char pJobTopicNotifyNext[ TOPIC_NOTIFY_NEXT_BUFFER_SIZE ];
+    /* This buffer is used to store generated MQTT topics. The static size
+     * are calculated from the templates and the corresponding parameters. */
+    static char pJobTopicNotifyNext[ TOPIC_NOTIFY_NEXT_BUFFER_SIZE ];
 
-	/* NULL-terminated list of topic string components */
-	const char * topicStringParts[] =
-	{
-		MQTT_API_THINGS,
-		NULL, /* Thing Name not available at compile time, initialized below */
-		MQTT_API_JOBS_NOTIFY_NEXT,
-		NULL
-	};
+    /* NULL-terminated list of topic string components */
+    const char * topicStringParts[] =
+    {
+        MQTT_API_THINGS,
+        NULL, /* Thing Name not available at compile time, initialized below */
+        MQTT_API_JOBS_NOTIFY_NEXT,
+        NULL
+    };
 
-	assert( pAgentCtx != NULL );
+    assert( pAgentCtx != NULL );
 
-	/* Suppress warnings about unused variables. */
-	( void ) pOtaJobsNotifyNextTopicTemplate;
+    /* Suppress warnings about unused variables. */
+    ( void ) pOtaJobsNotifyNextTopicTemplate;
 
-	topicStringParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
+    topicStringParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
 
-	topicLen = ( uint16_t ) stringBuilder(
-		pJobTopicNotifyNext,
-		sizeof( pJobTopicNotifyNext ),
-		topicStringParts );
+    topicLen = ( uint16_t ) stringBuilder(
+        pJobTopicNotifyNext,
+        sizeof( pJobTopicNotifyNext ),
+        topicStringParts );
 
-	/* The buffer is static and the size is calculated to fit. */
-	assert( ( topicLen > 0U ) && ( topicLen < sizeof( pJobTopicNotifyNext ) ) );
+    /* The buffer is static and the size is calculated to fit. */
+    assert( ( topicLen > 0U ) && ( topicLen < sizeof( pJobTopicNotifyNext ) ) );
 
-	mqttStatus = pAgentCtx->pOtaInterface->mqtt.subscribe( pJobTopicNotifyNext,
-	                                                       topicLen,
-	                                                       1 );
+    mqttStatus = pAgentCtx->pOtaInterface->mqtt.subscribe( pJobTopicNotifyNext,
+                                                           topicLen,
+                                                           1 );
 
-	if( mqttStatus == OtaMqttSuccess )
-	{
-		LogInfo( ( "Subscribed to MQTT topic: %s", pJobTopicNotifyNext ) );
-	}
-	else
-	{
-		LogError( ( "Failed to subscribe to MQTT topic: "
-		            "subscribe returned error: "
-		            "OtaMqttStatus_t=%s"
-		            ", topic=%s",
-		            OTA_MQTT_strerror( mqttStatus ),
-		            pJobTopicNotifyNext ) );
-	}
+    if( mqttStatus == OtaMqttSuccess )
+    {
+        LogInfo( ( "Subscribed to MQTT topic: %s", pJobTopicNotifyNext ) );
+    }
+    else
+    {
+        LogError( ( "Failed to subscribe to MQTT topic: "
+                    "subscribe returned error: "
+                    "OtaMqttStatus_t=%s"
+                    ", topic=%s",
+                    OTA_MQTT_strerror( mqttStatus ),
+                    pJobTopicNotifyNext ) );
+    }
 
-	return mqttStatus;
+    return mqttStatus;
 }
 
 /*
@@ -418,60 +418,60 @@ static OtaMqttStatus_t subscribeToJobNotificationTopics( const OtaAgentContext_t
  */
 static OtaMqttStatus_t unsubscribeFromDataStream( const OtaAgentContext_t * pAgentCtx )
 {
-	OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
+    OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
 
-	/* This buffer is used to store the generated MQTT topic. The static size
-	 * is calculated from the template and the corresponding parameters. */
-	char pOtaRxStreamTopic[ TOPIC_STREAM_DATA_BUFFER_SIZE ];
-	uint16_t topicLen = 0;
-	const OtaFileContext_t * pFileContext = NULL;
+    /* This buffer is used to store the generated MQTT topic. The static size
+     * is calculated from the template and the corresponding parameters. */
+    char pOtaRxStreamTopic[ TOPIC_STREAM_DATA_BUFFER_SIZE ];
+    uint16_t topicLen = 0;
+    const OtaFileContext_t * pFileContext = NULL;
 
-	/* NULL-terminated list of topic string parts. */
-	const char * topicStringParts[] =
-	{
-		MQTT_API_THINGS,
-		NULL, /* Thing Name not available at compile time, initialized below. */
-		MQTT_API_STREAMS,
-		NULL, /* Stream Name not available at compile time, initialized below. */
-		MQTT_API_DATA_CBOR,
-		NULL
-	};
+    /* NULL-terminated list of topic string parts. */
+    const char * topicStringParts[] =
+    {
+        MQTT_API_THINGS,
+        NULL, /* Thing Name not available at compile time, initialized below. */
+        MQTT_API_STREAMS,
+        NULL, /* Stream Name not available at compile time, initialized below. */
+        MQTT_API_DATA_CBOR,
+        NULL
+    };
 
-	assert( pAgentCtx != NULL );
+    assert( pAgentCtx != NULL );
 
-	pFileContext = &( pAgentCtx->fileContext );
+    pFileContext = &( pAgentCtx->fileContext );
 
-	topicStringParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
-	topicStringParts[ 3 ] = ( const char * ) pFileContext->pStreamName;
+    topicStringParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
+    topicStringParts[ 3 ] = ( const char * ) pFileContext->pStreamName;
 
-	/* Try to build the dynamic data stream topic and unsubscribe from it. */
-	topicLen = ( uint16_t ) stringBuilder(
-		pOtaRxStreamTopic,
-		sizeof( pOtaRxStreamTopic ),
-		topicStringParts );
+    /* Try to build the dynamic data stream topic and unsubscribe from it. */
+    topicLen = ( uint16_t ) stringBuilder(
+        pOtaRxStreamTopic,
+        sizeof( pOtaRxStreamTopic ),
+        topicStringParts );
 
-	/* The buffer is static and the size is calculated to fit. */
-	assert( ( topicLen > 0U ) && ( topicLen < sizeof( pOtaRxStreamTopic ) ) );
+    /* The buffer is static and the size is calculated to fit. */
+    assert( ( topicLen > 0U ) && ( topicLen < sizeof( pOtaRxStreamTopic ) ) );
 
-	mqttStatus = pAgentCtx->pOtaInterface->mqtt.unsubscribe( pOtaRxStreamTopic,
-	                                                         topicLen,
-	                                                         1 );
+    mqttStatus = pAgentCtx->pOtaInterface->mqtt.unsubscribe( pOtaRxStreamTopic,
+                                                             topicLen,
+                                                             1 );
 
-	if( mqttStatus == OtaMqttSuccess )
-	{
-		LogInfo( ( "Unsubscribed to MQTT topic: %s", pOtaRxStreamTopic ) );
-	}
-	else
-	{
-		LogError( ( "Failed to unsubscribe to MQTT topic: "
-		            "unsubscribe returned error: "
-		            "OtaMqttStatus_t=%s"
-		            ", topic=%s",
-		            OTA_MQTT_strerror( mqttStatus ),
-		            pOtaRxStreamTopic ) );
-	}
+    if( mqttStatus == OtaMqttSuccess )
+    {
+        LogInfo( ( "Unsubscribed to MQTT topic: %s", pOtaRxStreamTopic ) );
+    }
+    else
+    {
+        LogError( ( "Failed to unsubscribe to MQTT topic: "
+                    "unsubscribe returned error: "
+                    "OtaMqttStatus_t=%s"
+                    ", topic=%s",
+                    OTA_MQTT_strerror( mqttStatus ),
+                    pOtaRxStreamTopic ) );
+    }
 
-	return mqttStatus;
+    return mqttStatus;
 }
 
 /*
@@ -479,58 +479,58 @@ static OtaMqttStatus_t unsubscribeFromDataStream( const OtaAgentContext_t * pAge
  */
 static OtaMqttStatus_t unsubscribeFromJobNotificationTopic( const OtaAgentContext_t * pAgentCtx )
 {
-	OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
+    OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
 
-	/* This buffer is used to store the generated MQTT topic. The static size
-	 * is calculated from the template and the corresponding parameters. This
-	 * buffer is used with two separate templates and its size is set fit the
-	 * larger of the two. */
-	char pJobTopic[ TOPIC_NOTIFY_NEXT_BUFFER_SIZE ];
-	uint16_t topicLen = 0;
+    /* This buffer is used to store the generated MQTT topic. The static size
+     * is calculated from the template and the corresponding parameters. This
+     * buffer is used with two separate templates and its size is set fit the
+     * larger of the two. */
+    char pJobTopic[ TOPIC_NOTIFY_NEXT_BUFFER_SIZE ];
+    uint16_t topicLen = 0;
 
-	/* NULL-terminated list of topic string parts. */
-	const char * topicStringParts[] =
-	{
-		MQTT_API_THINGS,
-		NULL, /* Thing Name not available at compile time, initialized below. */
-		MQTT_API_JOBS_NOTIFY_NEXT,
-		NULL
-	};
+    /* NULL-terminated list of topic string parts. */
+    const char * topicStringParts[] =
+    {
+        MQTT_API_THINGS,
+        NULL, /* Thing Name not available at compile time, initialized below. */
+        MQTT_API_JOBS_NOTIFY_NEXT,
+        NULL
+    };
 
-	assert( pAgentCtx != NULL );
-	assert( pAgentCtx->pOtaInterface != NULL );
-	assert( pAgentCtx->pOtaInterface->mqtt.unsubscribe != NULL );
+    assert( pAgentCtx != NULL );
+    assert( pAgentCtx->pOtaInterface != NULL );
+    assert( pAgentCtx->pOtaInterface->mqtt.unsubscribe != NULL );
 
-	/* Try to unsubscribe from the first of two job topics. */
+    /* Try to unsubscribe from the first of two job topics. */
 
-	topicStringParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
-	topicLen = ( uint16_t ) stringBuilder(
-		pJobTopic,
-		sizeof( pJobTopic ),
-		topicStringParts );
+    topicStringParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
+    topicLen = ( uint16_t ) stringBuilder(
+        pJobTopic,
+        sizeof( pJobTopic ),
+        topicStringParts );
 
-	/* The buffer is static and the size is calculated to fit. */
-	assert( ( topicLen > 0U ) && ( topicLen < sizeof( pJobTopic ) ) );
+    /* The buffer is static and the size is calculated to fit. */
+    assert( ( topicLen > 0U ) && ( topicLen < sizeof( pJobTopic ) ) );
 
-	mqttStatus = pAgentCtx->pOtaInterface->mqtt.unsubscribe( pJobTopic,
-	                                                         topicLen,
-	                                                         0 );
+    mqttStatus = pAgentCtx->pOtaInterface->mqtt.unsubscribe( pJobTopic,
+                                                             topicLen,
+                                                             0 );
 
-	if( mqttStatus == OtaMqttSuccess )
-	{
-		LogInfo( ( "Unsubscribed to MQTT topic: %s", pJobTopic ) );
-	}
-	else
-	{
-		LogError( ( "Failed to unsubscribe to MQTT topic: "
-		            "unsubscribe returned error: "
-		            "OtaMqttStatus_t=%s"
-		            ", topic=%s",
-		            OTA_MQTT_strerror( mqttStatus ),
-		            pJobTopic ) );
-	}
+    if( mqttStatus == OtaMqttSuccess )
+    {
+        LogInfo( ( "Unsubscribed to MQTT topic: %s", pJobTopic ) );
+    }
+    else
+    {
+        LogError( ( "Failed to unsubscribe to MQTT topic: "
+                    "unsubscribe returned error: "
+                    "OtaMqttStatus_t=%s"
+                    ", topic=%s",
+                    OTA_MQTT_strerror( mqttStatus ),
+                    pJobTopic ) );
+    }
 
-	return mqttStatus;
+    return mqttStatus;
 }
 
 /*
@@ -541,71 +541,71 @@ static OtaMqttStatus_t publishStatusMessage( const OtaAgentContext_t * pAgentCtx
                                              uint32_t msgSize,
                                              uint8_t qos )
 {
-	OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
-	size_t topicLen = 0;
+    OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
+    size_t topicLen = 0;
 
-	/* This buffer is used to store the generated MQTT topic. The static size
-	 * is calculated from the template and the corresponding parameters. */
-	char pTopicBuffer[ TOPIC_JOB_STATUS_BUFFER_SIZE ];
-	/* NULL-terminated list of topic string parts. */
-	const char * topicStringParts[] =
-	{
-		MQTT_API_THINGS,
-		NULL, /* Thing Name not available at compile time, initialized below. */
-		MQTT_API_JOBS,
-		NULL, /* Active Job Name not available at compile time, initialized below. */
-		MQTT_API_UPDATE,
-		NULL
-	};
+    /* This buffer is used to store the generated MQTT topic. The static size
+     * is calculated from the template and the corresponding parameters. */
+    char pTopicBuffer[ TOPIC_JOB_STATUS_BUFFER_SIZE ];
+    /* NULL-terminated list of topic string parts. */
+    const char * topicStringParts[] =
+    {
+        MQTT_API_THINGS,
+        NULL, /* Thing Name not available at compile time, initialized below. */
+        MQTT_API_JOBS,
+        NULL, /* Active Job Name not available at compile time, initialized below. */
+        MQTT_API_UPDATE,
+        NULL
+    };
 
-	assert( pAgentCtx != NULL );
-	/* pMsg is a static buffer of size "OTA_STATUS_MSG_MAX_SIZE". */
-	assert( pMsg != NULL );
+    assert( pAgentCtx != NULL );
+    /* pMsg is a static buffer of size "OTA_STATUS_MSG_MAX_SIZE". */
+    assert( pMsg != NULL );
 
-	/* Suppress warnings about unused variables. */
-	( void ) pOtaJobStatusTopicTemplate;
+    /* Suppress warnings about unused variables. */
+    ( void ) pOtaJobStatusTopicTemplate;
 
-	/* Build the dynamic job status topic . */
+    /* Build the dynamic job status topic . */
 
-	topicStringParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
-	topicStringParts[ 3 ] = ( const char * ) pAgentCtx->pActiveJobName;
+    topicStringParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
+    topicStringParts[ 3 ] = ( const char * ) pAgentCtx->pActiveJobName;
 
-	topicLen = stringBuilder(
-		pTopicBuffer,
-		sizeof( pTopicBuffer ),
-		topicStringParts );
+    topicLen = stringBuilder(
+        pTopicBuffer,
+        sizeof( pTopicBuffer ),
+        topicStringParts );
 
-	/* The buffer is static and the size is calculated to fit. */
-	assert( ( topicLen > 0U ) && ( topicLen < sizeof( pTopicBuffer ) ) );
+    /* The buffer is static and the size is calculated to fit. */
+    assert( ( topicLen > 0U ) && ( topicLen < sizeof( pTopicBuffer ) ) );
 
-	/* Publish the status message. */
-	LogDebug( ( "Attempting to publish MQTT status message: "
-	            "message=%s",
-	            pMsg ) );
+    /* Publish the status message. */
+    LogDebug( ( "Attempting to publish MQTT status message: "
+                "message=%s",
+                pMsg ) );
 
-	mqttStatus = pAgentCtx->pOtaInterface->mqtt.publish( pTopicBuffer,
-	                                                     ( uint16_t ) topicLen,
-	                                                     &pMsg[ 0 ],
-	                                                     msgSize,
-	                                                     qos );
+    mqttStatus = pAgentCtx->pOtaInterface->mqtt.publish( pTopicBuffer,
+                                                         ( uint16_t ) topicLen,
+                                                         &pMsg[ 0 ],
+                                                         msgSize,
+                                                         qos );
 
-	if( mqttStatus == OtaMqttSuccess )
-	{
-		LogDebug( ( "Published to MQTT topic: "
-		            "topic=%s",
-		            pTopicBuffer ) );
-	}
-	else
-	{
-		LogError( ( "Failed to publish MQTT message: "
-		            "publish returned error: "
-		            "OtaMqttStatus_t=%s"
-		            ", topic=%s",
-		            OTA_MQTT_strerror( mqttStatus ),
-		            pTopicBuffer ) );
-	}
+    if( mqttStatus == OtaMqttSuccess )
+    {
+        LogDebug( ( "Published to MQTT topic: "
+                    "topic=%s",
+                    pTopicBuffer ) );
+    }
+    else
+    {
+        LogError( ( "Failed to publish MQTT message: "
+                    "publish returned error: "
+                    "OtaMqttStatus_t=%s"
+                    ", topic=%s",
+                    OTA_MQTT_strerror( mqttStatus ),
+                    pTopicBuffer ) );
+    }
 
-	return mqttStatus;
+    return mqttStatus;
 }
 
 static uint32_t buildStatusMessageReceiving( char * pMsgBuffer,
@@ -613,57 +613,57 @@ static uint32_t buildStatusMessageReceiving( char * pMsgBuffer,
                                              OtaJobStatus_t status,
                                              const OtaFileContext_t * pOTAFileCtx )
 {
-	char receivedString[ U32_MAX_LEN + 1 ];
-	char numBlocksString[ U32_MAX_LEN + 1 ];
-	uint32_t numBlocks = 0;
-	uint32_t received = 0;
-	uint32_t msgSize = 0;
-	/* NULL-terminated list of JSON payload components */
-	/* NOTE: this must conform to the following format, do not add spaces, etc. */
-	/*       "\"%s\":\"%u/%u\"}}" */
+    char receivedString[ U32_MAX_LEN + 1 ];
+    char numBlocksString[ U32_MAX_LEN + 1 ];
+    uint32_t numBlocks = 0;
+    uint32_t received = 0;
+    uint32_t msgSize = 0;
+    /* NULL-terminated list of JSON payload components */
+    /* NOTE: this must conform to the following format, do not add spaces, etc. */
+    /*       "\"%s\":\"%u/%u\"}}" */
 
-	const char * payloadStringParts[] =
-	{
-		NULL, /* Job status is not available at compile time, initialized below. */
-		pOtaStringReceive,
-		":\"",
-		NULL, /* Received string is not available at compile time, initialized below. */
-		"/",
-		NULL, /* # blocks string is not available at compile time, initialized below. */
-		"\"}}",
-		NULL
-	};
+    const char * payloadStringParts[] =
+    {
+        NULL, /* Job status is not available at compile time, initialized below. */
+        pOtaStringReceive,
+        ":\"",
+        NULL, /* Received string is not available at compile time, initialized below. */
+        "/",
+        NULL, /* # blocks string is not available at compile time, initialized below. */
+        "\"}}",
+        NULL
+    };
 
-	assert( pMsgBuffer != NULL );
-	/* This function is only called when a file is received, so it can't be NULL. */
-	assert( pOTAFileCtx != NULL );
+    assert( pMsgBuffer != NULL );
+    /* This function is only called when a file is received, so it can't be NULL. */
+    assert( pOTAFileCtx != NULL );
 
-	numBlocks = ( pOTAFileCtx->fileSize + ( OTA_FILE_BLOCK_SIZE - 1U ) ) >> otaconfigLOG2_FILE_BLOCK_SIZE;
-	received = numBlocks - pOTAFileCtx->blocksRemaining;
+    numBlocks = ( pOTAFileCtx->fileSize + ( OTA_FILE_BLOCK_SIZE - 1U ) ) >> otaconfigLOG2_FILE_BLOCK_SIZE;
+    received = numBlocks - pOTAFileCtx->blocksRemaining;
 
-	/* Output a status update when receiving first file block to let user know the OTA job status
-	 * more clearly. Then output a status update once in a while. */
+    /* Output a status update when receiving first file block to let user know the OTA job status
+     * more clearly. Then output a status update once in a while. */
 
-	if( ( received == 1U ) || ( ( received % ( uint32_t ) otaconfigOTA_UPDATE_STATUS_FREQUENCY ) == 0U ) )
-	{
-		payloadStringParts[ 0 ] = pOtaJobStatusStrings[ status ];
-		payloadStringParts[ 3 ] = receivedString;
-		payloadStringParts[ 5 ] = numBlocksString;
+    if( ( received == 1U ) || ( ( received % ( uint32_t ) otaconfigOTA_UPDATE_STATUS_FREQUENCY ) == 0U ) )
+    {
+        payloadStringParts[ 0 ] = pOtaJobStatusStrings[ status ];
+        payloadStringParts[ 3 ] = receivedString;
+        payloadStringParts[ 5 ] = numBlocksString;
 
-		( void ) stringBuilderUInt32Decimal( receivedString, sizeof( receivedString ), received );
-		( void ) stringBuilderUInt32Decimal( numBlocksString, sizeof( numBlocksString ), numBlocks );
+        ( void ) stringBuilderUInt32Decimal( receivedString, sizeof( receivedString ), received );
+        ( void ) stringBuilderUInt32Decimal( numBlocksString, sizeof( numBlocksString ), numBlocks );
 
 
-		msgSize = ( uint32_t ) stringBuilder(
-			pMsgBuffer,
-			msgBufferSize,
-			payloadStringParts );
+        msgSize = ( uint32_t ) stringBuilder(
+            pMsgBuffer,
+            msgBufferSize,
+            payloadStringParts );
 
-		/* The buffer is static and the size is calculated to fit. */
-		assert( ( msgSize > 0U ) && ( msgSize < msgBufferSize ) );
-	}
+        /* The buffer is static and the size is calculated to fit. */
+        assert( ( msgSize > 0U ) && ( msgSize < msgBufferSize ) );
+    }
 
-	return msgSize;
+    return msgSize;
 }
 
 static uint32_t prvBuildStatusMessageSelfTest( char * pMsgBuffer,
@@ -671,42 +671,42 @@ static uint32_t prvBuildStatusMessageSelfTest( char * pMsgBuffer,
                                                OtaJobStatus_t status,
                                                int32_t reason )
 {
-	uint32_t msgSize = 0;
+    uint32_t msgSize = 0;
 
-	/* NULL-terminated list of JSON payload components */
-	/* NOTE: this must agree with the following format, do not add spaces, etc. */
-	/*       "\"%s\":\"%s\",\"" OTA_JSON_UPDATED_BY_KEY_ONLY "\":\"0x%x\"}}" */
-	char versionString[ U32_MAX_LEN + 1 ];
-	const char * pPayloadStringParts[] =
-	{
-		NULL, /* Job status string not available at compile time, initialized below. */
-		"\"",
-		OTA_JSON_SELF_TEST_KEY_ONLY,
-		"\":\"",
-		NULL, /* Job reason string not available at compile time, initialized below. */
-		"\",\"" OTA_JSON_UPDATED_BY_KEY_ONLY "\":\"0x",
-		NULL, /* Version string not available at compile time, initialized below. */
-		"\"}}",
-		NULL
-	};
+    /* NULL-terminated list of JSON payload components */
+    /* NOTE: this must agree with the following format, do not add spaces, etc. */
+    /*       "\"%s\":\"%s\",\"" OTA_JSON_UPDATED_BY_KEY_ONLY "\":\"0x%x\"}}" */
+    char versionString[ U32_MAX_LEN + 1 ];
+    const char * pPayloadStringParts[] =
+    {
+        NULL, /* Job status string not available at compile time, initialized below. */
+        "\"",
+        OTA_JSON_SELF_TEST_KEY_ONLY,
+        "\":\"",
+        NULL, /* Job reason string not available at compile time, initialized below. */
+        "\",\"" OTA_JSON_UPDATED_BY_KEY_ONLY "\":\"0x",
+        NULL, /* Version string not available at compile time, initialized below. */
+        "\"}}",
+        NULL
+    };
 
-	assert( pMsgBuffer != NULL );
+    assert( pMsgBuffer != NULL );
 
-	( void ) stringBuilderUInt32Hex( versionString, sizeof( versionString ), appFirmwareVersion.u.unsignedVersion32 );
-	pPayloadStringParts[ 0 ] = pOtaJobStatusStrings[ status ];
-	pPayloadStringParts[ 4 ] = pOtaJobReasonStrings[ reason ];
-	pPayloadStringParts[ 6 ] = versionString;
+    ( void ) stringBuilderUInt32Hex( versionString, sizeof( versionString ), appFirmwareVersion.u.unsignedVersion32 );
+    pPayloadStringParts[ 0 ] = pOtaJobStatusStrings[ status ];
+    pPayloadStringParts[ 4 ] = pOtaJobReasonStrings[ reason ];
+    pPayloadStringParts[ 6 ] = versionString;
 
-	msgSize = ( uint32_t ) stringBuilder(
-		pMsgBuffer,
-		msgBufferSize,
-		pPayloadStringParts );
+    msgSize = ( uint32_t ) stringBuilder(
+        pMsgBuffer,
+        msgBufferSize,
+        pPayloadStringParts );
 
-	assert( ( msgSize > 0U ) && ( msgSize < msgBufferSize ) );
+    assert( ( msgSize > 0U ) && ( msgSize < msgBufferSize ) );
 
-	LogDebug( ( "Created self test update: %s", pMsgBuffer ) );
+    LogDebug( ( "Created self test update: %s", pMsgBuffer ) );
 
-	return msgSize;
+    return msgSize;
 }
 
 static uint32_t prvBuildStatusMessageFinish( char * pMsgBuffer,
@@ -716,136 +716,136 @@ static uint32_t prvBuildStatusMessageFinish( char * pMsgBuffer,
                                              int32_t subReason,
                                              uint32_t previousVersion )
 {
-	uint32_t msgSize = 0;
-	char reasonString[ U32_MAX_LEN + 1 ];
-	char subReasonString[ U32_MAX_LEN + 1 ];
-	char newVersionMajorString[ U32_MAX_LEN + 1 ];
-	char newVersionMinorString[ U32_MAX_LEN + 1 ];
-	char newVersionBuildString[ U32_MAX_LEN + 1 ];
-	char prevVersionMajorString[ U32_MAX_LEN + 1 ];
-	char prevVersionMinorString[ U32_MAX_LEN + 1 ];
-	char prevVersionBuildString[ U32_MAX_LEN + 1 ];
+    uint32_t msgSize = 0;
+    char reasonString[ U32_MAX_LEN + 1 ];
+    char subReasonString[ U32_MAX_LEN + 1 ];
+    char newVersionMajorString[ U32_MAX_LEN + 1 ];
+    char newVersionMinorString[ U32_MAX_LEN + 1 ];
+    char newVersionBuildString[ U32_MAX_LEN + 1 ];
+    char prevVersionMajorString[ U32_MAX_LEN + 1 ];
+    char prevVersionMinorString[ U32_MAX_LEN + 1 ];
+    char prevVersionBuildString[ U32_MAX_LEN + 1 ];
 
-	AppVersion32_t newVersion = { 0 }, prevVersion = { 0 };
+    AppVersion32_t newVersion = { 0 }, prevVersion = { 0 };
 
-	/* NULL-terminated list of payload string parts */
-	/* NOTE: this must conform to the following format, do not add spaces, etc. */
-	/*       "\"reason\":\"0x%08x: 0x%08x\"}}" */
+    /* NULL-terminated list of payload string parts */
+    /* NOTE: this must conform to the following format, do not add spaces, etc. */
+    /*       "\"reason\":\"0x%08x: 0x%08x\"}}" */
 
-	const char * pPayloadPartsStatusFailedWithValue[] =
-	{
-		NULL, /* Job status string not available at compile time, initialized below. */
-		"\"reason\":\"0x",
-		NULL, /* Reason string not available at compile time, initialized below. */
-		": 0x",
-		NULL, /* Sub-Reason string not available at compile time, initialized below. */
-		"\"}}",
-		NULL
-	};
-	/* NULL-terminated list of payload string parts */
-	/* NOTE: this must agree with the following format, do not add spaces, etc. */
-	/*       "\"reason\":\"%s v%u.%u.%u\"}}" */
-	const char * pPayloadPartsStatusSucceeded[] =
-	{
-		NULL,                                 /* Job status string not available at compile time, initialized below. */
-		"\"reason\":\"",
-		NULL,                                 /*  Reason string not available at compile time, initialized below. */
-		"  v",
-		NULL,                                 /* Version major string not available at compile time, initialized below. */
-		".",
-		NULL,                                 /* Version minor string not available at compile time, initialized below. */
-		".",
-		NULL,                                 /* Version build string not available at compile time, initialized below. */
-		"\",\"" OTA_JSON_UPDATED_BY_KEY_ONLY "\":\"", /* Expands to `","updatedBy":` */
-		"  v",
-		NULL,                                 /* Previous version major string not available at compile time, initialized below. */
-		".",
-		NULL,                                 /* Previous version minor string not available at compile time, initialized below. */
-		".",
-		NULL,                                 /* Previous version build string not available at compile time, initialized below. */
-		"\"}}",
-		NULL
-	};
+    const char * pPayloadPartsStatusFailedWithValue[] =
+    {
+        NULL, /* Job status string not available at compile time, initialized below. */
+        "\"reason\":\"0x",
+        NULL, /* Reason string not available at compile time, initialized below. */
+        ": 0x",
+        NULL, /* Sub-Reason string not available at compile time, initialized below. */
+        "\"}}",
+        NULL
+    };
+    /* NULL-terminated list of payload string parts */
+    /* NOTE: this must agree with the following format, do not add spaces, etc. */
+    /*       "\"reason\":\"%s v%u.%u.%u\"}}" */
+    const char * pPayloadPartsStatusSucceeded[] =
+    {
+        NULL,                                         /* Job status string not available at compile time, initialized below. */
+        "\"reason\":\"",
+        NULL,                                         /*  Reason string not available at compile time, initialized below. */
+        "  v",
+        NULL,                                         /* Version major string not available at compile time, initialized below. */
+        ".",
+        NULL,                                         /* Version minor string not available at compile time, initialized below. */
+        ".",
+        NULL,                                         /* Version build string not available at compile time, initialized below. */
+        "\",\"" OTA_JSON_UPDATED_BY_KEY_ONLY "\":\"", /* Expands to `","updatedBy":` */
+        "  v",
+        NULL,                                         /* Previous version major string not available at compile time, initialized below. */
+        ".",
+        NULL,                                         /* Previous version minor string not available at compile time, initialized below. */
+        ".",
+        NULL,                                         /* Previous version build string not available at compile time, initialized below. */
+        "\"}}",
+        NULL
+    };
 
-	/* NULL-terminated list of payload string parts */
-	/* NOTE: this must agree with the following format, do not add spaces, etc. */
-	/*       "\"reason\":\"%s: 0x%08x\"}}" */
-	const char * pPayloadPartsStatusOther[] =
-	{
-		NULL, /* Job status string not available at compile time, initialized below. */
-		"\"reason\":\"",
-		NULL, /*  Reason string not available at compile time, initialized below. */
-		": 0x",
-		NULL, /* Sub-Reason string not available at compile time, initialized below. */
-		"\"}}",
-		NULL
-	};
-	const char ** pPayloadParts;
+    /* NULL-terminated list of payload string parts */
+    /* NOTE: this must agree with the following format, do not add spaces, etc. */
+    /*       "\"reason\":\"%s: 0x%08x\"}}" */
+    const char * pPayloadPartsStatusOther[] =
+    {
+        NULL, /* Job status string not available at compile time, initialized below. */
+        "\"reason\":\"",
+        NULL, /*  Reason string not available at compile time, initialized below. */
+        ": 0x",
+        NULL, /* Sub-Reason string not available at compile time, initialized below. */
+        "\"}}",
+        NULL
+    };
+    const char ** pPayloadParts;
 
-	assert( pMsgBuffer != NULL );
+    assert( pMsgBuffer != NULL );
 
-	newVersion.u.signedVersion32 = subReason;
-	prevVersion.u.signedVersion32 = ( int32_t ) previousVersion;
+    newVersion.u.signedVersion32 = subReason;
+    prevVersion.u.signedVersion32 = ( int32_t ) previousVersion;
 
-	( void ) stringBuilderUInt32Hex( reasonString, sizeof( reasonString ), ( uint32_t ) reason );
-	( void ) stringBuilderUInt32Hex( subReasonString, sizeof( subReasonString ), ( uint32_t ) subReason );
+    ( void ) stringBuilderUInt32Hex( reasonString, sizeof( reasonString ), ( uint32_t ) reason );
+    ( void ) stringBuilderUInt32Hex( subReasonString, sizeof( subReasonString ), ( uint32_t ) subReason );
 
-	/* FailedWithVal uses a numeric OTA error code and sub-reason code to cover
-	 * the case where there may be too many description strings to reasonably
-	 * include in the code.
-	 */
-	if( status == JobStatusFailedWithVal )
-	{
-		pPayloadParts = pPayloadPartsStatusFailedWithValue;
-		pPayloadParts[ 0 ] = pOtaJobStatusStrings[ status ];
-		pPayloadParts[ 2 ] = reasonString;
-		pPayloadParts[ 4 ] = subReasonString;
-	}
+    /* FailedWithVal uses a numeric OTA error code and sub-reason code to cover
+     * the case where there may be too many description strings to reasonably
+     * include in the code.
+     */
+    if( status == JobStatusFailedWithVal )
+    {
+        pPayloadParts = pPayloadPartsStatusFailedWithValue;
+        pPayloadParts[ 0 ] = pOtaJobStatusStrings[ status ];
+        pPayloadParts[ 2 ] = reasonString;
+        pPayloadParts[ 4 ] = subReasonString;
+    }
 
-	/* If the status update is for "Succeeded," we are identifying the version
-	 * of firmware that has been accepted. This makes it easy to find the
-	 * version associated with each device (Thing) when examining the OTA jobs
-	 * on the service side via the CLI or possibly with some console tool.
-	 */
-	else if( status == JobStatusSucceeded )
-	{
-		/* New version string.*/
-		( void ) stringBuilderUInt32Decimal( newVersionMajorString, sizeof( newVersionMajorString ), newVersion.u.x.major );
-		( void ) stringBuilderUInt32Decimal( newVersionMinorString, sizeof( newVersionMinorString ), newVersion.u.x.minor );
-		( void ) stringBuilderUInt32Decimal( newVersionBuildString, sizeof( newVersionBuildString ), newVersion.u.x.build );
+    /* If the status update is for "Succeeded," we are identifying the version
+     * of firmware that has been accepted. This makes it easy to find the
+     * version associated with each device (Thing) when examining the OTA jobs
+     * on the service side via the CLI or possibly with some console tool.
+     */
+    else if( status == JobStatusSucceeded )
+    {
+        /* New version string.*/
+        ( void ) stringBuilderUInt32Decimal( newVersionMajorString, sizeof( newVersionMajorString ), newVersion.u.x.major );
+        ( void ) stringBuilderUInt32Decimal( newVersionMinorString, sizeof( newVersionMinorString ), newVersion.u.x.minor );
+        ( void ) stringBuilderUInt32Decimal( newVersionBuildString, sizeof( newVersionBuildString ), newVersion.u.x.build );
 
-		/* Updater version string.*/
-		( void ) stringBuilderUInt32Decimal( prevVersionMajorString, sizeof( prevVersionMajorString ), prevVersion.u.x.major );
-		( void ) stringBuilderUInt32Decimal( prevVersionMinorString, sizeof( prevVersionMinorString ), prevVersion.u.x.minor );
-		( void ) stringBuilderUInt32Decimal( prevVersionBuildString, sizeof( prevVersionMinorString ), prevVersion.u.x.build );
+        /* Updater version string.*/
+        ( void ) stringBuilderUInt32Decimal( prevVersionMajorString, sizeof( prevVersionMajorString ), prevVersion.u.x.major );
+        ( void ) stringBuilderUInt32Decimal( prevVersionMinorString, sizeof( prevVersionMinorString ), prevVersion.u.x.minor );
+        ( void ) stringBuilderUInt32Decimal( prevVersionBuildString, sizeof( prevVersionMinorString ), prevVersion.u.x.build );
 
-		pPayloadParts = pPayloadPartsStatusSucceeded;
-		pPayloadParts[ 0 ] = pOtaJobStatusStrings[ status ];
-		pPayloadParts[ 2 ] = pOtaJobReasonStrings[ reason ];
-		pPayloadParts[ 4 ] = newVersionMajorString;
-		pPayloadParts[ 6 ] = newVersionMinorString;
-		pPayloadParts[ 8 ] = newVersionBuildString;
-		pPayloadParts[ 11 ] = prevVersionMajorString;
-		pPayloadParts[ 13 ] = prevVersionMinorString;
-		pPayloadParts[ 15 ] = prevVersionBuildString;
-	}
-	else
-	{
-		pPayloadParts = pPayloadPartsStatusOther;
-		pPayloadParts[ 0 ] = pOtaJobStatusStrings[ status ];
-		pPayloadParts[ 2 ] = pOtaJobReasonStrings[ reason ];
-		pPayloadParts[ 4 ] = subReasonString;
-	}
+        pPayloadParts = pPayloadPartsStatusSucceeded;
+        pPayloadParts[ 0 ] = pOtaJobStatusStrings[ status ];
+        pPayloadParts[ 2 ] = pOtaJobReasonStrings[ reason ];
+        pPayloadParts[ 4 ] = newVersionMajorString;
+        pPayloadParts[ 6 ] = newVersionMinorString;
+        pPayloadParts[ 8 ] = newVersionBuildString;
+        pPayloadParts[ 11 ] = prevVersionMajorString;
+        pPayloadParts[ 13 ] = prevVersionMinorString;
+        pPayloadParts[ 15 ] = prevVersionBuildString;
+    }
+    else
+    {
+        pPayloadParts = pPayloadPartsStatusOther;
+        pPayloadParts[ 0 ] = pOtaJobStatusStrings[ status ];
+        pPayloadParts[ 2 ] = pOtaJobReasonStrings[ reason ];
+        pPayloadParts[ 4 ] = subReasonString;
+    }
 
-	msgSize = ( uint32_t ) stringBuilder(
-		pMsgBuffer,
-		msgBufferSize,
-		pPayloadParts );
+    msgSize = ( uint32_t ) stringBuilder(
+        pMsgBuffer,
+        msgBufferSize,
+        pPayloadParts );
 
-	/* The buffer is static and the size is calculated to fit. */
-	assert( ( msgSize > 0U ) && ( msgSize < msgBufferSize ) );
+    /* The buffer is static and the size is calculated to fit. */
+    assert( ( msgSize > 0U ) && ( msgSize < msgBufferSize ) );
 
-	return msgSize;
+    return msgSize;
 }
 
 /*
@@ -855,98 +855,98 @@ static uint32_t prvBuildStatusMessageFinish( char * pMsgBuffer,
 
 OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
 {
-	/* This buffer is used to store the generated MQTT topic. The static size
-	 * is calculated from the template and the corresponding parameters. */
-	char pJobTopic[ TOPIC_GET_NEXT_BUFFER_SIZE ];
+    /* This buffer is used to store the generated MQTT topic. The static size
+     * is calculated from the template and the corresponding parameters. */
+    char pJobTopic[ TOPIC_GET_NEXT_BUFFER_SIZE ];
 
-	/* The following buffer is big enough to hold a dynamically constructed
-	 * $next/get job message. It contains a client token that is used to track
-	 * how many requests have been made. */
-	char pMsg[ MSG_GET_NEXT_BUFFER_SIZE ] = { '\0' };
+    /* The following buffer is big enough to hold a dynamically constructed
+     * $next/get job message. It contains a client token that is used to track
+     * how many requests have been made. */
+    char pMsg[ MSG_GET_NEXT_BUFFER_SIZE ] = { '\0' };
 
-	static uint32_t reqCounter = 0;
-	OtaErr_t otaError = OtaErrRequestJobFailed;
-	OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
-	uint32_t msgSize = 0;
-	uint16_t topicLen = 0;
-	uint32_t xThingNameLength = 0;
-	uint32_t reqCounterStringLength = 0;
+    static uint32_t reqCounter = 0;
+    OtaErr_t otaError = OtaErrRequestJobFailed;
+    OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
+    uint32_t msgSize = 0;
+    uint16_t topicLen = 0;
+    uint32_t xThingNameLength = 0;
+    uint32_t reqCounterStringLength = 0;
 
-	/* NULL-terminated list of topic string parts. */
-	const char * pTopicParts[] =
-	{
-		MQTT_API_THINGS,
-		NULL, /* Thing Name not available at compile time, initialized below. */
-		MQTT_API_JOBS_NEXT_GET,
-		NULL
-	};
-	char reqCounterString[ U32_MAX_LEN + 1 ];
+    /* NULL-terminated list of topic string parts. */
+    const char * pTopicParts[] =
+    {
+        MQTT_API_THINGS,
+        NULL, /* Thing Name not available at compile time, initialized below. */
+        MQTT_API_JOBS_NEXT_GET,
+        NULL
+    };
+    char reqCounterString[ U32_MAX_LEN + 1 ];
 
-	/* NULL-terminated list of payload parts */
+    /* NULL-terminated list of payload parts */
 
-	assert( pAgentCtx != NULL );
+    assert( pAgentCtx != NULL );
 
-	/* Suppress warnings about unused variables. */
-	( void ) pOtaJobsGetNextTopicTemplate;
-	( void ) pOtaGetNextJobMsgTemplate;
+    /* Suppress warnings about unused variables. */
+    ( void ) pOtaJobsGetNextTopicTemplate;
+    ( void ) pOtaGetNextJobMsgTemplate;
 
-	/* Client token max length is 64. It is a combination of request counter (max 10 characters), a separator colon, and the ThingName. */
-	xThingNameLength = ( uint32_t ) strnlen( ( const char * ) pAgentCtx->pThingName, OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN );
+    /* Client token max length is 64. It is a combination of request counter (max 10 characters), a separator colon, and the ThingName. */
+    xThingNameLength = ( uint32_t ) strnlen( ( const char * ) pAgentCtx->pThingName, OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN );
 
-	reqCounterStringLength = ( uint32_t ) stringBuilderUInt32Decimal( reqCounterString, sizeof( reqCounterString ), reqCounter );
+    reqCounterStringLength = ( uint32_t ) stringBuilderUInt32Decimal( reqCounterString, sizeof( reqCounterString ), reqCounter );
 
-	/* Assemble the string by copying the pieces into the buffer. This is done manually since we know the size of the thingname. */
-	strncpy( &pMsg[ msgSize ], "{\"clientToken\":\"", MSG_GET_NEXT_BUFFER_SIZE );
-	msgSize = 16U;
-	strncpy( &pMsg[ msgSize ], reqCounterString, reqCounterStringLength );
-	/* Do not count the terminating null byte on the request counter string */
-	msgSize += reqCounterStringLength-1;
-	strncpy( &pMsg[ msgSize ], ":", MSG_GET_NEXT_BUFFER_SIZE - msgSize );
-	msgSize++;
-	strncpy( &pMsg[ msgSize ], ( const char * ) pAgentCtx->pThingName, xThingNameLength );
-	msgSize += xThingNameLength;
-	strncpy( &pMsg[ msgSize ], "\"}", MSG_GET_NEXT_BUFFER_SIZE - msgSize );
-	msgSize += 2U;
+    /* Assemble the string by copying the pieces into the buffer. This is done manually since we know the size of the thingname. */
+    strncpy( &pMsg[ msgSize ], "{\"clientToken\":\"", MSG_GET_NEXT_BUFFER_SIZE );
+    msgSize = 16U;
+    strncpy( &pMsg[ msgSize ], reqCounterString, reqCounterStringLength );
+    /* Do not count the terminating null byte on the request counter string */
+    msgSize += reqCounterStringLength - 1;
+    strncpy( &pMsg[ msgSize ], ":", MSG_GET_NEXT_BUFFER_SIZE - msgSize );
+    msgSize++;
+    strncpy( &pMsg[ msgSize ], ( const char * ) pAgentCtx->pThingName, xThingNameLength );
+    msgSize += xThingNameLength;
+    strncpy( &pMsg[ msgSize ], "\"}", MSG_GET_NEXT_BUFFER_SIZE - msgSize );
+    msgSize += 2U;
 
-	/* Subscribe to the OTA job notification topic. */
-	mqttStatus = subscribeToJobNotificationTopics( pAgentCtx );
+    /* Subscribe to the OTA job notification topic. */
+    mqttStatus = subscribeToJobNotificationTopics( pAgentCtx );
 
-	if( mqttStatus == OtaMqttSuccess )
-	{
-		LogDebug( ( "MQTT job request number: counter=%u", reqCounter ) );
+    if( mqttStatus == OtaMqttSuccess )
+    {
+        LogDebug( ( "MQTT job request number: counter=%u", reqCounter ) );
 
-		/* The buffer is static and the size is calculated to fit. */
-		assert( ( msgSize > 0U ) && ( msgSize < sizeof( pMsg ) ) );
+        /* The buffer is static and the size is calculated to fit. */
+        assert( ( msgSize > 0U ) && ( msgSize < sizeof( pMsg ) ) );
 
-		reqCounter++;
+        reqCounter++;
 
-		topicLen = ( uint16_t ) stringBuilder(
-			pJobTopic,
-			sizeof( pJobTopic ),
-			pTopicParts );
+        topicLen = ( uint16_t ) stringBuilder(
+            pJobTopic,
+            sizeof( pJobTopic ),
+            pTopicParts );
 
-		/* The buffer is static and the size is calculated to fit. */
-		assert( ( topicLen > 0U ) && ( topicLen < sizeof( pJobTopic ) ) );
+        /* The buffer is static and the size is calculated to fit. */
+        assert( ( topicLen > 0U ) && ( topicLen < sizeof( pJobTopic ) ) );
 
-		mqttStatus = pAgentCtx->pOtaInterface->mqtt.publish( pJobTopic, topicLen, pMsg, msgSize, 1 );
+        mqttStatus = pAgentCtx->pOtaInterface->mqtt.publish( pJobTopic, topicLen, pMsg, msgSize, 1 );
 
-		if( mqttStatus == OtaMqttSuccess )
-		{
-			LogDebug( ( "Published MQTT request to get the next job: "
-			            "topic=%s",
-			            pJobTopic ) );
-			otaError = OtaErrNone;
-		}
-		else
-		{
-			LogError( ( "Failed to publish MQTT message:"
-			            "publish returned error: "
-			            "OtaMqttStatus_t=%s",
-			            OTA_MQTT_strerror( mqttStatus ) ) );
-		}
-	}
+        if( mqttStatus == OtaMqttSuccess )
+        {
+            LogDebug( ( "Published MQTT request to get the next job: "
+                        "topic=%s",
+                        pJobTopic ) );
+            otaError = OtaErrNone;
+        }
+        else
+        {
+            LogError( ( "Failed to publish MQTT message:"
+                        "publish returned error: "
+                        "OtaMqttStatus_t=%s",
+                        OTA_MQTT_strerror( mqttStatus ) ) );
+        }
+    }
 
-	return otaError;
+    return otaError;
 }
 
 
@@ -958,64 +958,64 @@ OtaErr_t updateJobStatus_Mqtt( const OtaAgentContext_t * pAgentCtx,
                                int32_t reason,
                                int32_t subReason )
 {
-	OtaErr_t result = OtaErrNone;
-	OtaMqttStatus_t mqttStatus = OtaMqttPublishFailed;
-	/* A message size of zero means don't publish anything. */
-	uint32_t msgSize = 0U;
-	/* All job state transitions except streaming progress use QOS 1 since it is required to have status in the job document. */
-	char pMsg[ OTA_STATUS_MSG_MAX_SIZE ];
-	uint8_t qos = 1;
-	const OtaFileContext_t * pFileContext = NULL;
+    OtaErr_t result = OtaErrNone;
+    OtaMqttStatus_t mqttStatus = OtaMqttPublishFailed;
+    /* A message size of zero means don't publish anything. */
+    uint32_t msgSize = 0U;
+    /* All job state transitions except streaming progress use QOS 1 since it is required to have status in the job document. */
+    char pMsg[ OTA_STATUS_MSG_MAX_SIZE ];
+    uint8_t qos = 1;
+    const OtaFileContext_t * pFileContext = NULL;
 
-	assert( pAgentCtx != NULL );
+    assert( pAgentCtx != NULL );
 
-	/* Get the current file context. */
-	pFileContext = &( pAgentCtx->fileContext );
+    /* Get the current file context. */
+    pFileContext = &( pAgentCtx->fileContext );
 
-	if( status == JobStatusInProgress )
-	{
-		if( reason == ( int32_t ) JobReasonReceiving )
-		{
-			msgSize = buildStatusMessageReceiving( pMsg, sizeof( pMsg ), status, pFileContext );
+    if( status == JobStatusInProgress )
+    {
+        if( reason == ( int32_t ) JobReasonReceiving )
+        {
+            msgSize = buildStatusMessageReceiving( pMsg, sizeof( pMsg ), status, pFileContext );
 
-			/* Downgrade Progress updates to QOS 0 to avoid overloading MQTT buffers during active streaming. */
-			qos = 0;
-		}
-		else
-		{
-			/* We're no longer receiving but we're still In Progress so we are implicitly in the Self
-			 * Test phase. Prepare to update the job status with the self_test phase (ready or active). */
-			msgSize = prvBuildStatusMessageSelfTest( pMsg, sizeof( pMsg ), status, reason );
-		}
-	}
-	else
-	{
-		/* The potential values for status are constant at compile time. */
-		assert( status < NumJobStatusMappings );
-		msgSize = prvBuildStatusMessageFinish( pMsg, sizeof( pMsg ), status, reason, subReason, pAgentCtx->fileContext.updaterVersion );
-	}
+            /* Downgrade Progress updates to QOS 0 to avoid overloading MQTT buffers during active streaming. */
+            qos = 0;
+        }
+        else
+        {
+            /* We're no longer receiving but we're still In Progress so we are implicitly in the Self
+             * Test phase. Prepare to update the job status with the self_test phase (ready or active). */
+            msgSize = prvBuildStatusMessageSelfTest( pMsg, sizeof( pMsg ), status, reason );
+        }
+    }
+    else
+    {
+        /* The potential values for status are constant at compile time. */
+        assert( status < NumJobStatusMappings );
+        msgSize = prvBuildStatusMessageFinish( pMsg, sizeof( pMsg ), status, reason, subReason, pAgentCtx->fileContext.updaterVersion );
+    }
 
-	if( msgSize > 0U )
-	{
-		/* Publish the string created above. */
-		mqttStatus = publishStatusMessage( pAgentCtx, pMsg, msgSize, qos );
+    if( msgSize > 0U )
+    {
+        /* Publish the string created above. */
+        mqttStatus = publishStatusMessage( pAgentCtx, pMsg, msgSize, qos );
 
-		if( mqttStatus == OtaMqttSuccess )
-		{
-			LogDebug( ( "Published update to the job status." ) );
-		}
-		else
-		{
-			LogError( ( "Failed to publish MQTT status message: "
-			            "publishStatusMessage returned error: "
-			            "OtaMqttStatus_t=%s",
-			            OTA_MQTT_strerror( mqttStatus ) ) );
+        if( mqttStatus == OtaMqttSuccess )
+        {
+            LogDebug( ( "Published update to the job status." ) );
+        }
+        else
+        {
+            LogError( ( "Failed to publish MQTT status message: "
+                        "publishStatusMessage returned error: "
+                        "OtaMqttStatus_t=%s",
+                        OTA_MQTT_strerror( mqttStatus ) ) );
 
-			result = OtaErrUpdateJobStatusFailed;
-		}
-	}
+            result = OtaErrUpdateJobStatusFailed;
+        }
+    }
 
-	return result;
+    return result;
 }
 
 /*
@@ -1023,65 +1023,65 @@ OtaErr_t updateJobStatus_Mqtt( const OtaAgentContext_t * pAgentCtx,
  */
 OtaErr_t initFileTransfer_Mqtt( const OtaAgentContext_t * pAgentCtx )
 {
-	OtaErr_t result = OtaErrInitFileTransferFailed;
-	OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
+    OtaErr_t result = OtaErrInitFileTransferFailed;
+    OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
 
-	/* This buffer is used to store the generated MQTT topic. The static size
-	 * is calculated from the template and the corresponding parameters. */
-	static char pRxStreamTopic[ TOPIC_STREAM_DATA_BUFFER_SIZE ]; /*!< Buffer to store the topic generated for requesting data stream. */
-	uint16_t topicLen = 0;
-	const OtaFileContext_t * pFileContext = NULL;
+    /* This buffer is used to store the generated MQTT topic. The static size
+     * is calculated from the template and the corresponding parameters. */
+    static char pRxStreamTopic[ TOPIC_STREAM_DATA_BUFFER_SIZE ]; /*!< Buffer to store the topic generated for requesting data stream. */
+    uint16_t topicLen = 0;
+    const OtaFileContext_t * pFileContext = NULL;
 
-	/* NULL-terminated list of topic string parts. */
-	const char * pTopicParts[] =
-	{
-		MQTT_API_THINGS,
-		NULL, /* Thing Name not available at compile time, initialized below. */
-		MQTT_API_STREAMS,
-		NULL, /* Stream Name not available at compile time, initialized below. */
-		MQTT_API_DATA_CBOR,
-		NULL
-	};
+    /* NULL-terminated list of topic string parts. */
+    const char * pTopicParts[] =
+    {
+        MQTT_API_THINGS,
+        NULL, /* Thing Name not available at compile time, initialized below. */
+        MQTT_API_STREAMS,
+        NULL, /* Stream Name not available at compile time, initialized below. */
+        MQTT_API_DATA_CBOR,
+        NULL
+    };
 
-	assert( pAgentCtx != NULL );
+    assert( pAgentCtx != NULL );
 
-	/* Suppress warnings about unused variables. */
-	( void ) pOtaStreamDataTopicTemplate;
+    /* Suppress warnings about unused variables. */
+    ( void ) pOtaStreamDataTopicTemplate;
 
-	pFileContext = &( pAgentCtx->fileContext );
-	pTopicParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
-	pTopicParts[ 3 ] = ( const char * ) pFileContext->pStreamName;
+    pFileContext = &( pAgentCtx->fileContext );
+    pTopicParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
+    pTopicParts[ 3 ] = ( const char * ) pFileContext->pStreamName;
 
-	topicLen = ( uint16_t ) stringBuilder(
-		pRxStreamTopic,
-		sizeof( pRxStreamTopic ),
-		pTopicParts );
+    topicLen = ( uint16_t ) stringBuilder(
+        pRxStreamTopic,
+        sizeof( pRxStreamTopic ),
+        pTopicParts );
 
-	/* The buffer is static and the size is calculated to fit. */
-	assert( ( topicLen > 0U ) && ( topicLen < sizeof( pRxStreamTopic ) ) );
+    /* The buffer is static and the size is calculated to fit. */
+    assert( ( topicLen > 0U ) && ( topicLen < sizeof( pRxStreamTopic ) ) );
 
-	mqttStatus = pAgentCtx->pOtaInterface->mqtt.subscribe( pRxStreamTopic,
-	                                                       topicLen,
-	                                                       0 );
+    mqttStatus = pAgentCtx->pOtaInterface->mqtt.subscribe( pRxStreamTopic,
+                                                           topicLen,
+                                                           0 );
 
-	if( mqttStatus == OtaMqttSuccess )
-	{
-		LogDebug( ( "Subscribed to the OTA data stream topic: "
-		            "topic=%s",
-		            pRxStreamTopic ) );
-		result = OtaErrNone;
-	}
-	else
-	{
-		LogError( ( "Failed to subscribe to MQTT topic: "
-		            "subscribe returned error: "
-		            "OtaMqttStatus_t=%s"
-		            ", topic=%s",
-		            OTA_MQTT_strerror( mqttStatus ),
-		            pRxStreamTopic ) );
-	}
+    if( mqttStatus == OtaMqttSuccess )
+    {
+        LogDebug( ( "Subscribed to the OTA data stream topic: "
+                    "topic=%s",
+                    pRxStreamTopic ) );
+        result = OtaErrNone;
+    }
+    else
+    {
+        LogError( ( "Failed to subscribe to MQTT topic: "
+                    "subscribe returned error: "
+                    "OtaMqttStatus_t=%s"
+                    ", topic=%s",
+                    OTA_MQTT_strerror( mqttStatus ),
+                    pRxStreamTopic ) );
+    }
 
-	return result;
+    return result;
 }
 
 /*
@@ -1089,104 +1089,104 @@ OtaErr_t initFileTransfer_Mqtt( const OtaAgentContext_t * pAgentCtx )
  */
 OtaErr_t requestFileBlock_Mqtt( OtaAgentContext_t * pAgentCtx )
 {
-	OtaErr_t result = OtaErrRequestFileBlockFailed;
-	OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
-	size_t msgSizeFromStream = 0;
-	uint32_t blockSize = OTA_FILE_BLOCK_SIZE;
-	uint32_t numBlocks = 0;
-	uint32_t bitmapLen = 0;
-	uint32_t msgSizeToPublish = 0;
-	uint32_t topicLen = 0;
-	bool cborEncodeRet = false;
-	char pMsg[ OTA_REQUEST_MSG_MAX_SIZE ];
+    OtaErr_t result = OtaErrRequestFileBlockFailed;
+    OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
+    size_t msgSizeFromStream = 0;
+    uint32_t blockSize = OTA_FILE_BLOCK_SIZE;
+    uint32_t numBlocks = 0;
+    uint32_t bitmapLen = 0;
+    uint32_t msgSizeToPublish = 0;
+    uint32_t topicLen = 0;
+    bool cborEncodeRet = false;
+    char pMsg[ OTA_REQUEST_MSG_MAX_SIZE ];
 
-	/* This buffer is used to store the generated MQTT topic. The static size
-	 * is calculated from the template and the corresponding parameters. */
-	char pTopicBuffer[ TOPIC_GET_STREAM_BUFFER_SIZE ];
-	const OtaFileContext_t * pFileContext = NULL;
+    /* This buffer is used to store the generated MQTT topic. The static size
+     * is calculated from the template and the corresponding parameters. */
+    char pTopicBuffer[ TOPIC_GET_STREAM_BUFFER_SIZE ];
+    const OtaFileContext_t * pFileContext = NULL;
 
-	/* NULL-terminated list of topic string parts. */
-	const char * pTopicParts[] =
-	{
-		MQTT_API_THINGS,
-		NULL, /* Thing Name not available at compile time, initialized below. */
-		MQTT_API_STREAMS,
-		NULL, /* Stream Name not available at compile time, initialized below. */
-		MQTT_API_GET_CBOR,
-		NULL
-	};
+    /* NULL-terminated list of topic string parts. */
+    const char * pTopicParts[] =
+    {
+        MQTT_API_THINGS,
+        NULL, /* Thing Name not available at compile time, initialized below. */
+        MQTT_API_STREAMS,
+        NULL, /* Stream Name not available at compile time, initialized below. */
+        MQTT_API_GET_CBOR,
+        NULL
+    };
 
-	assert( pAgentCtx != NULL );
+    assert( pAgentCtx != NULL );
 
-	/* Suppress warnings about unused variables. */
-	( void ) pOtaGetStreamTopicTemplate;
+    /* Suppress warnings about unused variables. */
+    ( void ) pOtaGetStreamTopicTemplate;
 
-	/* Get the current file context. */
-	pFileContext = &( pAgentCtx->fileContext );
+    /* Get the current file context. */
+    pFileContext = &( pAgentCtx->fileContext );
 
-	pTopicParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
-	pTopicParts[ 3 ] = ( const char * ) pFileContext->pStreamName;
+    pTopicParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
+    pTopicParts[ 3 ] = ( const char * ) pFileContext->pStreamName;
 
-	/* Reset number of blocks requested. */
-	pAgentCtx->numOfBlocksToReceive = otaconfigMAX_NUM_BLOCKS_REQUEST;
+    /* Reset number of blocks requested. */
+    pAgentCtx->numOfBlocksToReceive = otaconfigMAX_NUM_BLOCKS_REQUEST;
 
-	numBlocks = ( pFileContext->fileSize + ( OTA_FILE_BLOCK_SIZE - 1U ) ) >> otaconfigLOG2_FILE_BLOCK_SIZE;
-	bitmapLen = ( numBlocks + ( BITS_PER_BYTE - 1U ) ) >> LOG2_BITS_PER_BYTE;
+    numBlocks = ( pFileContext->fileSize + ( OTA_FILE_BLOCK_SIZE - 1U ) ) >> otaconfigLOG2_FILE_BLOCK_SIZE;
+    bitmapLen = ( numBlocks + ( BITS_PER_BYTE - 1U ) ) >> LOG2_BITS_PER_BYTE;
 
-	cborEncodeRet = OTA_CBOR_Encode_GetStreamRequestMessage( ( uint8_t * ) pMsg,
-	                                                         sizeof( pMsg ),
-	                                                         &msgSizeFromStream,
-	                                                         OTA_CLIENT_TOKEN,
-	                                                         ( int32_t ) pFileContext->serverFileID,
-	                                                         ( int32_t ) blockSize,
-	                                                         0,
-	                                                         pFileContext->pRxBlockBitmap,
-	                                                         bitmapLen,
-	                                                         ( int32_t ) otaconfigMAX_NUM_BLOCKS_REQUEST );
+    cborEncodeRet = OTA_CBOR_Encode_GetStreamRequestMessage( ( uint8_t * ) pMsg,
+                                                             sizeof( pMsg ),
+                                                             &msgSizeFromStream,
+                                                             OTA_CLIENT_TOKEN,
+                                                             ( int32_t ) pFileContext->serverFileID,
+                                                             ( int32_t ) blockSize,
+                                                             0,
+                                                             pFileContext->pRxBlockBitmap,
+                                                             bitmapLen,
+                                                             ( int32_t ) otaconfigMAX_NUM_BLOCKS_REQUEST );
 
-	if( cborEncodeRet == true )
-	{
-		msgSizeToPublish = ( uint32_t ) msgSizeFromStream;
+    if( cborEncodeRet == true )
+    {
+        msgSizeToPublish = ( uint32_t ) msgSizeFromStream;
 
-		/* Try to build the dynamic data REQUEST topic to publish to. */
+        /* Try to build the dynamic data REQUEST topic to publish to. */
 
-		topicLen = ( uint32_t ) stringBuilder(
-			pTopicBuffer,
-			sizeof( pTopicBuffer ),
-			pTopicParts );
+        topicLen = ( uint32_t ) stringBuilder(
+            pTopicBuffer,
+            sizeof( pTopicBuffer ),
+            pTopicParts );
 
-		/* The buffer is static and the size is calculated to fit. */
-		assert( ( topicLen > 0U ) && ( topicLen < sizeof( pTopicBuffer ) ) );
+        /* The buffer is static and the size is calculated to fit. */
+        assert( ( topicLen > 0U ) && ( topicLen < sizeof( pTopicBuffer ) ) );
 
-		mqttStatus = pAgentCtx->pOtaInterface->mqtt.publish( pTopicBuffer,
-		                                                     ( uint16_t ) topicLen,
-		                                                     &pMsg[ 0 ],
-		                                                     msgSizeToPublish,
-		                                                     0 );
+        mqttStatus = pAgentCtx->pOtaInterface->mqtt.publish( pTopicBuffer,
+                                                             ( uint16_t ) topicLen,
+                                                             &pMsg[ 0 ],
+                                                             msgSizeToPublish,
+                                                             0 );
 
-		if( mqttStatus == OtaMqttSuccess )
-		{
-			LogDebug( ( "Published to MQTT topic to request the next block: "
-			            "topic=%s",
-			            pTopicBuffer ) );
-			result = OtaErrNone;
-		}
-		else
-		{
-			LogError( ( "Failed to publish MQTT message: "
-			            "publish returned error: "
-			            "OtaMqttStatus_t=%s",
-			            OTA_MQTT_strerror( mqttStatus ) ) );
-		}
-	}
-	else
-	{
-		result = OtaErrFailedToEncodeCbor;
-		LogError( ( "Failed to CBOR encode stream request message: "
-		            "OTA_CBOR_Encode_GetStreamRequestMessage returned error." ) );
-	}
+        if( mqttStatus == OtaMqttSuccess )
+        {
+            LogDebug( ( "Published to MQTT topic to request the next block: "
+                        "topic=%s",
+                        pTopicBuffer ) );
+            result = OtaErrNone;
+        }
+        else
+        {
+            LogError( ( "Failed to publish MQTT message: "
+                        "publish returned error: "
+                        "OtaMqttStatus_t=%s",
+                        OTA_MQTT_strerror( mqttStatus ) ) );
+        }
+    }
+    else
+    {
+        result = OtaErrFailedToEncodeCbor;
+        LogError( ( "Failed to CBOR encode stream request message: "
+                    "OTA_CBOR_Encode_GetStreamRequestMessage returned error." ) );
+    }
 
-	return result;
+    return result;
 }
 
 /*
@@ -1200,32 +1200,32 @@ OtaErr_t decodeFileBlock_Mqtt( const uint8_t * pMessageBuffer,
                                uint8_t * const * pPayload,
                                size_t * pPayloadSize )
 {
-	OtaErr_t result = OtaErrFailedToDecodeCbor;
-	bool cborDecodeRet = false;
+    OtaErr_t result = OtaErrFailedToDecodeCbor;
+    bool cborDecodeRet = false;
 
-	/* Decode the CBOR content. */
-	cborDecodeRet = OTA_CBOR_Decode_GetStreamResponseMessage( pMessageBuffer,
-	                                                          messageSize,
-	                                                          pFileId,
-	                                                          pBlockId, /* CBOR requires pointer to int and our block indices never exceed 31 bits. */
-	                                                          pBlockSize, /* CBOR requires pointer to int and our block sizes never exceed 31 bits. */
-	                                                          pPayload, /* This payload gets malloc'd by OTA_CBOR_Decode_GetStreamResponseMessage(). We must free it. */
-	                                                          pPayloadSize );
+    /* Decode the CBOR content. */
+    cborDecodeRet = OTA_CBOR_Decode_GetStreamResponseMessage( pMessageBuffer,
+                                                              messageSize,
+                                                              pFileId,
+                                                              pBlockId,   /* CBOR requires pointer to int and our block indices never exceed 31 bits. */
+                                                              pBlockSize, /* CBOR requires pointer to int and our block sizes never exceed 31 bits. */
+                                                              pPayload,   /* This payload gets malloc'd by OTA_CBOR_Decode_GetStreamResponseMessage(). We must free it. */
+                                                              pPayloadSize );
 
-	if( cborDecodeRet == true )
-	{
-		/* pPayload and pPayloadSize is allocated by the caller. */
-		assert( ( pPayload != NULL ) && ( pPayloadSize != NULL ) );
+    if( cborDecodeRet == true )
+    {
+        /* pPayload and pPayloadSize is allocated by the caller. */
+        assert( ( pPayload != NULL ) && ( pPayloadSize != NULL ) );
 
-		result = OtaErrNone;
-	}
-	else
-	{
-		LogError( ( "Failed to decode MQTT file block: "
-		            "OTA_CBOR_Decode_GetStreamResponseMessage returned error." ) );
-	}
+        result = OtaErrNone;
+    }
+    else
+    {
+        LogError( ( "Failed to decode MQTT file block: "
+                    "OTA_CBOR_Decode_GetStreamResponseMessage returned error." ) );
+    }
 
-	return result;
+    return result;
 }
 
 /*
@@ -1233,27 +1233,27 @@ OtaErr_t decodeFileBlock_Mqtt( const uint8_t * pMessageBuffer,
  */
 OtaErr_t cleanupControl_Mqtt( const OtaAgentContext_t * pAgentCtx )
 {
-	OtaErr_t result = OtaErrNone;
-	OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
+    OtaErr_t result = OtaErrNone;
+    OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
 
-	assert( pAgentCtx != NULL );
+    assert( pAgentCtx != NULL );
 
-	if( pAgentCtx->unsubscribeOnShutdown != 0U )
-	{
-		/* Unsubscribe from job notification topics. */
-		mqttStatus = unsubscribeFromJobNotificationTopic( pAgentCtx );
+    if( pAgentCtx->unsubscribeOnShutdown != 0U )
+    {
+        /* Unsubscribe from job notification topics. */
+        mqttStatus = unsubscribeFromJobNotificationTopic( pAgentCtx );
 
-		if( mqttStatus != OtaMqttSuccess )
-		{
-			LogWarn( ( "Failed cleanup for MQTT control plane: "
-			           "unsubscribeFromJobNotificationTopic returned error: "
-			           "OtaMqttStatus_t=%s",
-			           OTA_MQTT_strerror( mqttStatus ) ) );
-			result = OtaErrCleanupControlFailed;
-		}
-	}
+        if( mqttStatus != OtaMqttSuccess )
+        {
+            LogWarn( ( "Failed cleanup for MQTT control plane: "
+                       "unsubscribeFromJobNotificationTopic returned error: "
+                       "OtaMqttStatus_t=%s",
+                       OTA_MQTT_strerror( mqttStatus ) ) );
+            result = OtaErrCleanupControlFailed;
+        }
+    }
 
-	return result;
+    return result;
 }
 
 /*
@@ -1261,55 +1261,55 @@ OtaErr_t cleanupControl_Mqtt( const OtaAgentContext_t * pAgentCtx )
  */
 OtaErr_t cleanupData_Mqtt( const OtaAgentContext_t * pAgentCtx )
 {
-	OtaErr_t result = OtaErrNone;
-	OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
+    OtaErr_t result = OtaErrNone;
+    OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
 
-	assert( pAgentCtx != NULL );
+    assert( pAgentCtx != NULL );
 
-	if( pAgentCtx->unsubscribeOnShutdown != 0U )
-	{
-		/* Unsubscribe from data stream topics. */
-		mqttStatus = unsubscribeFromDataStream( pAgentCtx );
+    if( pAgentCtx->unsubscribeOnShutdown != 0U )
+    {
+        /* Unsubscribe from data stream topics. */
+        mqttStatus = unsubscribeFromDataStream( pAgentCtx );
 
-		if( mqttStatus != OtaMqttSuccess )
-		{
-			LogWarn( ( "Failed cleanup for MQTT data plane: "
-			           "unsubscribeFromDataStream returned error: "
-			           "OtaMqttStatus_t=%s",
-			           OTA_MQTT_strerror( mqttStatus ) ) );
-			result = OtaErrCleanupDataFailed;
-		}
-	}
+        if( mqttStatus != OtaMqttSuccess )
+        {
+            LogWarn( ( "Failed cleanup for MQTT data plane: "
+                       "unsubscribeFromDataStream returned error: "
+                       "OtaMqttStatus_t=%s",
+                       OTA_MQTT_strerror( mqttStatus ) ) );
+            result = OtaErrCleanupDataFailed;
+        }
+    }
 
-	return result;
+    return result;
 }
 
 const char * OTA_MQTT_strerror( OtaMqttStatus_t status )
 {
-	const char * str = NULL;
+    const char * str = NULL;
 
-	switch( status )
-	{
-	case OtaMqttSuccess:
-		str = "OtaMqttSuccess";
-		break;
+    switch( status )
+    {
+        case OtaMqttSuccess:
+            str = "OtaMqttSuccess";
+            break;
 
-	case OtaMqttPublishFailed:
-		str = "OtaMqttPublishFailed";
-		break;
+        case OtaMqttPublishFailed:
+            str = "OtaMqttPublishFailed";
+            break;
 
-	case OtaMqttSubscribeFailed:
-		str = "OtaMqttSubscribeFailed";
-		break;
+        case OtaMqttSubscribeFailed:
+            str = "OtaMqttSubscribeFailed";
+            break;
 
-	case OtaMqttUnsubscribeFailed:
-		str = "OtaMqttUnsubscribeFailed";
-		break;
+        case OtaMqttUnsubscribeFailed:
+            str = "OtaMqttUnsubscribeFailed";
+            break;
 
-	default:
-		str = "InvalidErrorCode";
-		break;
-	}
+        default:
+            str = "InvalidErrorCode";
+            break;
+    }
 
-	return str;
+    return str;
 }

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -48,10 +48,10 @@
 #define OTA_CLIENT_TOKEN                      "rdy"         /*!< Arbitrary client token sent in the stream "GET" message. */
 
 /* Maximum length of ThingName appended onto the ClientToken*/
-#define OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN    53 /*<!  Max ThingName length = Max client token length (64) - Max request count length (10) - 1 (colon separator) */
+#define OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN    53U           /*!<  Max ThingName length = Max client token length (64) - Max request count length (10) - 1 (colon separator) */
 
 /* Agent to Job Service status message constants. */
-#define OTA_STATUS_MSG_MAX_SIZE               128U      /*!< Max length of a job status message to the service. */
+#define OTA_STATUS_MSG_MAX_SIZE               128U          /*!< Max length of a job status message to the service. */
 
 /**
  *  @brief Topic strings used by the OTA process.

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -45,24 +45,27 @@
 #include "ota_appversion32.h"
 
 /* Stream GET message constants. */
-#define OTA_CLIENT_TOKEN             "rdy"                  /*!< Arbitrary client token sent in the stream "GET" message. */
+#define OTA_CLIENT_TOKEN                      "rdy"         /*!< Arbitrary client token sent in the stream "GET" message. */
+
+/* Maximum length of ThingName appended onto the ClientToken*/
+#define OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN    53 /* Max client token length (64) - Max request count length (10) - 1 (colon separator). */
 
 /* Agent to Job Service status message constants. */
-#define OTA_STATUS_MSG_MAX_SIZE      128U               /*!< Max length of a job status message to the service. */
+#define OTA_STATUS_MSG_MAX_SIZE               128U      /*!< Max length of a job status message to the service. */
 
 /**
  *  @brief Topic strings used by the OTA process.
  *
  * These first few are topic extensions to the dynamic base topic that includes the Thing name.
  */
-#define MQTT_API_THINGS              "$aws/things/"                   /*!< Topic prefix for thing APIs. */
-#define MQTT_API_JOBS_NEXT_GET       "/jobs/$next/get"                /*!< Topic suffix for job API. */
-#define MQTT_API_JOBS_NOTIFY_NEXT    "/jobs/notify-next"              /*!< Topic suffix for job API. */
-#define MQTT_API_JOBS                "/jobs/"                         /*!< Job API identifier. */
-#define MQTT_API_UPDATE              "/update"                        /*!< Job API identifier. */
-#define MQTT_API_STREAMS             "/streams/"                      /*!< Stream API identifier. */
-#define MQTT_API_DATA_CBOR           "/data/cbor"                     /*!< Stream API suffix. */
-#define MQTT_API_GET_CBOR            "/get/cbor"                      /*!< Stream API suffix. */
+#define MQTT_API_THINGS                       "$aws/things/"          /*!< Topic prefix for thing APIs. */
+#define MQTT_API_JOBS_NEXT_GET                "/jobs/$next/get"       /*!< Topic suffix for job API. */
+#define MQTT_API_JOBS_NOTIFY_NEXT             "/jobs/notify-next"     /*!< Topic suffix for job API. */
+#define MQTT_API_JOBS                         "/jobs/"                /*!< Job API identifier. */
+#define MQTT_API_UPDATE                       "/update"               /*!< Job API identifier. */
+#define MQTT_API_STREAMS                      "/streams/"             /*!< Stream API identifier. */
+#define MQTT_API_DATA_CBOR                    "/data/cbor"            /*!< Stream API suffix. */
+#define MQTT_API_GET_CBOR                     "/get/cbor"             /*!< Stream API suffix. */
 
 /* NOTE: The format specifiers in this string are placeholders only; the lengths of these
  * strings are used to calculate buffer sizes.
@@ -867,7 +870,7 @@ OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
     uint32_t msgSize = 0;
     uint16_t topicLen = 0;
     size_t xThingNameLength = 0;
-    char pcClientTokenThingName[54] = { '\0' };
+    char pcClientTokenThingName[ 54 ] = { '\0' };
 
     /* NULL-terminated list of topic string parts. */
     const char * pTopicParts[] =
@@ -897,12 +900,12 @@ OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
     ( void ) pOtaGetNextJobMsgTemplate;
 
     /* Client token max length is 64. It is a combination of request counter (max 10 characters), a separator colon, and the ThingName. */
-    xThingNameLength = strlen((const char *) pAgentCtx->pThingName);
-    strncpy(pcClientTokenThingName, (const char *) pAgentCtx->pThingName, (xThingNameLength > 53) ? 53 : xThingNameLength);
+    xThingNameLength = strlen( ( const char * ) pAgentCtx->pThingName );
+    strncpy( pcClientTokenThingName, ( const char * ) pAgentCtx->pThingName, ( xThingNameLength > OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN ) ? OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN : xThingNameLength );
 
     pTopicParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
     pPayloadParts[ 1 ] = reqCounterString;
-    pPayloadParts[ 3 ] = (const char *) pcClientTokenThingName;
+    pPayloadParts[ 3 ] = ( const char * ) pcClientTokenThingName;
 
     ( void ) stringBuilderUInt32Decimal( reqCounterString, sizeof( reqCounterString ), reqCounter );
 

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -884,7 +884,7 @@ OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
 
     /* NULL-terminated list of payload parts */
 
-    assert( pAgentgit stCtx != NULL );
+    assert( pAgentCtx != NULL );
 
     /* Suppress warnings about unused variables. */
     ( void ) pOtaJobsGetNextTopicTemplate;

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -48,7 +48,7 @@
 #define OTA_CLIENT_TOKEN                      "rdy"         /*!< Arbitrary client token sent in the stream "GET" message. */
 
 /* Maximum length of ThingName appended onto the ClientToken*/
-#define OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN    53 /* Max client token length (64) - Max request count length (10) - 1 (colon separator). */
+#define OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN    53 /*<!  Max ThingName length = Max client token length (64) - Max request count length (10) - 1 (colon separator) */
 
 /* Agent to Job Service status message constants. */
 #define OTA_STATUS_MSG_MAX_SIZE               128U      /*!< Max length of a job status message to the service. */

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -905,7 +905,7 @@ OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
     strncpy( &pMsg[ msgSize ], ( const char * ) pAgentCtx->pThingName, xThingNameLength );
     msgSize += xThingNameLength;
     strcat( &pMsg[ msgSize ], "\"}" );
-    msgSize += 2;
+    msgSize += 2U;
 
     /* Subscribe to the OTA job notification topic. */
     mqttStatus = subscribeToJobNotificationTopics( pAgentCtx );

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -866,6 +866,8 @@ OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
     OtaMqttStatus_t mqttStatus = OtaMqttSuccess;
     uint32_t msgSize = 0;
     uint16_t topicLen = 0;
+    size_t xThingNameLength = 0;
+    char pcClientTokenThingName[54] = { '\0' };
 
     /* NULL-terminated list of topic string parts. */
     const char * pTopicParts[] =
@@ -895,9 +897,8 @@ OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
     ( void ) pOtaGetNextJobMsgTemplate;
 
     /* Client token max length is 64. It is a combination of request counter (max 10 characters), a seperator colon, and the ThingName. */
-    size_t xThingNameLength = strlen(pAgentCtx->pThingName);
-    char pcClientTokenThingName[54] = { '\0' };
-    strncpy(pcClientTokenThingName, pAgentCtx->pThingName, (xThingNameLength > 53) ? 53 : xThingNameLength);
+    xThingNameLength = strlen((const char *) pAgentCtx->pThingName);
+    strncpy(pcClientTokenThingName, (const char *) pAgentCtx->pThingName, (xThingNameLength > 53) ? 53 : xThingNameLength);
 
     pTopicParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
     pPayloadParts[ 1 ] = reqCounterString;

--- a/test/cbmc/proofs/OTA_Init/Makefile
+++ b/test/cbmc/proofs/OTA_Init/Makefile
@@ -13,7 +13,7 @@ PROJECT_SOURCES += $(SRCDIR)/source/ota.c
 
 NONDET_STATIC += "--nondet-static"
 
-UNWINDSET += strlen.0:66
+UNWINDSET += strlen.0:150
 
 REMOVE_FUNCTION_BODY += setControlInterface
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_ota_c_initializeAppBuffers

--- a/test/cbmc/proofs/requestJob_Mqtt/Makefile
+++ b/test/cbmc/proofs/requestJob_Mqtt/Makefile
@@ -13,7 +13,7 @@ PROJECT_SOURCES += $(SRCDIR)/source/ota_mqtt.c
 # The strncpy bound is large due to requestJob_Mqtt copying message peices
 # into a buffer. This is much higher than the 84 characters of the buffer
 # as null characters are used after the copied in strin to fill the buffer.
-UNWINDSET += __builtin___strncpy_chk.0:220
+UNWINDSET += strncpy.0:220
 # The strnlen function is used when calculating the maximum thingname length 
 # which can be used to generate the client token.
 UNWINDSET += strnlen.0:54

--- a/test/cbmc/proofs/requestJob_Mqtt/Makefile
+++ b/test/cbmc/proofs/requestJob_Mqtt/Makefile
@@ -9,8 +9,8 @@ PROOF_UID = requestJob_Mqtt
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/source/ota_mqtt.c
 
-UNWINDSET += strlen.0:300
-UNWINDSET += strncpy.0:300
+UNWINDSET += strlen.0:150
+UNWINDSET += strncpy.0:200
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/test/cbmc/proofs/requestJob_Mqtt/Makefile
+++ b/test/cbmc/proofs/requestJob_Mqtt/Makefile
@@ -11,10 +11,7 @@ PROJECT_SOURCES += $(SRCDIR)/source/ota_mqtt.c
 
 UNWINDSET += strlen.0:150
 UNWINDSET += strncpy.0:200
-UNWINDSET += strncpy.1:200
 UNWINDSET += strcat.0:500
-UNWINDSET += strcat.1:500
-UNWINDSET += strcat.2:500
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/test/cbmc/proofs/requestJob_Mqtt/Makefile
+++ b/test/cbmc/proofs/requestJob_Mqtt/Makefile
@@ -11,6 +11,7 @@ PROJECT_SOURCES += $(SRCDIR)/source/ota_mqtt.c
 
 UNWINDSET += strlen.0:150
 UNWINDSET += strncpy.0:200
+UNWINDSET += strcat.0:150
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/test/cbmc/proofs/requestJob_Mqtt/Makefile
+++ b/test/cbmc/proofs/requestJob_Mqtt/Makefile
@@ -11,7 +11,7 @@ PROJECT_SOURCES += $(SRCDIR)/source/ota_mqtt.c
 
 UNWINDSET += strlen.0:150
 UNWINDSET += strncpy.0:200
-UNWINDSET += strcat.0:150
+UNWINDSET += strcat.0:200
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/test/cbmc/proofs/requestJob_Mqtt/Makefile
+++ b/test/cbmc/proofs/requestJob_Mqtt/Makefile
@@ -9,6 +9,8 @@ PROOF_UID = requestJob_Mqtt
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/source/ota_mqtt.c
 
+UNWINDSET += strlen.0:150
+
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will
 # restrict the number of EXPENSIVE CBMC jobs running at once. See the

--- a/test/cbmc/proofs/requestJob_Mqtt/Makefile
+++ b/test/cbmc/proofs/requestJob_Mqtt/Makefile
@@ -10,9 +10,13 @@ PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROOF_SOURCES += $(PROOF_STUB)/strnlen.c
 PROJECT_SOURCES += $(SRCDIR)/source/ota_mqtt.c
 
-UNWINDSET += strcat.1:165
-UNWINDSET += strncpy.0:75
-UNWINDSET += strnlen_impl.0:54
+# The strncpy bound is large due to requestJob_Mqtt copying message peices
+# into a buffer. This is much higher than the 84 characters of the buffer
+# as null characters are used after the copied in strin to fill the buffer.
+UNWINDSET += __builtin___strncpy_chk.0:220
+# The strnlen function is used when calculating the maximum thingname length 
+# which can be used to generate the client token.
+UNWINDSET += strnlen.0:54
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/test/cbmc/proofs/requestJob_Mqtt/Makefile
+++ b/test/cbmc/proofs/requestJob_Mqtt/Makefile
@@ -11,7 +11,10 @@ PROJECT_SOURCES += $(SRCDIR)/source/ota_mqtt.c
 
 UNWINDSET += strlen.0:150
 UNWINDSET += strncpy.0:200
-UNWINDSET += strcat.0:200
+UNWINDSET += strncpy.1:200
+UNWINDSET += strcat.0:500
+UNWINDSET += strcat.1:500
+UNWINDSET += strcat.2:500
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/test/cbmc/proofs/requestJob_Mqtt/Makefile
+++ b/test/cbmc/proofs/requestJob_Mqtt/Makefile
@@ -9,7 +9,8 @@ PROOF_UID = requestJob_Mqtt
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/source/ota_mqtt.c
 
-UNWINDSET += strlen.0:150
+UNWINDSET += strlen.0:300
+UNWINDSET += strncpy.0:300
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/test/cbmc/proofs/requestJob_Mqtt/Makefile
+++ b/test/cbmc/proofs/requestJob_Mqtt/Makefile
@@ -7,11 +7,12 @@ HARNESS_FILE = $(HARNESS_ENTRY)
 PROOF_UID = requestJob_Mqtt
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROOF_SOURCES += $(PROOF_STUB)/strnlen.c
 PROJECT_SOURCES += $(SRCDIR)/source/ota_mqtt.c
 
-UNWINDSET += strlen.0:150
-UNWINDSET += strncpy.0:200
-UNWINDSET += strcat.0:500
+UNWINDSET += strcat.1:165
+UNWINDSET += strncpy.0:75
+UNWINDSET += strnlen_impl.0:54
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/test/cbmc/proofs/requestJob_Mqtt/requestJob_Mqtt_harness.c
+++ b/test/cbmc/proofs/requestJob_Mqtt/requestJob_Mqtt_harness.c
@@ -34,23 +34,23 @@ size_t __CPROVER_file_local_ota_mqtt_c_stringBuilder( char * pBuffer,
                                                       size_t bufferSizeBytes,
                                                       const char * strings[] )
 {
-    size_t stringLength;
+	size_t stringLength;
 
-    /* pBuffer is initialized in requestJob_Mqtt function before passing it to the
-     * stringBuilder function and thus cannot be NULL. */
-    __CPROVER_assert( pBuffer != NULL,
-                      "Unable to use pBuffer: passed pointer value is NULL." );
+	/* pBuffer is initialized in requestJob_Mqtt function before passing it to the
+	 * stringBuilder function and thus cannot be NULL. */
+	__CPROVER_assert( pBuffer != NULL,
+	                  "Unable to use pBuffer: passed pointer value is NULL." );
 
-    /* strings is initialized requestJob_Mqtt function before passing it to the
-     * stringBuilder function and thus cannot be NULL. */
-    __CPROVER_assert( strings != NULL,
-                      "Unable to use strings: passed pointer value is NULL." );
+	/* strings is initialized requestJob_Mqtt function before passing it to the
+	 * stringBuilder function and thus cannot be NULL. */
+	__CPROVER_assert( strings != NULL,
+	                  "Unable to use strings: passed pointer value is NULL." );
 
-    /* The size of the static pbuffer is declared inside requestJob_Mqtt
-     * function. */
-    __CPROVER_assume( stringLength > 0U && stringLength < bufferSizeBytes );
+	/* The size of the static pbuffer is declared inside requestJob_Mqtt
+	 * function. */
+	__CPROVER_assume( stringLength > 0U && stringLength < bufferSizeBytes );
 
-    return stringLength;
+	return stringLength;
 }
 
 /* Stub required to convert a decimal number into a string. */
@@ -58,26 +58,26 @@ size_t __CPROVER_file_local_ota_mqtt_c_stringBuilderUInt32Decimal( char * pBuffe
                                                                    size_t bufferSizeBytes,
                                                                    uint32_t value )
 {
-    size_t buffersize;
+	size_t buffersize;
 
-    /* Output can only be at most 10 characters as max unsigned 32-bit integer value is 10 characters long */
-    __CPROVER_assume( buffersize <= 10U );
+	/* Output can only be at most 10 characters as max unsigned 32-bit integer value is 10 characters long */
+	__CPROVER_assume( buffersize > 0 && buffersize <= 10U );
 
-    /* pBuffer is always initialized before passing it to the stringBuilderUInt32Decimal
-     * function and thus should not be NULL. */
-    __CPROVER_assert( pBuffer != NULL,
-                      "Unable to use pBuffer: passed pointer value is NULL." );
+	/* pBuffer is always initialized before passing it to the stringBuilderUInt32Decimal
+	 * function and thus should not be NULL. */
+	__CPROVER_assert( pBuffer != NULL,
+	                  "Unable to use pBuffer: passed pointer value is NULL." );
 
 
-    return buffersize;
+	return buffersize;
 }
 
 /* Stub required to convert a hexadecimal number into a string. */
 OtaMqttStatus_t __CPROVER_file_local_ota_mqtt_c_subscribeToJobNotificationTopics( const OtaAgentContext_t * pAgentCtx )
 {
-    OtaMqttStatus_t mqttStatus;
+	OtaMqttStatus_t mqttStatus;
 
-    return mqttStatus;
+	return mqttStatus;
 }
 
 /* Stub to user defined MQTT-publish operation. */
@@ -87,28 +87,28 @@ OtaMqttStatus_t stubMqttPublish( const char * const pacTopic,
                                  uint32_t ulMsgSize,
                                  uint8_t ucQoS )
 {
-    OtaMqttStatus_t mqttstatus;
+	OtaMqttStatus_t mqttstatus;
 
-    return mqttstatus;
+	return mqttstatus;
 }
 
 /*****************************************************************************/
 
 void requestJob_Mqtt_harness()
 {
-    OtaAgentContext_t agent;
-    OtaInterfaces_t otaInterface;
-    size_t size;
+	OtaAgentContext_t agent;
+	OtaInterfaces_t otaInterface;
+	size_t size;
 
-    __CPROVER_assume( size < 128U );
+	__CPROVER_assume( size >= 1 && size < 128U );
 
-    /* publish reference to the mqtt function is expected to be assigned by the user and thus
-     * assumed not to be NULL. */
-    otaInterface.mqtt.publish = stubMqttPublish;
+	/* publish reference to the mqtt function is expected to be assigned by the user and thus
+	 * assumed not to be NULL. */
+	otaInterface.mqtt.publish = stubMqttPublish;
 
-    agent.pOtaInterface = &otaInterface;
-    agent.pThingName[ size ] = '\0';
+	agent.pOtaInterface = &otaInterface;
+	agent.pThingName[ size ] = '\0';
 
-    /* Ota agent is declared globally and cannot be NULL. */
-    requestJob_Mqtt( &agent );
+	/* Ota agent is declared globally and cannot be NULL. */
+	requestJob_Mqtt( &agent );
 }

--- a/test/cbmc/proofs/requestJob_Mqtt/requestJob_Mqtt_harness.c
+++ b/test/cbmc/proofs/requestJob_Mqtt/requestJob_Mqtt_harness.c
@@ -95,12 +95,16 @@ void requestJob_Mqtt_harness()
 {
     OtaAgentContext_t agent;
     OtaInterfaces_t otaInterface;
+    size_t size;
+
+    __CPROVER_assume(size < 128U);
 
     /* publish reference to the mqtt function is expected to be assigned by the user and thus
      * assumed not to be NULL. */
     otaInterface.mqtt.publish = stubMqttPublish;
 
     agent.pOtaInterface = &otaInterface;
+    agent.pThingName[size] = '\0';
 
     /* Ota agent is declared globally and cannot be NULL. */
     requestJob_Mqtt( &agent );

--- a/test/cbmc/proofs/requestJob_Mqtt/requestJob_Mqtt_harness.c
+++ b/test/cbmc/proofs/requestJob_Mqtt/requestJob_Mqtt_harness.c
@@ -60,6 +60,9 @@ size_t __CPROVER_file_local_ota_mqtt_c_stringBuilderUInt32Decimal( char * pBuffe
 {
     size_t buffersize;
 
+    /* Output can only be at most 10 characters as max unsigned 32-bit integer value is 10 characters long */
+    __CPROVER_assume( buffersize <= 10U );
+
     /* pBuffer is always initialized before passing it to the stringBuilderUInt32Decimal
      * function and thus should not be NULL. */
     __CPROVER_assert( pBuffer != NULL,

--- a/test/cbmc/proofs/requestJob_Mqtt/requestJob_Mqtt_harness.c
+++ b/test/cbmc/proofs/requestJob_Mqtt/requestJob_Mqtt_harness.c
@@ -97,14 +97,14 @@ void requestJob_Mqtt_harness()
     OtaInterfaces_t otaInterface;
     size_t size;
 
-    __CPROVER_assume(size < 128U);
+    __CPROVER_assume( size < 128U );
 
     /* publish reference to the mqtt function is expected to be assigned by the user and thus
      * assumed not to be NULL. */
     otaInterface.mqtt.publish = stubMqttPublish;
 
     agent.pOtaInterface = &otaInterface;
-    agent.pThingName[size] = '\0';
+    agent.pThingName[ size ] = '\0';
 
     /* Ota agent is declared globally and cannot be NULL. */
     requestJob_Mqtt( &agent );

--- a/test/cbmc/proofs/requestJob_Mqtt/requestJob_Mqtt_harness.c
+++ b/test/cbmc/proofs/requestJob_Mqtt/requestJob_Mqtt_harness.c
@@ -34,23 +34,23 @@ size_t __CPROVER_file_local_ota_mqtt_c_stringBuilder( char * pBuffer,
                                                       size_t bufferSizeBytes,
                                                       const char * strings[] )
 {
-	size_t stringLength;
+    size_t stringLength;
 
-	/* pBuffer is initialized in requestJob_Mqtt function before passing it to the
-	 * stringBuilder function and thus cannot be NULL. */
-	__CPROVER_assert( pBuffer != NULL,
-	                  "Unable to use pBuffer: passed pointer value is NULL." );
+    /* pBuffer is initialized in requestJob_Mqtt function before passing it to the
+     * stringBuilder function and thus cannot be NULL. */
+    __CPROVER_assert( pBuffer != NULL,
+                      "Unable to use pBuffer: passed pointer value is NULL." );
 
-	/* strings is initialized requestJob_Mqtt function before passing it to the
-	 * stringBuilder function and thus cannot be NULL. */
-	__CPROVER_assert( strings != NULL,
-	                  "Unable to use strings: passed pointer value is NULL." );
+    /* strings is initialized requestJob_Mqtt function before passing it to the
+     * stringBuilder function and thus cannot be NULL. */
+    __CPROVER_assert( strings != NULL,
+                      "Unable to use strings: passed pointer value is NULL." );
 
-	/* The size of the static pbuffer is declared inside requestJob_Mqtt
-	 * function. */
-	__CPROVER_assume( stringLength > 0U && stringLength < bufferSizeBytes );
+    /* The size of the static pbuffer is declared inside requestJob_Mqtt
+     * function. */
+    __CPROVER_assume( stringLength > 0U && stringLength < bufferSizeBytes );
 
-	return stringLength;
+    return stringLength;
 }
 
 /* Stub required to convert a decimal number into a string. */
@@ -58,26 +58,26 @@ size_t __CPROVER_file_local_ota_mqtt_c_stringBuilderUInt32Decimal( char * pBuffe
                                                                    size_t bufferSizeBytes,
                                                                    uint32_t value )
 {
-	size_t buffersize;
+    size_t buffersize;
 
-	/* Output can only be at most 10 characters as max unsigned 32-bit integer value is 10 characters long */
-	__CPROVER_assume( buffersize > 0 && buffersize <= 10U );
+    /* Output can only be at most 10 characters as max unsigned 32-bit integer value is 10 characters long */
+    __CPROVER_assume( buffersize > 0 && buffersize <= 10U );
 
-	/* pBuffer is always initialized before passing it to the stringBuilderUInt32Decimal
-	 * function and thus should not be NULL. */
-	__CPROVER_assert( pBuffer != NULL,
-	                  "Unable to use pBuffer: passed pointer value is NULL." );
+    /* pBuffer is always initialized before passing it to the stringBuilderUInt32Decimal
+     * function and thus should not be NULL. */
+    __CPROVER_assert( pBuffer != NULL,
+                      "Unable to use pBuffer: passed pointer value is NULL." );
 
 
-	return buffersize;
+    return buffersize;
 }
 
 /* Stub required to convert a hexadecimal number into a string. */
 OtaMqttStatus_t __CPROVER_file_local_ota_mqtt_c_subscribeToJobNotificationTopics( const OtaAgentContext_t * pAgentCtx )
 {
-	OtaMqttStatus_t mqttStatus;
+    OtaMqttStatus_t mqttStatus;
 
-	return mqttStatus;
+    return mqttStatus;
 }
 
 /* Stub to user defined MQTT-publish operation. */
@@ -87,28 +87,28 @@ OtaMqttStatus_t stubMqttPublish( const char * const pacTopic,
                                  uint32_t ulMsgSize,
                                  uint8_t ucQoS )
 {
-	OtaMqttStatus_t mqttstatus;
+    OtaMqttStatus_t mqttstatus;
 
-	return mqttstatus;
+    return mqttstatus;
 }
 
 /*****************************************************************************/
 
 void requestJob_Mqtt_harness()
 {
-	OtaAgentContext_t agent;
-	OtaInterfaces_t otaInterface;
-	size_t size;
+    OtaAgentContext_t agent;
+    OtaInterfaces_t otaInterface;
+    size_t size;
 
-	__CPROVER_assume( size >= 1 && size < 128U );
+    __CPROVER_assume( size >= 1 && size < 128U );
 
-	/* publish reference to the mqtt function is expected to be assigned by the user and thus
-	 * assumed not to be NULL. */
-	otaInterface.mqtt.publish = stubMqttPublish;
+    /* publish reference to the mqtt function is expected to be assigned by the user and thus
+     * assumed not to be NULL. */
+    otaInterface.mqtt.publish = stubMqttPublish;
 
-	agent.pOtaInterface = &otaInterface;
-	agent.pThingName[ size ] = '\0';
+    agent.pOtaInterface = &otaInterface;
+    agent.pThingName[ size ] = '\0';
 
-	/* Ota agent is declared globally and cannot be NULL. */
-	requestJob_Mqtt( &agent );
+    /* Ota agent is declared globally and cannot be NULL. */
+    requestJob_Mqtt( &agent );
 }

--- a/test/cbmc/source/strnlen.c
+++ b/test/cbmc/source/strnlen.c
@@ -1,0 +1,47 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+/**
+ * FUNCTION: strlen
+ *
+ * This function overrides the original implementation of the strlen function
+ * from string.h. It copies the values of n bytes from the *src to the *dst.
+ * It also checks if the size of the arrays pointed to by both the *dst and
+ * *src parameters are at least n bytes and if they overlap.
+ */
+
+
+#ifndef __CPROVER_STRING_H_INCLUDED
+#include <string.h>
+#define __CPROVER_STRING_H_INCLUDED
+#endif
+
+#include <stdlib.h>
+
+#undef strnlen
+
+
+/**
+ * Override the version of memcpy used by CBMC.
+ */
+size_t strnlen_impl(const char *s, size_t maxlen) {
+    __CPROVER_HIDE:;
+    #ifdef __CPROVER_STRING_ABSTRACTION
+        __CPROVER_precondition(__CPROVER_is_zero_string(s), "strlen zero-termination");
+        return __CPROVER_zero_string_length(s);
+    #else
+        __CPROVER_size_t len=0;
+        while(s[len]!=0 && len < maxlen ) len++;
+        return len;
+  #endif
+}
+
+size_t strnlen(const char *s, size_t maxlen) {
+    return strnlen_impl(s,maxlen);
+}
+
+size_t __builtin___strnlen_chk(const char *s, size_t maxlen) {
+    return strnlen_impl(s, maxlen);
+}

--- a/test/cbmc/source/strnlen.c
+++ b/test/cbmc/source/strnlen.c
@@ -30,7 +30,7 @@ size_t strnlen_impl( const char * s,
 {
 __CPROVER_HIDE:;
     #ifdef __CPROVER_STRING_ABSTRACTION
-        __CPROVER_precondition( __CPROVER_is_zero_string( s ), "strlen zero-termination" );
+        __CPROVER_precondition( __CPROVER_is_zero_string( s ), "strnlen zero-termination" );
         return __CPROVER_zero_string_length( s );
     #else
         __CPROVER_size_t len = 0;

--- a/test/cbmc/source/strnlen.c
+++ b/test/cbmc/source/strnlen.c
@@ -4,18 +4,17 @@
  */
 
 /**
- * FUNCTION: strlen
+ * FUNCTION: strnlen
  *
- * This function overrides the original implementation of the strlen function
- * from string.h. It copies the values of n bytes from the *src to the *dst.
- * It also checks if the size of the arrays pointed to by both the *dst and
- * *src parameters are at least n bytes and if they overlap.
+ * This function overrides the original implementation of the strnlen function
+ * from string.h. It returns the size of the c-string *s up to a maximum of
+ * length maxlen. The length excludes the null-byte.
  */
 
 
 #ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
+    #include <string.h>
+    #define __CPROVER_STRING_H_INCLUDED
 #endif
 
 #include <stdlib.h>
@@ -24,24 +23,34 @@
 
 
 /**
- * Override the version of memcpy used by CBMC.
+ * Override the version of strnlen used by CBMC.
  */
-size_t strnlen_impl(const char *s, size_t maxlen) {
-    __CPROVER_HIDE:;
+size_t strnlen_impl( const char * s,
+                     size_t maxlen )
+{
+__CPROVER_HIDE:;
     #ifdef __CPROVER_STRING_ABSTRACTION
-        __CPROVER_precondition(__CPROVER_is_zero_string(s), "strlen zero-termination");
-        return __CPROVER_zero_string_length(s);
+        __CPROVER_precondition( __CPROVER_is_zero_string( s ), "strlen zero-termination" );
+        return __CPROVER_zero_string_length( s );
     #else
-        __CPROVER_size_t len=0;
-        while(s[len]!=0 && len < maxlen ) len++;
+        __CPROVER_size_t len = 0;
+
+        while( s[ len ] != 0 && len < maxlen )
+        {
+            len++;
+        }
         return len;
-  #endif
+    #endif
 }
 
-size_t strnlen(const char *s, size_t maxlen) {
-    return strnlen_impl(s,maxlen);
+size_t strnlen( const char * s,
+                size_t maxlen )
+{
+    return strnlen_impl( s, maxlen );
 }
 
-size_t __builtin___strnlen_chk(const char *s, size_t maxlen) {
-    return strnlen_impl(s, maxlen);
+size_t __builtin___strnlen_chk( const char * s,
+                                size_t maxlen )
+{
+    return strnlen_impl( s, maxlen );
 }

--- a/test/cbmc/stubs/strnlen.c
+++ b/test/cbmc/stubs/strnlen.c
@@ -6,7 +6,7 @@
 /**
  * FUNCTION: strnlen
  *
- * This function overrides the original implementation of the strnlen function
+ * This function stubs the standard implementation of the strnlen function
  * from string.h. It returns the size of the c-string *s up to a maximum of
  * length maxlen. The length excludes the null-byte.
  */
@@ -15,10 +15,10 @@
 #include <stdlib.h>
 
 /**
- * Override the version of strnlen used by CBMC.
+ * Stub strnlen used by CBMC.
  */
-size_t strnlen_impl( const char * s,
-                     size_t maxlen )
+size_t strnlen( const char * s,
+                size_t maxlen )
 {
     #ifdef __CPROVER_STRING_ABSTRACTION
         __CPROVER_precondition( __CPROVER_is_zero_string( s ), "strnlen zero-termination" );
@@ -34,14 +34,8 @@ size_t strnlen_impl( const char * s,
     #endif
 }
 
-size_t strnlen( const char * s,
-                size_t maxlen )
-{
-    return strnlen_impl( s, maxlen );
-}
-
 size_t __builtin___strnlen_chk( const char * s,
                                 size_t maxlen )
 {
-    return strnlen_impl( s, maxlen );
+    return strnlen( s, maxlen );
 }

--- a/test/cbmc/stubs/strnlen.c
+++ b/test/cbmc/stubs/strnlen.c
@@ -12,15 +12,7 @@
  */
 
 
-#ifndef __CPROVER_STRING_H_INCLUDED
-    #include <string.h>
-    #define __CPROVER_STRING_H_INCLUDED
-#endif
-
 #include <stdlib.h>
-
-#undef strnlen
-
 
 /**
  * Override the version of strnlen used by CBMC.
@@ -28,12 +20,11 @@
 size_t strnlen_impl( const char * s,
                      size_t maxlen )
 {
-__CPROVER_HIDE:;
     #ifdef __CPROVER_STRING_ABSTRACTION
         __CPROVER_precondition( __CPROVER_is_zero_string( s ), "strnlen zero-termination" );
         return __CPROVER_zero_string_length( s );
     #else
-        __CPROVER_size_t len = 0;
+        size_t len = 0;
 
         while( s[ len ] != 0 && len < maxlen )
         {

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -481,16 +481,15 @@ static OtaMqttStatus_t stubMqttPublishOnlySuccedsIfTruncatedValue( const char * 
     TEST_ASSERT_LESS_OR_EQUAL( 83U, msgSize );
     TEST_ASSERT_GREATER_THAN( 19U, msgSize );
 
-
     char expected[ 54 ] = { 0 };
     char actual[ 54 ] = { 0 };
 
-    /*Calculate the start of the thingname */
+    /* Calculate the start of the thingname */
     int offset = msgSize - 53U - 2;
 
-    /*Copy out the first 53 characters of the thingname */
+    /* Copy out the first 53 characters of the thingname */
     memcpy( expected, longestThingname, 53U );
-    /*Copy out the 53 characters of the truncated thingname */
+    /* Copy out the 53 characters of the truncated thingname */
     memcpy( actual, msg + ( offset ), 53U );
 
     TEST_ASSERT_EQUAL_STRING( expected, actual );

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -487,6 +487,12 @@ static OtaMqttStatus_t stubMqttPublishOnlySuccedsIfTruncatedValue( const char * 
     /* Calculate the start of the thingname */
     int offset = msgSize - 53U - 2;
 
+    memcpy(actual, msg, 16U);
+
+    TEST_ASSERT_EQUAL_STRING("{\"clientToken\":\"", actual);
+
+    TEST_ASSERT_EQUAL_CHAR(':', *(msg + ( offset - 1 )));
+
     /* Copy out the first 53 characters of the thingname */
     memcpy( expected, longestThingname, 53U );
     /* Copy out the 53 characters of the truncated thingname */

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -85,14 +85,14 @@
 #define OTA_FILE_BITMAP_SIZE              50
 #define OTA_UPDATE_URL_SIZE               100
 #define OTA_AUTH_SCHEME_SIZE              50
-#define OTA_APP_BUFFER_SIZE           \
-        ( OTA_UPDATE_FILE_PATH_SIZE + \
-          OTA_CERT_FILE_PATH_SIZE +   \
-          OTA_STREAM_NAME_SIZE +      \
-          OTA_DECODE_MEMORY_SIZE +    \
-          OTA_FILE_BITMAP_SIZE +      \
-          OTA_UPDATE_URL_SIZE +       \
-          OTA_AUTH_SCHEME_SIZE )
+#define OTA_APP_BUFFER_SIZE       \
+    ( OTA_UPDATE_FILE_PATH_SIZE + \
+      OTA_CERT_FILE_PATH_SIZE +   \
+      OTA_STREAM_NAME_SIZE +      \
+      OTA_DECODE_MEMORY_SIZE +    \
+      OTA_FILE_BITMAP_SIZE +      \
+      OTA_UPDATE_URL_SIZE +       \
+      OTA_AUTH_SCHEME_SIZE )
 
 #define min( x, y )    ( x < y ? x : y )
 

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -487,11 +487,11 @@ static OtaMqttStatus_t stubMqttPublishOnlySuccedsIfTruncatedValue( const char * 
     /* Calculate the start of the thingname */
     int offset = msgSize - 53U - 2;
 
-    memcpy(actual, msg, 16U);
+    memcpy( actual, msg, 16U );
 
-    TEST_ASSERT_EQUAL_STRING("{\"clientToken\":\"", actual);
+    TEST_ASSERT_EQUAL_STRING( "{\"clientToken\":\"", actual );
 
-    TEST_ASSERT_EQUAL_CHAR(':', *(msg + ( offset - 1 )));
+    TEST_ASSERT_EQUAL_CHAR( ':', *( msg + ( offset - 1 ) ) );
 
     /* Copy out the first 53 characters of the thingname */
     memcpy( expected, longestThingname, 53U );

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -1025,10 +1025,20 @@ void test_OTA_InitWithNullName()
     TEST_ASSERT_EQUAL( OtaAgentStateStopped, OTA_GetState() );
 }
 
+void test_OTA_InitWithNameAtMaxLength()
+{
+    /* OTA does not accept name longer than 128. Explicitly test long client name. */
+    char long_name[ 129 ] = { 0 };
+
+    memset( long_name, 1, sizeof( long_name ) - 1 );
+    otaInit( long_name, mockAppCallback );
+    TEST_ASSERT_EQUAL( OtaAgentStateInit, OTA_GetState() );
+}
+
 void test_OTA_InitWithNameTooLong()
 {
-    /* OTA does not accept name longer than 64. Explicitly test long client name. */
-    char long_name[ 100 ] = { 0 };
+    /* OTA does not accept name longer than 128. Explicitly test long client name. */
+    char long_name[ 130 ] = { 0 };
 
     memset( long_name, 1, sizeof( long_name ) - 1 );
     otaInit( long_name, mockAppCallback );

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -819,6 +819,7 @@ stringsize
 strlength
 stringbuilder
 stringsize
+strnlen
 struct
 structs
 sublicense

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -274,6 +274,7 @@ int
 intel
 ioffset
 iot
+iotcore
 ip
 ip
 isinselftest
@@ -776,6 +777,7 @@ sendtimeout
 sendtimeoutms
 serverfileid
 serverinfo
+servicequotas
 setcontrolinterface
 setdatainterface
 setimagestate

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -317,6 +317,7 @@ malloc
 mac
 maxattempts
 maxfragmentlength
+maxlen
 mcu
 md
 mem


### PR DESCRIPTION
Description
-----------
Updated the `ThingName` maximum length to 128 characters. This matches the documented AWS IoT Core length limit. Because of this change, the ThingName will be truncated to 53 characters maximum when added to the `ClientToken` field.

Testing:
---------
1. Pulled changes to Ubuntu 22.04 Ec2 instance
2. Followed unit test instructions.
3. Unit tests passed. Output below...

```
Test project /home/ubuntu/ota-for-aws-iot-embedded-sdk/build
    Start 1: ota_utest
1/4 Test #1: ota_utest ........................   Passed    0.02 sec
    Start 2: ota_base64_utest
2/4 Test #2: ota_base64_utest .................   Passed    0.00 sec
    Start 3: ota_cbor_utest
3/4 Test #3: ota_cbor_utest ...................   Passed    0.00 sec
    Start 4: ota_os_posix_utest
4/4 Test #4: ota_os_posix_utest ...............   Passed    5.01 sec

100% tests passed, 0 tests failed out of 4
```

Checklist:
----------
- [ X ] I have tested my changes. No regression in existing tests.
- [ X ] My code is formatted using Uncrustify.
- [ X ] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.