### PR TITLE
FIX: Invalid topic used to publish request for outstanding OTA jobs

### DIFF
--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -888,6 +888,8 @@ OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
     ( void ) pOtaJobsGetNextTopicTemplate;
     ( void ) pOtaGetNextJobMsgTemplate;
 
+    pTopicParts[ 1 ] = ( const char * ) pAgentCtx->pThingName;
+
     /* Client token max length is 64. It is a combination of request counter (max 10 characters), a separator colon, and the ThingName. */
     xThingNameLength = ( uint32_t ) strnlen( ( const char * ) pAgentCtx->pThingName, OTA_CLIENT_TOKEN_MAX_THINGNAME_LEN );
 

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -483,9 +483,9 @@ static OtaMqttStatus_t stubMqttPublishOnlySuccedsTopicIsCorrect( const char * co
 
     char expected[ 129 ] = { 0 };
 
-    strcat(expected, "$aws/things/");
-    strcat(expected, pOtaDefaultClientId);
-    strcat(expected, "/jobs/$next/get");
+    strcat( expected, "$aws/things/" );
+    strcat( expected, pOtaDefaultClientId );
+    strcat( expected, "/jobs/$next/get" );
 
     TEST_ASSERT_EQUAL_STRING( expected, topic );
 

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -467,6 +467,31 @@ static OtaMqttStatus_t stubMqttPublish( const char * const unused_1,
     return OtaMqttSuccess;
 }
 
+static OtaMqttStatus_t stubMqttPublishOnlySuccedsTopicIsCorrect( const char * const topic,
+                                                                 uint16_t topicLength,
+                                                                 const char * unused_1,
+                                                                 uint32_t unused_2,
+                                                                 uint8_t unused_3 )
+{
+    ( void ) unused_1;
+    ( void ) unused_2;
+    ( void ) unused_3;
+
+    /* Maximum topic size is 128 characters for IoT Core */
+    TEST_ASSERT_LESS_OR_EQUAL( 128U, topicLength );
+    TEST_ASSERT_GREATER_THAN( 1U, topicLength );
+
+    char expected[ 129 ] = { 0 };
+
+    strcat(expected, "$aws/things/");
+    strcat(expected, pOtaDefaultClientId);
+    strcat(expected, "/jobs/$next/get");
+
+    TEST_ASSERT_EQUAL_STRING( expected, topic );
+
+    return OtaMqttSuccess;
+}
+
 static OtaMqttStatus_t stubMqttPublishOnlySuccedsIfTruncatedValue( const char * const unused_1,
                                                                    uint16_t unused_2,
                                                                    const char * msg,
@@ -2815,6 +2840,20 @@ void test_OTA_MQTT_JobSubscribingFailed()
     otaInterfaces.mqtt.subscribe = stubMqttSubscribeAlwaysFail;
     err = requestJob_Mqtt( &otaAgent );
     TEST_ASSERT_EQUAL( OtaErrRequestJobFailed, err );
+}
+
+/* Test the publish topic is assembled correctly */
+void test_OTA_MQTT_PublishesToCorrectTopic()
+{
+    OtaErr_t err = OtaErrNone;
+
+    otaInitDefault();
+    otaInterfaces.mqtt.subscribe = stubMqttSubscribe;
+    otaInterfaces.mqtt.publish = stubMqttPublishOnlySuccedsTopicIsCorrect;
+
+    err = requestJob_Mqtt( &otaAgent );
+
+    TEST_ASSERT_EQUAL( OtaErrNone, err );
 }
 
 /* Test thingname is truncated in requestJob_Mqtt */


### PR DESCRIPTION
FIX: Invalid topic used to publish request for outstanding OTA jobs

Description
-----------
From the original poster @imoir:

> This looks like a regression in commit https://github.com/aws/ota-for-aws-iot-embedded-sdk/commit/e43672a0881d6aad65df3a61ece5a4e019c3559f, the thing name is not added to the topic parts in function requestJob_Mqtt() in source/ota_mqtt.c.

fix #480 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [X] I have tested my changes. No regression in existing tests.
- [X] My code is formatted using Uncrustify.
- [X] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.