### PR TITLE
Fix typing issue on resumeHandler proof

### DIFF
--- a/test/cbmc/proofs/resumeHandler/resumeHandler_harness.c
+++ b/test/cbmc/proofs/resumeHandler/resumeHandler_harness.c
@@ -30,7 +30,7 @@
 #include "ota.h"
 
 /* Mangled name definition of the static function. */
-void __CPROVER_file_local_ota_c_resumeHandler( const OtaEventData_t * pEventData );
+OtaErr_t __CPROVER_file_local_ota_c_resumeHandler( const OtaEventData_t * pEventData );
 
 void resumeHandler_harness()
 {


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail -->

Fix type-checking issue in the memory safety proof for `resumeHandler`.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is formatted using Uncrustify.
- [x] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.