### PR TITLE
Remove \r\n from logging statements.

### DIFF
--- a/source/ota.c
+++ b/source/ota.c
@@ -3234,7 +3234,7 @@ static void resetEventQueue( void )
 
     while( otaAgent.pOtaInterface->os.event.recv( NULL, &eventMsg, 0 ) == OtaOsSuccess )
     {
-        LogWarn( ( "Event(%d) is dropped.\r\n", eventMsg.eventId ) );
+        LogWarn( ( "Event(%d) is dropped.", eventMsg.eventId ) );
 
         /* Call handleUnexpectedEvents to notify user to release resources if necessary. */
         handleUnexpectedEvents( &eventMsg );
@@ -3312,7 +3312,7 @@ OtaErr_t OTA_Init( const OtaAppBuffer_t * pOtaBuffer,
 
         if( pThingName == NULL )
         {
-            LogError( ( "Error: Thing name is NULL.\r\n" ) );
+            LogError( ( "Error: Thing name is NULL." ) );
         }
         else
         {
@@ -3329,7 +3329,7 @@ OtaErr_t OTA_Init( const OtaAppBuffer_t * pOtaBuffer,
             }
             else
             {
-                LogError( ( "Error: Thing name is too long.\r\n" ) );
+                LogError( ( "Error: Thing name is too long." ) );
             }
         }
 

--- a/source/portable/os/ota_os_freertos.c
+++ b/source/portable/os/ota_os_freertos.c
@@ -176,7 +176,7 @@ static void selfTestTimerCallback( TimerHandle_t T )
 {
     ( void ) T;
 
-    LogDebug( ( "Self-test expired within %ums\r\n",
+    LogDebug( ( "Self-test expired within %ums",
                 otaconfigSELF_TEST_RESPONSE_WAIT_MS ) );
 
     if( otaTimerCallbackPtr != NULL )
@@ -185,7 +185,7 @@ static void selfTestTimerCallback( TimerHandle_t T )
     }
     else
     {
-        LogWarn( ( "Self-test timer event unhandled.\r\n" ) );
+        LogWarn( ( "Self-test timer event unhandled." ) );
     }
 }
 
@@ -193,7 +193,7 @@ static void requestTimerCallback( TimerHandle_t T )
 {
     ( void ) T;
 
-    LogDebug( ( "Request timer expired in %ums \r\n",
+    LogDebug( ( "Request timer expired in %ums",
                 otaconfigFILE_REQUEST_WAIT_MS ) );
 
     if( otaTimerCallbackPtr != NULL )
@@ -202,7 +202,7 @@ static void requestTimerCallback( TimerHandle_t T )
     }
     else
     {
-        LogWarn( ( "Request timer event unhandled.\r\n" ) );
+        LogWarn( ( "Request timer event unhandled." ) );
     }
 }
 

--- a/source/portable/os/ota_os_posix.c
+++ b/source/portable/os/ota_os_posix.c
@@ -285,7 +285,7 @@ static void selfTestTimerCallback( union sigval arg )
 {
     ( void ) arg;
 
-    LogDebug( ( "Self-test expired within %ums\r\n",
+    LogDebug( ( "Self-test expired within %ums",
                 otaconfigSELF_TEST_RESPONSE_WAIT_MS ) );
 
     if( otaTimerCallbackPtr != NULL )
@@ -294,7 +294,7 @@ static void selfTestTimerCallback( union sigval arg )
     }
     else
     {
-        LogWarn( ( "Self-test timer event unhandled.\r\n" ) );
+        LogWarn( ( "Self-test timer event unhandled." ) );
     }
 }
 
@@ -302,7 +302,7 @@ static void requestTimerCallback( union sigval arg )
 {
     ( void ) arg;
 
-    LogDebug( ( "Request timer expired in %ums \r\n",
+    LogDebug( ( "Request timer expired in %ums",
                 otaconfigFILE_REQUEST_WAIT_MS ) );
 
     if( otaTimerCallbackPtr != NULL )
@@ -311,7 +311,7 @@ static void requestTimerCallback( union sigval arg )
     }
     else
     {
-        LogWarn( ( "Request timer event unhandled.\r\n" ) );
+        LogWarn( ( "Request timer event unhandled." ) );
     }
 }
 


### PR DESCRIPTION
Description
-----------
Remove CR and LF character from logging calls.

Newline characters are highly platform dependent, so should be handled in the logging macro defined by the integrator of the OTA library.

Checklist:
----------
- [ X ] I have tested my changes. No regression in existing tests.
- [ X ] My code is formatted using Uncrustify.
- [ X ] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.