### PR TITLE
OTA Bitmap Field Size Comparison

### DIFF
--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -10,7 +10,7 @@
     <tr>
         <td>ota.c</td>
         <td><center>8.5K</center></td>
-        <td><center>7.6K</center></td>
+        <td><center>7.7K</center></td>
     </tr>
     <tr>
         <td>ota_interface.c</td>
@@ -40,6 +40,6 @@
     <tr>
         <td><b>Total estimates</b></td>
         <td><b><center>12.7K</center></b></td>
-        <td><b><center>11.5K</center></b></td>
+        <td><b><center>11.6K</center></b></td>
     </tr>
 </table>

--- a/source/ota.c
+++ b/source/ota.c
@@ -2367,6 +2367,11 @@ static OtaFileContext_t * parseJobDoc( const JsonDocParam_t * pJsonExpectedParam
     }
     else
     {
+        if( pFileContext->blocksRemaining > OTA_MAX_BLOCK_BITMAP_SIZE )
+        {
+            err = OtaJobParseErrBadModelInitParams;
+        }
+
         parseError = parseJSONbyModel( pJson, messageLength, &otaJobDocModel );
 
         if( parseError == DocParseErrNone )

--- a/source/ota.c
+++ b/source/ota.c
@@ -2365,13 +2365,12 @@ static OtaFileContext_t * parseJobDoc( const JsonDocParam_t * pJsonExpectedParam
     {
         err = OtaJobParseErrBadModelInitParams;
     }
+    else if( pFileContext->blocksRemaining > OTA_MAX_BLOCK_BITMAP_SIZE )
+    {
+        err = OtaJobParseErrBadModelInitParams;
+    }
     else
     {
-        if( pFileContext->blocksRemaining > OTA_MAX_BLOCK_BITMAP_SIZE )
-        {
-            err = OtaJobParseErrBadModelInitParams;
-        }
-
         parseError = parseJSONbyModel( pJson, messageLength, &otaJobDocModel );
 
         if( parseError == DocParseErrNone )

--- a/source/ota.c
+++ b/source/ota.c
@@ -2368,6 +2368,8 @@ static OtaFileContext_t * parseJobDoc( const JsonDocParam_t * pJsonExpectedParam
     else if( pFileContext->blocksRemaining > OTA_MAX_BLOCK_BITMAP_SIZE )
     {
         err = OtaJobParseErrBadModelInitParams;
+        LogWarn( ( "OTA size (%u blocks) greater than can be tracked. Increase `OTA_MAX_BLOCK_BITMAP_SIZE`",
+                   pFileContext->blocksRemaining ) );
     }
     else
     {

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -3528,6 +3528,25 @@ void test_OTA_parseJobFailsNullJsonDocument()
     TEST_ASSERT_EQUAL( false, updateJob );
 }
 
+void test_OTA_parseJobFailsMoreBlocksThanBitmap()
+{
+    OtaFileContext_t * pContext;
+    bool updateJob = false;
+    JsonDocParam_t otaCustomJobDocModelParamStructure[ 1 ] =
+    {
+        { OTA_JSON_JOB_ID_KEY, OTA_JOB_PARAM_REQUIRED, U16_OFFSET( OtaFileContext_t, pJobName ), U16_OFFSET( OtaFileContext_t, jobNameMaxSize ), UINT16_MAX },
+    };
+
+    /* The document structure has an invalid value for ModelParamType_t. */
+    otaAgent.fileContext.blocksRemaining = OTA_MAX_BLOCK_BITMAP_SIZE + 1;
+    otaInitDefault();
+    pContext = parseJobDoc( otaCustomJobDocModelParamStructure, 1, JOB_DOC_A, strlen( JOB_DOC_A ), &updateJob );
+
+    TEST_ASSERT_NULL( pContext );
+    TEST_ASSERT_EQUAL( false, updateJob );
+    otaAgent.fileContext.blocksRemaining = 0;
+}
+
 void test_OTA_extractParameterFailInvalidJobDocModel()
 {
     OtaFileContext_t * pContext;

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -3544,7 +3544,6 @@ void test_OTA_parseJobFailsMoreBlocksThanBitmap()
 
     TEST_ASSERT_NULL( pContext );
     TEST_ASSERT_EQUAL( false, updateJob );
-    otaAgent.fileContext.blocksRemaining = 0;
 }
 
 void test_OTA_extractParameterFailInvalidJobDocModel()


### PR DESCRIPTION
Add a check into the parseJobDoc() function to see if the OTA transfer will require more blocks than the bitmap has declared.

This pull request was created to fix #476 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.