### PR TITLE
Fix assumptions on definitions of fixed width types

### DIFF
--- a/source/ota.c
+++ b/source/ota.c
@@ -630,7 +630,7 @@ static void otaTimerCallback( OtaTimerId_t otaTimerId )
         OtaEventMsg_t xEventMsg = { 0 };
 
         LogDebug( ( "Self-test expired within %ums",
-                    otaconfigFILE_REQUEST_WAIT_MS ) );
+                    ( unsigned ) otaconfigFILE_REQUEST_WAIT_MS ) );
 
         xEventMsg.eventId = OtaAgentEventRequestTimer;
 
@@ -643,7 +643,7 @@ static void otaTimerCallback( OtaTimerId_t otaTimerId )
     else /*  otaTimerId == OtaSelfTestTimer  */
     {
         LogError( ( "Self test failed to complete within %ums",
-                    otaconfigSELF_TEST_RESPONSE_WAIT_MS ) );
+                    ( unsigned ) otaconfigSELF_TEST_RESPONSE_WAIT_MS ) );
 
         ( void ) otaAgent.pOtaInterface->pal.reset( &otaAgent.fileContext );
     }
@@ -764,8 +764,8 @@ static OtaErr_t setImageStateWithReason( OtaImageState_t stateToSet,
                    ", reason=%d",
                    OTA_Err_strerror( err ),
                    OTA_PalStatus_strerror( OTA_PAL_MAIN_ERR( palStatus ) ),
-                   stateToSet,
-                   reasonToSet ) );
+                   ( int ) stateToSet,
+                   ( int ) reasonToSet ) );
     }
 
     return err;
@@ -1171,7 +1171,7 @@ static void dataHandlerCleanup( void )
         LogWarn( ( "Failed to trigger closing file: "
                    "Unable to signal event: "
                    "event=%d",
-                   eventMsg.eventId ) );
+                   ( int ) eventMsg.eventId ) );
     }
 }
 
@@ -1235,7 +1235,7 @@ static OtaErr_t processDataHandler( const OtaEventData_t * pEventData )
     }
     else if( result < IngestResultFileComplete )
     {
-        LogError( ( "Failed to ingest data block, rejecting image: ingestDataBlock returned error: OtaErr_t=%d", result ) );
+        LogError( ( "Failed to ingest data block, rejecting image: ingestDataBlock returned error: OtaErr_t=%d", ( int ) result ) );
 
         /* Call the platform specific code to reject the image. */
         ( void ) otaAgent.pOtaInterface->pal.setPlatformImageState( &( otaAgent.fileContext ), OtaImageStateRejected );
@@ -1284,7 +1284,7 @@ static OtaErr_t processDataHandler( const OtaEventData_t * pEventData )
 
             if( OTA_SignalEvent( &eventMsg ) == false )
             {
-                LogWarn( ( "Failed to trigger requesting the next block: Unable to signal event=%d", eventMsg.eventId ) );
+                LogWarn( ( "Failed to trigger requesting the next block: Unable to signal event=%d", ( int ) eventMsg.eventId ) );
             }
         }
     }
@@ -1314,7 +1314,7 @@ static OtaErr_t closeFileHandler( const OtaEventData_t * pEventData )
 
     LogInfo( ( "Closing file: "
                "file index=%u",
-               otaAgent.fileIndex ) );
+               ( unsigned ) otaAgent.fileIndex ) );
 
     ( void ) otaClose( &( otaAgent.fileContext ) );
 
@@ -1563,7 +1563,7 @@ static DocParseErr_t validateJSON( const char * pJson,
             LogError( ( "Invalid JSON document: "
                         "JSON_Validate returned error: "
                         "JSONStatus_t=%d",
-                        result ) );
+                        ( int ) result ) );
             err = DocParseErr_InvalidJSONBuffer;
         }
     }
@@ -1598,7 +1598,7 @@ static DocParseErr_t decodeAndStoreKey( const char * pValueInJson,
         LogError( ( "Failed to decode Base64 data: "
                     "base64Decode returned error: "
                     "error=%d",
-                    base64Status ) );
+                    ( int ) base64Status ) );
         err = DocParseErrBase64Decode;
     }
     else
@@ -1717,7 +1717,7 @@ static DocParseErr_t extractParameter( JsonDocParam_t docParam,
         if( ( errno == 0 ) && ( pEnd == &pValueInJson[ valueLength ] ) )
         {
             LogInfo( ( "Extracted parameter: [key: value]=[%s: %u]",
-                       docParam.pSrcKey, *pUint32 ) );
+                       docParam.pSrcKey, ( unsigned ) *pUint32 ) );
         }
         else
         {
@@ -1737,13 +1737,13 @@ static DocParseErr_t extractParameter( JsonDocParam_t docParam,
     }
     else
     {
-        LogWarn( ( "Invalid parameter type: %d", docParam.modelParamType ) );
+        LogWarn( ( "Invalid parameter type: %d", ( int ) docParam.modelParamType ) );
     }
 
     if( err != DocParseErrNone )
     {
         LogDebug( ( "Failed to extract document parameter: error=%d, paramter key=%s",
-                    err, docParam.pSrcKey ) );
+                    ( int ) err, docParam.pSrcKey ) );
     }
 
     return err;
@@ -1856,7 +1856,7 @@ static DocParseErr_t parseJSONbyModel( const char * pJson,
     {
         LogDebug( ( "Failed to parse JSON document as AFR_OTA job: "
                     "DocParseErr_t=%d",
-                    err ) );
+                    ( int ) err ) );
     }
 
     return err;
@@ -1892,8 +1892,8 @@ static DocParseErr_t initDocModel( JsonDocModel_t * pDocModel,
         LogError( ( "Parameter check failed: "
                     "Document model has %u parameters: "
                     "Document model should have <= %u parameters.",
-                    numJobParams,
-                    OTA_DOC_MODEL_MAX_PARAMS ) );
+                    ( unsigned ) numJobParams,
+                    ( unsigned ) OTA_DOC_MODEL_MAX_PARAMS ) );
         err = DocParseErrTooManyParams;
     }
     else
@@ -1921,7 +1921,7 @@ static DocParseErr_t initDocModel( JsonDocModel_t * pDocModel,
     if( err != DocParseErrNone )
     {
         LogError( ( "Failed to initialize document model: "
-                    "DocParseErr_t=%d", err ) );
+                    "DocParseErr_t=%d", ( int ) err ) );
     }
 
     return err;
@@ -1970,8 +1970,8 @@ static OtaErr_t validateUpdateVersion( const OtaFileContext_t * pFileContext )
             LogInfo( ( "New image has a higher version number than the current image: "
                        "New image version=%u.%u.%u"
                        ", Previous image version=%u.%u.%u",
-                       appFirmwareVersion.u.x.major, appFirmwareVersion.u.x.minor, appFirmwareVersion.u.x.build,
-                       previousVersion.u.x.major, previousVersion.u.x.minor, previousVersion.u.x.build ) );
+                       ( unsigned ) appFirmwareVersion.u.x.major, ( unsigned ) appFirmwareVersion.u.x.minor, ( unsigned ) appFirmwareVersion.u.x.build,
+                       ( unsigned ) previousVersion.u.x.major, ( unsigned ) previousVersion.u.x.minor, ( unsigned ) previousVersion.u.x.build ) );
         }
     }
 
@@ -2141,7 +2141,7 @@ static void handleSelfTestJobDoc( const OtaFileContext_t * pFileContext )
     #if ( otaconfigAllowDowngrade == 1U )
         {
             LogWarn( ( "OTA Config Allow Downgrade has been set to 1, bypassing version check: Begin testing file: File ID=%d",
-                       otaAgent.serverFileID ) );
+                       ( int ) otaAgent.serverFileID ) );
 
             /* Downgrade is allowed so this means we're ready to start self test phase.
              * Set image state accordingly and update job status with self test identifier.
@@ -2161,7 +2161,7 @@ static void handleSelfTestJobDoc( const OtaFileContext_t * pFileContext )
             if( errVersionCheck == OtaErrNone )
             {
                 LogInfo( ( "Image version is valid: Begin testing file: File ID=%d",
-                           otaAgent.serverFileID ) );
+                           ( int ) otaAgent.serverFileID ) );
 
                 /* The running firmware version is newer than the firmware that performed
                  * the update so this means we're ready to start the self test phase.
@@ -2369,7 +2369,7 @@ static OtaFileContext_t * parseJobDoc( const JsonDocParam_t * pJsonExpectedParam
     {
         err = OtaJobParseErrBadModelInitParams;
         LogWarn( ( "OTA size (%u blocks) greater than can be tracked. Increase `OTA_MAX_BLOCK_BITMAP_SIZE`",
-                   pFileContext->blocksRemaining ) );
+                   ( unsigned ) pFileContext->blocksRemaining ) );
     }
     else
     {
@@ -2539,7 +2539,7 @@ static bool validateDataBlock( const OtaFileContext_t * pFileContext,
     {
         ret = true;
         LogDebug( ( "Received valid file block: Block index=%u, Size=%u",
-                    blockIndex, blockSize ) );
+                    ( unsigned ) blockIndex, ( unsigned ) blockSize ) );
     }
 
     return ret;
@@ -2575,7 +2575,7 @@ static IngestResult_t processDataBlock( OtaFileContext_t * pFileContext,
         {
             LogError( ( "Block range check failed: Received a block outside of the expected range: "
                         "Block index=%u, Block size=%u",
-                        uBlockIndex, uBlockSize ) );
+                        ( unsigned ) uBlockIndex, ( unsigned ) uBlockSize ) );
             eIngestResult = IngestResultBlockOutOfRange;
         }
     }
@@ -2591,9 +2591,9 @@ static IngestResult_t processDataBlock( OtaFileContext_t * pFileContext,
         if( ( ( pFileContext->pRxBlockBitmap[ byte ] ) & bitMask ) == 0U )
         {
             LogWarn( ( "Received a duplicate block: Block index=%u, Block size=%u",
-                       uBlockIndex, uBlockSize ) );
+                       ( unsigned ) uBlockIndex, ( unsigned ) uBlockSize ) );
             LogDebug( ( "Number of blocks remaining: %u",
-                        pFileContext->blocksRemaining ) );
+                        ( unsigned ) pFileContext->blocksRemaining ) );
 
             eIngestResult = IngestResultDuplicate_Continue;
             *pCloseResult = OTA_PAL_COMBINE_ERR( OtaPalSuccess, 0 ); /* This is a success path. */
@@ -2617,7 +2617,7 @@ static IngestResult_t processDataBlock( OtaFileContext_t * pFileContext,
         {
             eIngestResult = IngestResultWriteBlockFailed;
             LogError( ( "Failed to ingest received block: iBytesWritten: %d, IngestResult_t=%d",
-                        iBytesWritten, eIngestResult ) );
+                        ( int ) iBytesWritten, ( int ) eIngestResult ) );
         }
     }
 
@@ -2751,7 +2751,7 @@ static IngestResult_t ingestDataBlockCleanup( OtaFileContext_t * pFileContext,
             else
             {
                 LogError( ( "Failed to close the OTA file: Error=(%s:0x%06x)",
-                            OTA_PalStatus_strerror( otaPalMainErr ), otaPalSubErr ) );
+                            OTA_PalStatus_strerror( otaPalMainErr ), ( unsigned ) otaPalSubErr ) );
 
                 if( otaPalMainErr == ( uint32_t ) OtaPalSignatureCheckFailed )
                 {
@@ -2820,13 +2820,13 @@ static IngestResult_t ingestDataBlock( OtaFileContext_t * pFileContext,
     if( eIngestResult == IngestResultAccepted_Continue )
     {
         LogDebug( ( "Ingested received block %u",
-                    uBlockIndex ) );
+                    ( unsigned ) uBlockIndex ) );
 
         /* Print progress every 32 blocks received */
         if( ( pFileContext->blocksRemaining & 0x1Fu ) == 0u )
         {
             LogInfo( ( "Number of blocks remaining: %u",
-                       pFileContext->blocksRemaining ) );
+                       ( unsigned ) pFileContext->blocksRemaining ) );
         }
     }
 
@@ -3040,7 +3040,7 @@ static void callOtaCallback( OtaJobEvent_t eEvent,
     }
     else
     {
-        LogWarn( ( "OtaAppCallback is not registered, event=%d", eEvent ) );
+        LogWarn( ( "OtaAppCallback is not registered, event=%d", ( int ) eEvent ) );
     }
 }
 
@@ -3240,7 +3240,7 @@ static void resetEventQueue( void )
 
     while( otaAgent.pOtaInterface->os.event.recv( NULL, &eventMsg, 0 ) == OtaOsSuccess )
     {
-        LogWarn( ( "Event(%d) is dropped.", eventMsg.eventId ) );
+        LogWarn( ( "Event(%d) is dropped.", ( int ) eventMsg.eventId ) );
 
         /* Call handleUnexpectedEvents to notify user to release resources if necessary. */
         handleUnexpectedEvents( &eventMsg );
@@ -3366,7 +3366,7 @@ OtaState_t OTA_Shutdown( uint32_t ticksToWait,
 
     LogDebug( ( "Number of ticks to idle while the OTA Agent shuts down: "
                 "ticks=%u",
-                ticks ) );
+                ( unsigned ) ticks ) );
 
     if( ( otaAgent.state != OtaAgentStateStopped ) && ( otaAgent.state != OtaAgentStateShuttingDown ) ) /* LCOV_EXCL_BR_LINE */
     {
@@ -3403,7 +3403,7 @@ OtaState_t OTA_Shutdown( uint32_t ticksToWait,
 
     LogDebug( ( "Number of ticks remaining when OTA Agent shutdown: "
                 "ticks=%u",
-                ticks ) );
+                ( unsigned ) ticks ) );
 
     return otaAgent.state;
 }

--- a/source/ota_cbor.c
+++ b/source/ota_cbor.c
@@ -132,7 +132,7 @@ bool OTA_CBOR_Decode_GetStreamResponseMessage( const uint8_t * pMessageBuffer,
     if( CborNoError == cborResult )
     {
         cborResult = cbor_value_get_int( &cborValue,
-                                         ( int32_t * ) pFileId );
+                                         ( int * ) pFileId );
     }
 
     /* Find the block ID. */
@@ -151,7 +151,7 @@ bool OTA_CBOR_Decode_GetStreamResponseMessage( const uint8_t * pMessageBuffer,
     if( CborNoError == cborResult )
     {
         cborResult = cbor_value_get_int( &cborValue,
-                                         ( int32_t * ) pBlockId );
+                                         ( int * ) pBlockId );
     }
 
     /* Find the block size. */
@@ -170,7 +170,7 @@ bool OTA_CBOR_Decode_GetStreamResponseMessage( const uint8_t * pMessageBuffer,
     if( CborNoError == cborResult )
     {
         cborResult = cbor_value_get_int( &cborValue,
-                                         ( int32_t * ) pBlockSize );
+                                         ( int * ) pBlockSize );
     }
 
     /* Find the payload bytes. */

--- a/source/ota_mqtt.c
+++ b/source/ota_mqtt.c
@@ -913,7 +913,7 @@ OtaErr_t requestJob_Mqtt( const OtaAgentContext_t * pAgentCtx )
 
     if( mqttStatus == OtaMqttSuccess )
     {
-        LogDebug( ( "MQTT job request number: counter=%u", reqCounter ) );
+        LogDebug( ( "MQTT job request number: counter=%u", ( unsigned ) reqCounter ) );
 
         /* The buffer is static and the size is calculated to fit. */
         assert( ( msgSize > 0U ) && ( msgSize < sizeof( pMsg ) ) );

--- a/source/portable/os/ota_os_freertos.c
+++ b/source/portable/os/ota_os_freertos.c
@@ -81,8 +81,8 @@ OtaOsStatus_t OtaInitEvent_FreeRTOS( OtaEventContext_t * pEventCtx )
 
         LogError( ( "Failed to create OTA Event Queue: "
                     "xQueueCreateStatic returned error: "
-                    "OtaOsStatus_t=%i ",
-                    otaOsStatus ) );
+                    "OtaOsStatus_t=%d ",
+                    ( int ) otaOsStatus ) );
     }
     else
     {
@@ -115,8 +115,8 @@ OtaOsStatus_t OtaSendEvent_FreeRTOS( OtaEventContext_t * pEventCtx,
 
         LogError( ( "Failed to send event to OTA Event Queue: "
                     "xQueueSendToBack returned error: "
-                    "OtaOsStatus_t=%i ",
-                    otaOsStatus ) );
+                    "OtaOsStatus_t=%d ",
+                    ( int ) otaOsStatus ) );
     }
 
     return otaOsStatus;
@@ -148,8 +148,8 @@ OtaOsStatus_t OtaReceiveEvent_FreeRTOS( OtaEventContext_t * pEventCtx,
 
         LogDebug( ( "Failed to receive event or timeout from OTA Event Queue: "
                     "xQueueReceive returned error: "
-                    "OtaOsStatus_t=%i ",
-                    otaOsStatus ) );
+                    "OtaOsStatus_t=%d ",
+                    ( int ) otaOsStatus ) );
     }
 
     return otaOsStatus;
@@ -177,7 +177,7 @@ static void selfTestTimerCallback( TimerHandle_t T )
     ( void ) T;
 
     LogDebug( ( "Self-test expired within %ums",
-                otaconfigSELF_TEST_RESPONSE_WAIT_MS ) );
+                ( unsigned ) otaconfigSELF_TEST_RESPONSE_WAIT_MS ) );
 
     if( otaTimerCallbackPtr != NULL )
     {
@@ -194,7 +194,7 @@ static void requestTimerCallback( TimerHandle_t T )
     ( void ) T;
 
     LogDebug( ( "Request timer expired in %ums",
-                otaconfigFILE_REQUEST_WAIT_MS ) );
+                ( unsigned ) otaconfigFILE_REQUEST_WAIT_MS ) );
 
     if( otaTimerCallbackPtr != NULL )
     {
@@ -236,8 +236,8 @@ OtaOsStatus_t OtaStartTimer_FreeRTOS( OtaTimerId_t otaTimerId,
 
             LogError( ( "Failed to create OTA timer: "
                         "timerCreate returned NULL "
-                        "OtaOsStatus_t=%i ",
-                        otaOsStatus ) );
+                        "OtaOsStatus_t=%d ",
+                        ( int ) otaOsStatus ) );
         }
         else
         {
@@ -274,8 +274,8 @@ OtaOsStatus_t OtaStartTimer_FreeRTOS( OtaTimerId_t otaTimerId,
 
             LogError( ( "Failed to set OTA timer timeout: "
                         "timer_settime returned error: "
-                        "OtaOsStatus_t=%i ",
-                        otaOsStatus ) );
+                        "OtaOsStatus_t=%d ",
+                        ( int ) otaOsStatus ) );
         }
     }
 
@@ -294,21 +294,21 @@ OtaOsStatus_t OtaStopTimer_FreeRTOS( OtaTimerId_t otaTimerId )
 
         if( retVal == pdTRUE )
         {
-            LogDebug( ( "OTA Timer Stopped for Timerid=%i.", otaTimerId ) );
+            LogDebug( ( "OTA Timer Stopped for Timerid=%d.", ( int ) otaTimerId ) );
         }
         else
         {
             LogError( ( "Failed to stop OTA timer: "
                         "timer_settime returned error: "
-                        "OtaOsStatus_t=%i ",
-                        otaOsStatus ) );
+                        "OtaOsStatus_t=%d ",
+                        ( int ) otaOsStatus ) );
 
             otaOsStatus = OtaOsTimerStopFailed;
         }
     }
     else
     {
-        LogWarn( ( "OTA Timer handle NULL for Timerid=%i, can't stop.", otaTimerId ) );
+        LogWarn( ( "OTA Timer handle NULL for Timerid=%d, can't stop.", ( int ) otaTimerId ) );
     }
 
     return otaOsStatus;
@@ -335,15 +335,15 @@ OtaOsStatus_t OtaDeleteTimer_FreeRTOS( OtaTimerId_t otaTimerId )
 
             LogError( ( "Failed to delete OTA timer: "
                         "timer_delete returned error: "
-                        "OtaOsStatus_t=%i ",
-                        otaOsStatus ) );
+                        "OtaOsStatus_t=%d ",
+                        ( int ) otaOsStatus ) );
         }
     }
     else
     {
         otaOsStatus = OtaOsTimerDeleteFailed;
 
-        LogWarn( ( "OTA Timer handle NULL for Timerid=%i, can't delete.", otaTimerId ) );
+        LogWarn( ( "OTA Timer handle NULL for Timerid=%d, can't delete.", ( int ) otaTimerId ) );
     }
 
     return otaOsStatus;

--- a/source/portable/os/ota_os_posix.c
+++ b/source/portable/os/ota_os_posix.c
@@ -120,9 +120,9 @@ OtaOsStatus_t Posix_OtaInitEvent( OtaEventContext_t * pEventCtx )
 
         LogError( ( "Failed to create OTA Event Queue: "
                     "mq_open returned error: "
-                    "OtaOsStatus_t=%i "
+                    "OtaOsStatus_t=%d "
                     ",errno=%s",
-                    otaOsStatus,
+                    ( int ) otaOsStatus,
                     strerror( errno ) ) );
     }
     else
@@ -149,7 +149,7 @@ OtaOsStatus_t Posix_OtaSendEvent( OtaEventContext_t * pEventCtx,
 
         LogError( ( "Invalid input, Posix_OtaSendEvent supports timeout < INT_MAX, "
                     "timeout = %u",
-                    timeout ) );
+                    ( unsigned ) timeout ) );
     }
 
     if( otaOsStatus == OtaOsSuccess )
@@ -165,7 +165,7 @@ OtaOsStatus_t Posix_OtaSendEvent( OtaEventContext_t * pEventCtx,
                         "Posix_OtaSendEvent returned error: "
                         "OtaOsStatus_t=%i "
                         ",errno=%s ",
-                        otaOsStatus,
+                        ( int ) otaOsStatus,
                         strerror( errno ) ) );
         }
     }
@@ -209,7 +209,7 @@ OtaOsStatus_t Posix_OtaReceiveEvent( OtaEventContext_t * pEventCtx,
 
         LogError( ( "Invalid input, Posix_OtaReceiveEvent supports timeout < INT_MAX, "
                     "timeout = %u",
-                    timeout ) );
+                    ( unsigned ) timeout ) );
     }
 
     if( otaOsStatus == OtaOsSuccess )
@@ -225,7 +225,7 @@ OtaOsStatus_t Posix_OtaReceiveEvent( OtaEventContext_t * pEventCtx,
                         "Posix_OtaReceiveEvent returned error: "
                         "OtaOsStatus_t=%i "
                         ",errno=%s ",
-                        otaOsStatus,
+                        ( int ) otaOsStatus,
                         strerror( errno ) ) );
         }
     }
@@ -270,7 +270,7 @@ OtaOsStatus_t Posix_OtaDeinitEvent( OtaEventContext_t * pEventCtx )
                     "mq_unlink returned error: "
                     "OtaOsStatus_t=%i "
                     ",errno=%s",
-                    otaOsStatus,
+                    ( int ) otaOsStatus,
                     strerror( errno ) ) );
     }
     else
@@ -286,7 +286,7 @@ static void selfTestTimerCallback( union sigval arg )
     ( void ) arg;
 
     LogDebug( ( "Self-test expired within %ums",
-                otaconfigSELF_TEST_RESPONSE_WAIT_MS ) );
+                ( unsigned ) otaconfigSELF_TEST_RESPONSE_WAIT_MS ) );
 
     if( otaTimerCallbackPtr != NULL )
     {
@@ -303,7 +303,7 @@ static void requestTimerCallback( union sigval arg )
     ( void ) arg;
 
     LogDebug( ( "Request timer expired in %ums",
-                otaconfigFILE_REQUEST_WAIT_MS ) );
+                ( unsigned ) otaconfigFILE_REQUEST_WAIT_MS ) );
 
     if( otaTimerCallbackPtr != NULL )
     {
@@ -378,12 +378,12 @@ static OtaOsStatus_t pollAndSend( const void * buff,
     {
         LogError( ( "Failed to send event to OTA Event Queue: "
                     "mq_send timeout: "
-                    "OtaOsStatus_t=%i"
+                    "OtaOsStatus_t=%d"
                     ", errno=%s"
                     ", revents=%x",
-                    otaOsStatus,
+                    ( int ) otaOsStatus,
                     strerror( errno ),
-                    fds.revents ) );
+                    ( unsigned ) fds.revents ) );
     }
 
     return otaOsStatus;
@@ -420,12 +420,12 @@ static OtaOsStatus_t pollAndReceive( char * buff,
     {
         LogError( ( "Failed to receive event to OTA Event Queue: "
                     "mq_receive timeout: "
-                    "OtaOsStatus_t=%i"
+                    "OtaOsStatus_t=%d"
                     ", errno=%s"
                     ", revents=%x",
-                    otaOsStatus,
+                    ( int ) otaOsStatus,
                     strerror( errno ),
-                    fds.revents ) );
+                    ( unsigned ) fds.revents ) );
     }
     else
     {
@@ -474,9 +474,9 @@ OtaOsStatus_t Posix_OtaStartTimer( OtaTimerId_t otaTimerId,
 
             LogError( ( "Failed to create OTA timer: "
                         "timer_create returned error: "
-                        "OtaOsStatus_t=%i "
+                        "OtaOsStatus_t=%d "
                         ",errno=%s",
-                        otaOsStatus,
+                        ( int ) otaOsStatus,
                         strerror( errno ) ) );
         }
         else
@@ -496,9 +496,9 @@ OtaOsStatus_t Posix_OtaStartTimer( OtaTimerId_t otaTimerId,
 
             LogError( ( "Failed to set OTA timer timeout: "
                         "timer_settime returned error: "
-                        "OtaOsStatus_t=%i "
+                        "OtaOsStatus_t=%d "
                         ",errno=%s",
-                        otaOsStatus,
+                        ( int ) otaOsStatus,
                         strerror( errno ) ) );
         }
         else
@@ -534,19 +534,19 @@ OtaOsStatus_t Posix_OtaStopTimer( OtaTimerId_t otaTimerId )
 
             LogError( ( "Failed to stop OTA timer: "
                         "timer_settime returned error: "
-                        "OtaOsStatus_t=%i "
+                        "OtaOsStatus_t=%d "
                         ",errno=%s",
-                        otaOsStatus,
+                        ( int ) otaOsStatus,
                         strerror( errno ) ) );
         }
         else
         {
-            LogDebug( ( "OTA Timer Stopped for Timerid=%i.", otaTimerId ) );
+            LogDebug( ( "OTA Timer Stopped for Timerid=%d.", ( int ) otaTimerId ) );
         }
     }
     else
     {
-        LogDebug( ( "OTA Timer handle NULL for Timerid=%i, can't stop.", otaTimerId ) );
+        LogDebug( ( "OTA Timer handle NULL for Timerid=%d, can't stop.", ( int ) otaTimerId ) );
 
         otaOsStatus = OtaOsTimerStopFailed;
     }
@@ -569,9 +569,9 @@ OtaOsStatus_t Posix_OtaDeleteTimer( OtaTimerId_t otaTimerId )
 
             LogError( ( "Failed to delete OTA timer: "
                         "timer_delete returned error: "
-                        "OtaOsStatus_t=%i "
+                        "OtaOsStatus_t=%d "
                         ",errno=%s",
-                        otaOsStatus,
+                        ( int ) otaOsStatus,
                         strerror( errno ) ) );
         }
         else
@@ -583,7 +583,7 @@ OtaOsStatus_t Posix_OtaDeleteTimer( OtaTimerId_t otaTimerId )
     }
     else
     {
-        LogWarn( ( "OTA Timer handle NULL for Timerid=%i, can't delete.", otaTimerId ) );
+        LogWarn( ( "OTA Timer handle NULL for Timerid=%d, can't delete.", ( int ) otaTimerId ) );
 
         otaOsStatus = OtaOsTimerDeleteFailed;
     }


### PR DESCRIPTION
This fixes assumptions that int32_t is defined as int and so on.

Printf parameters were also otherwise not cast to the type specifiers used in the format strings.

These can cause warnings and failed compilations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.