### PR TITLE
Fix stringBuilderUInt32Decimal to handle 0 value

### DIFF
--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -297,7 +297,7 @@ static size_t stringBuilderUInt32Decimal( char * pBuffer,
 
     /* Assert if there is not enough buffer space. */
 
-    assert( bufferSizeBytes >= U32_MAX_LEN );
+    assert( bufferSizeBytes >= U32_MAX_LEN + 1 );
     ( void ) bufferSizeBytes;
 
     do
@@ -315,7 +315,6 @@ static size_t stringBuilderUInt32Decimal( char * pBuffer,
     }
 
     pDest[ size ] = '\0';
-    size++;
     return size;
 }
 
@@ -332,7 +331,7 @@ static size_t stringBuilderUInt32Hex( char * pBuffer,
 
     /* Assert if there is not enough buffer space. */
 
-    assert( bufferSizeBytes >= U32_MAX_LEN );
+    assert( bufferSizeBytes >= U32_MAX_LEN + 1);
     ( void ) bufferSizeBytes;
 
     /* Render all 8 digits, including leading zeros. */
@@ -351,7 +350,6 @@ static size_t stringBuilderUInt32Hex( char * pBuffer,
     }
 
     pDest[ size ] = '\0';
-    size++;
     return size;
 }
 

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -297,6 +297,7 @@ static size_t stringBuilderUInt32Decimal( char * pBuffer,
     uint32_t valueCopy = value;
     size_t size = 0;
 
+    ( void ) bufferSizeBytes;
     /* Assert if there is not enough buffer space. */
     assert( bufferSizeBytes >= U32_MAX_LEN + 1 );
 
@@ -329,6 +330,7 @@ static size_t stringBuilderUInt32Hex( char * pBuffer,
     uint32_t valueCopy = value;
     size_t i;
 
+    ( void ) bufferSizeBytes;
     /* Assert if there is not enough buffer space. */
     assert( bufferSizeBytes >= U32_MAX_LEN + 1 );
 

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -282,6 +282,8 @@ static size_t stringBuilder( char * pBuffer,
         curLen += thisLength;
     }
 
+    pBuffer[ curLen ] = '\0';
+
     return curLen;
 }
 

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -298,9 +298,7 @@ static size_t stringBuilderUInt32Decimal( char * pBuffer,
     size_t size = 0;
 
     /* Assert if there is not enough buffer space. */
-
     assert( bufferSizeBytes >= U32_MAX_LEN + 1 );
-    ( void ) bufferSizeBytes;
 
     do
     {
@@ -332,9 +330,7 @@ static size_t stringBuilderUInt32Hex( char * pBuffer,
     size_t i;
 
     /* Assert if there is not enough buffer space. */
-
     assert( bufferSizeBytes >= U32_MAX_LEN + 1 );
-    ( void ) bufferSizeBytes;
 
     /* Render all 8 digits, including leading zeros. */
     for( i = 0U; i < 8U; i++ )
@@ -870,6 +866,7 @@ OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
     uint32_t msgSize = 0;
     uint16_t topicLen = 0;
     uint32_t xThingNameLength = 0;
+    char reqCounterString[ U32_MAX_LEN + 1 ];
     uint32_t reqCounterStringLength = 0;
 
     /* NULL-terminated list of topic string parts. */
@@ -880,7 +877,6 @@ OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
         MQTT_API_JOBS_NEXT_GET,
         NULL
     };
-    char reqCounterString[ U32_MAX_LEN + 1 ];
 
     /* NULL-terminated list of payload parts */
 

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -331,7 +331,7 @@ static size_t stringBuilderUInt32Hex( char * pBuffer,
 
     /* Assert if there is not enough buffer space. */
 
-    assert( bufferSizeBytes >= U32_MAX_LEN + 1);
+    assert( bufferSizeBytes >= U32_MAX_LEN + 1 );
     ( void ) bufferSizeBytes;
 
     /* Render all 8 digits, including leading zeros. */

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -300,12 +300,12 @@ static size_t stringBuilderUInt32Decimal( char * pBuffer,
     assert( bufferSizeBytes >= U32_MAX_LEN );
     ( void ) bufferSizeBytes;
 
-    while( valueCopy > 0U )
+    do
     {
         *pCur = asciiDigits[ ( valueCopy % 10U ) ];
         pCur++;
         valueCopy /= 10U;
-    }
+    } while( valueCopy > 0U );
 
     while( pCur > workBuf )
     {


### PR DESCRIPTION
Description
-----------
Previously the stringBuilder method would return
and empty string when the integer value of '0' was supplied. With this change, the string representation "0" is returned.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [ x ] I have tested my changes. No regression in existing tests.
- [ x ] My code is formatted using Uncrustify.
- [ x ] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.