### PR TITLE
Empty job fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         uses: FreeRTOS/CI-CD-Github-Actions/complexity@main
         with:
           path: ./
+          horrid_threshold: 10
 
   unittest:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The OTA library enables you to manage the notification of a newly available update, download the update, and perform cryptographic verification of the firmware update. Using the library, you can logically separate firmware updates from the application running on your devices. The OTA library can share a network connection with the application, saving memory in resource-constrained devices. In addition, the OTA library lets you define application-specific logic for testing, committing, or rolling back a firmware update. The library supports different application protocols like Message Queuing Telemetry Transport (MQTT) and Hypertext Transfer Protocol (HTTP), and provides various configuration options you can fine tune depending on network type and conditions. This library is distributed under the [MIT Open Source License](LICENSE).
 
-This library has gone through code quality checks including verification that no function has a [GNU Complexity](https://www.gnu.org/software/complexity/manual/complexity.html) score over 8. This library has also undergone static code analysis from [Coverity static analysis](https://scan.coverity.com/).
+This library has gone through code quality checks including verification that no function has a [GNU Complexity](https://www.gnu.org/software/complexity/manual/complexity.html) score over 10. This library has also undergone static code analysis from [Coverity static analysis](https://scan.coverity.com/).
 
 See memory requirements for this library [here](./docs/doxygen/include/size_table.md).
 

--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -9,7 +9,7 @@
     </tr>
     <tr>
         <td>ota.c</td>
-        <td><center>8.5K</center></td>
+        <td><center>8.6K</center></td>
         <td><center>7.7K</center></td>
     </tr>
     <tr>
@@ -39,7 +39,7 @@
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>12.7K</center></b></td>
+        <td><b><center>12.8K</center></b></td>
         <td><b><center>11.6K</center></b></td>
     </tr>
 </table>

--- a/source/include/ota.h
+++ b/source/include/ota.h
@@ -102,7 +102,7 @@ typedef enum OtaErr
     OtaErrFailedToDecodeCbor,     /*!< @brief Failed to decode CBOR object from streaming service response. */
     OtaErrActivateFailed,         /*!< @brief Failed to activate the new image. */
     OtaErrFileSizeOverflow,       /*!< @brief Firmware file size greater than the max allowed size. */
-    OtaErrEmptyJobDocument        /*!< @brief Empty job document found - this happens on start up. */ 
+    OtaErrEmptyJobDocument        /*!< @brief Empty job document found - this happens on start up. */
 } OtaErr_t;
 
 /**

--- a/source/include/ota.h
+++ b/source/include/ota.h
@@ -101,7 +101,8 @@ typedef enum OtaErr
     OtaErrFailedToEncodeCbor,     /*!< @brief Failed to encode CBOR object for requesting data block from streaming service. */
     OtaErrFailedToDecodeCbor,     /*!< @brief Failed to decode CBOR object from streaming service response. */
     OtaErrActivateFailed,         /*!< @brief Failed to activate the new image. */
-    OtaErrFileSizeOverflow        /*!< @brief Firmware file size greater than the max allowed size. */
+    OtaErrFileSizeOverflow,       /*!< @brief Firmware file size greater than the max allowed size. */
+    OtaErrEmptyJobDocument        /*!< @brief Empty job document found - this happens on start up. */ 
 } OtaErr_t;
 
 /**

--- a/source/include/ota_private.h
+++ b/source/include/ota_private.h
@@ -207,7 +207,7 @@ typedef enum
     DocParseErrParamKeyNotInModel,    /*!< The document model does not include the specified parameter key. */
     DocParseErrInvalidModelParamType, /*!< The document model specified an invalid parameter type. */
     DocParseErrInvalidToken,          /*!< The Jasmine token was invalid, producing a NULL pointer. */
-    DocParseErrEmptyJobDoc            /*!< The document is valid but doesn't contain all necessary fields. */
+    DocParseErrEmptyJobDoc            /*!< The document is valid but does not contain all necessary fields. */
 } DocParseErr_t;
 
 /**

--- a/source/include/ota_private.h
+++ b/source/include/ota_private.h
@@ -206,7 +206,8 @@ typedef enum
     DocParseErrTooManyParams,         /*!< The document model has more parameters than we can handle. */
     DocParseErrParamKeyNotInModel,    /*!< The document model does not include the specified parameter key. */
     DocParseErrInvalidModelParamType, /*!< The document model specified an invalid parameter type. */
-    DocParseErrInvalidToken           /*!< The Jasmine token was invalid, producing a NULL pointer. */
+    DocParseErrInvalidToken,          /*!< The Jasmine token was invalid, producing a NULL pointer. */
+    DocParseErrEmptyJobDoc            /*!< The document is valid but doesn't contain all necessary fields. */
 } DocParseErr_t;
 
 /**

--- a/source/ota.c
+++ b/source/ota.c
@@ -170,7 +170,7 @@ static IngestResult_t ingestDataBlockCleanup( OtaFileContext_t * pFileContext,
  *
  * @param[in] pRawMsg Raw job document.
  * @param[in] messageLength length of document.
- * @param[out] OtaFileContext_t** Information of file to be streamed.
+ * @param[out] pFileContext Information of file to be streamed.
  * @return OtaErr_t any OTA error while determining file context
  */
 static OtaErr_t getFileContextFromJob( const char * pRawMsg,
@@ -302,7 +302,7 @@ static OtaJobParseErr_t validateAndStartJob( OtaFileContext_t * pFileContext,
  * @param[in] pJson JSON job document.
  * @param[in] messageLength Length of the job document.
  * @param[in] pUpdateJob Represents if the job is accepted.
- * @param[out] OtaFileContext_t** File context to store file information.
+ * @param[out] pFileContext File context to store file information.
  * @return DocParseErr_t found when parsing the document
  */
 static DocParseErr_t parseJobDoc( const JsonDocParam_t * pJsonExpectedParams,
@@ -2966,7 +2966,7 @@ static void executeHandler( uint32_t index,
 {
     OtaErr_t err = OtaErrNone;
 
-    LogWarn( ( "Index: %lu. OTA event id: %i", index, ( int ) pEventMsg->eventId ) );
+    LogWarn( ( "Index: %u. OTA event id: %i", index, ( int ) pEventMsg->eventId ) );
 
     assert( otaTransitionTable[ index ].handler != NULL );
 

--- a/source/ota.c
+++ b/source/ota.c
@@ -78,13 +78,13 @@
 #define U16_OFFSET( type, member )    ( ( uint16_t ) offsetof( type, member ) )
 
 /**
-* @brief Resulting bitmap value from empty OTA job document.
-*
-* Empty OTA job documents will contain only the ClientToken
-* (bit 0) and Timestamp (bit 1) values.
-* Value is determined by the `otaJobDocModelParamStructure` mapping.
-*/
-#define EMPTY_JOB_DOC_PARAMETER_BITMAP 3U
+ * @brief Resulting bitmap value from empty OTA job document.
+ *
+ * Empty OTA job documents will contain only the ClientToken
+ * (bit 0) and Timestamp (bit 1) values.
+ * Value is determined by the `otaJobDocModelParamStructure` mapping.
+ */
+#define EMPTY_JOB_DOC_PARAMETER_BITMAP    3U
 
 /**
  * @brief OTA event handler definition.
@@ -174,8 +174,8 @@ static IngestResult_t ingestDataBlockCleanup( OtaFileContext_t * pFileContext,
  * @return OtaErr_t any OTA error while determining file context
  */
 static OtaErr_t getFileContextFromJob( const char * pRawMsg,
-                                        uint32_t messageLength,
-                                        OtaFileContext_t **pFileContext);
+                                       uint32_t messageLength,
+                                       OtaFileContext_t ** pFileContext );
 
 /**
  * @brief Validate JSON document and the DocModel.
@@ -306,11 +306,11 @@ static OtaJobParseErr_t validateAndStartJob( OtaFileContext_t * pFileContext,
  * @return DocParseErr_t found when parsing the document
  */
 static DocParseErr_t parseJobDoc( const JsonDocParam_t * pJsonExpectedParams,
-                                       uint16_t numJobParams,
-                                       const char * pJson,
-                                       uint32_t messageLength,
-                                       bool * pUpdateJob,
-                                       OtaFileContext_t ** pFileContext );
+                                  uint16_t numJobParams,
+                                  const char * pJson,
+                                  uint32_t messageLength,
+                                  bool * pUpdateJob,
+                                  OtaFileContext_t ** pFileContext );
 
 /**
  * @brief Validate block index and block size of the data block.
@@ -1012,8 +1012,8 @@ static OtaErr_t processJobHandler( const OtaEventData_t * pEventData )
      * Parse the job document and update file information in the file context.
      */
     retVal = getFileContextFromJob( ( const char * ) pEventData->data,
-                                             pEventData->dataLength,
-                                             &pOtaFileContext);
+                                    pEventData->dataLength,
+                                    &pOtaFileContext );
 
     /*
      * A null context here could either mean we didn't receive a valid job or it could
@@ -1023,7 +1023,8 @@ static OtaErr_t processJobHandler( const OtaEventData_t * pEventData )
      */
     if( pOtaFileContext == NULL )
     {
-        if ( retVal != OtaErrEmptyJobDocument ) {
+        if( retVal != OtaErrEmptyJobDocument )
+        {
             retVal = processNullFileContext();
         }
     }
@@ -1870,7 +1871,7 @@ static DocParseErr_t parseJSONbyModel( const char * pJson,
 
     /* The original error will be document malformed because if missing parameters. If only client token and
      * timestamp are set, then this is an empty job document. */
-    if ( err == DocParseErrMalformedDoc && pDocModel->paramsReceivedBitmap == EMPTY_JOB_DOC_PARAMETER_BITMAP )
+    if( ( err == DocParseErrMalformedDoc ) && ( pDocModel->paramsReceivedBitmap == EMPTY_JOB_DOC_PARAMETER_BITMAP ) )
     {
         err = DocParseErrEmptyJobDoc;
     }
@@ -1878,8 +1879,8 @@ static DocParseErr_t parseJSONbyModel( const char * pJson,
     if( err != DocParseErrNone )
     {
         LogWarn( ( "Failed to parse JSON document as AFR_OTA job: "
-                    "DocParseErr_t=%d",
-                    ( int ) err ) );
+                   "DocParseErr_t=%d",
+                   ( int ) err ) );
     }
 
     return err;
@@ -2366,11 +2367,11 @@ static void handleJobParsingError( const OtaFileContext_t * pFileContext,
  */
 
 static DocParseErr_t parseJobDoc( const JsonDocParam_t * pJsonExpectedParams,
-                                       uint16_t numJobParams,
-                                       const char * pJson,
-                                       uint32_t messageLength,
-                                       bool * pUpdateJob,
-                                       OtaFileContext_t ** pFinalFile )
+                                  uint16_t numJobParams,
+                                  const char * pJson,
+                                  uint32_t messageLength,
+                                  bool * pUpdateJob,
+                                  OtaFileContext_t ** pFinalFile )
 {
     OtaJobParseErr_t err = OtaJobParseErrUnknown;
     DocParseErr_t parseError = DocParseErrNone;
@@ -2396,7 +2397,7 @@ static DocParseErr_t parseJobDoc( const JsonDocParam_t * pJsonExpectedParams,
     }
     else
     {
-        parseError = parseJSONbyModel( pJson, messageLength, &otaJobDocModel);
+        parseError = parseJSONbyModel( pJson, messageLength, &otaJobDocModel );
 
         if( parseError == DocParseErrNone )
         {
@@ -2436,13 +2437,13 @@ static DocParseErr_t parseJobDoc( const JsonDocParam_t * pJsonExpectedParams,
 
 /* Called to update the filecontext structure from the job. */
 static OtaErr_t getFileContextFromJob( const char * pRawMsg,
-                                        uint32_t messageLength,
-                                        OtaFileContext_t ** pFileContext)
+                                       uint32_t messageLength,
+                                       OtaFileContext_t ** pFileContext )
 {
     uint32_t index;
     uint32_t numBlocks;                                 /* How many data pages are in the expected update image. */
     uint32_t bitmapLen;                                 /* Length of the file block bitmap in bytes. */
-    OtaFileContext_t * pUpdateFile = (*pFileContext);   /* Pointer to an OTA update context. */
+    OtaFileContext_t * pUpdateFile = ( *pFileContext ); /* Pointer to an OTA update context. */
     OtaErr_t err = OtaErrNone;
     DocParseErr_t parseErr = DocParseErrNone;
     OtaPalStatus_t palStatus;
@@ -2540,9 +2541,12 @@ static OtaErr_t getFileContextFromJob( const char * pRawMsg,
     }
 
     /* Translate any parsing errors*/
-    if ( pUpdateFile == NULL) {
-        LogWarn( ("Translating known document parsing errors to an OtaErr type") );
-        if ( parseErr == DocParseErrEmptyJobDoc ) {
+    if( pUpdateFile == NULL )
+    {
+        LogWarn( ( "Translating known document parsing errors to an OtaErr type" ) );
+
+        if( parseErr == DocParseErrEmptyJobDoc )
+        {
             err = OtaErrEmptyJobDocument;
         }
     }
@@ -2963,7 +2967,7 @@ static void executeHandler( uint32_t index,
 {
     OtaErr_t err = OtaErrNone;
 
-    LogWarn( ("Index: %lu. OTA event id: %i", index, (int) pEventMsg->eventId) );
+    LogWarn( ( "Index: %lu. OTA event id: %i", index, ( int ) pEventMsg->eventId ) );
 
     assert( otaTransitionTable[ index ].handler != NULL );
 
@@ -2985,7 +2989,7 @@ static void executeHandler( uint32_t index,
          */
         otaAgent.state = otaTransitionTable[ index ].nextState;
     }
-    else if ( err == OtaErrEmptyJobDocument )
+    else if( err == OtaErrEmptyJobDocument )
     {
         LogInfo( ( "Empty job docuemnt found for event=[%s]", pOtaEventStrings[ pEventMsg->eventId ] ) );
     }

--- a/test/cbmc/proofs/getFileContextFromJob/getFileContextFromJob_harness.c
+++ b/test/cbmc/proofs/getFileContextFromJob/getFileContextFromJob_harness.c
@@ -36,17 +36,20 @@
 OtaFileContext_t fileContext;
 
 extern OtaAgentContext_t otaAgent;
-extern OtaFileContext_t * getFileContextFromJob( const char * pRawMsg,
-                                                 uint32_t messageLength );
+static OtaErr_t getFileContextFromJob( const char * pRawMsg,
+                                       uint32_t messageLength,
+                                       OtaFileContext_t ** pFileContext );
 
-OtaFileContext_t * parseJobDoc( const JsonDocParam_t * pJsonExpectedParams,
-                                uint16_t numJobParams,
-                                const char * pJson,
-                                uint32_t messageLength,
-                                bool * pUpdateJob )
+DocParseErr_t parseJobDoc( const JsonDocParam_t * pJsonExpectedParams,
+                           uint16_t numJobParams,
+                           const char * pJson,
+                           uint32_t messageLength,
+                           bool * pUpdateJob,
+                           OtaFileContext_t ** pFileContext )
 {
     uint32_t fileSize;
     bool update;
+    DocParseErr_t parseError = DocParseErrNone;
 
     /* pJsonExpectedParams is expected to be a global structure. pUpdateJob is statically declared in
      * getFileContextFromJob before passing it to parseJobDoc hence cannot be NULL. */
@@ -76,7 +79,7 @@ OtaFileContext_t * parseJobDoc( const JsonDocParam_t * pJsonExpectedParams,
         fileContext.blockBitmapMaxSize = 0u;
     }
 
-    return &fileContext;
+    return parseError;
 }
 
 void getFileContextFromJob_harness()
@@ -107,5 +110,5 @@ void getFileContextFromJob_harness()
      * Agent specifically in receiveAndProcessOTAEvent function.*/
     otaAgent.pOtaInterface = &otaInterface;
 
-    ( void ) getFileContextFromJob( &rawMsg, messageLength );
+    ( void ) getFileContextFromJob( &rawMsg, messageLength, &fileContext );
 }

--- a/test/cbmc/proofs/parseJobDoc/parseJobDoc_harness.c
+++ b/test/cbmc/proofs/parseJobDoc/parseJobDoc_harness.c
@@ -33,12 +33,14 @@
 #include "ota_interface_private.h"
 
 extern OtaAgentContext_t otaAgent;
+
 extern JsonDocParam_t otaJobDocModelParamStructure[ OTA_NUM_JOB_PARAMS ];
-extern OtaFileContext_t * parseJobDoc( const JsonDocParam_t * pJsonExpectedParams,
-                                       uint16_t numJobParams,
-                                       const char * pJson,
-                                       uint32_t messageLength,
-                                       bool * pUpdateJob );
+extern DocParseErr_t parseJobDoc( const JsonDocParam_t * pJsonExpectedParams,
+                                  uint16_t numJobParams,
+                                  const char * pJson,
+                                  uint32_t messageLength,
+                                  bool * pUpdateJob,
+                                  OtaFileContext_t ** pFileContext );
 
 /* Stub to initialize the json docModel. */
 DocParseErr_t initDocModel( JsonDocModel_t * pDocModel,
@@ -105,6 +107,7 @@ OtaJobParseErr_t validateAndStartJob( OtaFileContext_t * pFileContext,
 
 void parseJobDoc_harness()
 {
+    OtaFileContext_t * pFileContext;
     JsonDocParam_t * pJsonExpectedParams;
     uint16_t numJobParams;
     char * pJson;
@@ -132,5 +135,5 @@ void parseJobDoc_harness()
     otaAgent.OtaAppCallback = otaAppCallbackStub;
 
     ( void ) parseJobDoc( otaJobDocModelParamStructure,
-                          numJobParams, pJson, messageLength, &updateJob );
+                          numJobParams, pJson, messageLength, &updateJob, &pFileContext );
 }

--- a/test/cbmc/proofs/processJobHandler/processJobHandler_harness.c
+++ b/test/cbmc/proofs/processJobHandler/processJobHandler_harness.c
@@ -59,6 +59,6 @@ void processJobHandler_harness()
 
     /* processJobHandler returns the values which follow OtaErr_t enum. If it does not, then
      * there is a problem. */
-    __CPROVER_assert( ( err >= OtaErrNone ) && ( err <= OtaErrActivateFailed ),
+    __CPROVER_assert( ( err >= OtaErrNone ) && ( err <= OtaErrEmptyJobDocument ),
                       "Invalid return value from processJobHandler: Expected a value from OtaErr_t enum." );
 }

--- a/test/cbmc/proofs/verifyRequiredParamsExtracted/verifyRequiredParamsExtracted_harness.c
+++ b/test/cbmc/proofs/verifyRequiredParamsExtracted/verifyRequiredParamsExtracted_harness.c
@@ -50,6 +50,6 @@ void verifyRequiredParamsExtracted_harness()
 
     err = __CPROVER_file_local_ota_c_verifyRequiredParamsExtracted( &modelParams, &docModel );
 
-    __CPROVER_assert( ( err == DocParseErrNone ) || ( err == DocParseErrMalformedDoc ),
+    __CPROVER_assert( ( DocParseErrEmptyJobDoc == err ) || ( err == DocParseErrNone ) || ( err == DocParseErrMalformedDoc ),
                       "Error: Expected return value to be either DocParseErrNone or DocParseErrMalformedDoc" );
 }

--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -54,6 +54,7 @@
 #define OTA_TEST_FILE_NUM_BLOCKS          ( OTA_TEST_FILE_SIZE / OTA_FILE_BLOCK_SIZE + 1 )
 #define OTA_TEST_DUPLICATE_NUM_BLOCKS     3
 #define OTA_TEST_FILE_SIZE_STR            "10240"
+#define JOB_DOC_EMPTY                     "{\"clientToken\":\"0:testclient\",\"timestamp\":1602795143}"
 #define JOB_DOC_A                         "{\"clientToken\":\"0:testclient\",\"timestamp\":1602795143,\"execution\":{\"jobId\":\"AFR_OTA-testjob20\",\"status\":\"QUEUED\",\"queuedAt\":1602795128,\"lastUpdatedAt\":1602795128,\"versionNumber\":1,\"executionNumber\":1,\"jobDocument\":{\"afr_ota\":{\"protocols\":[\"MQTT\"],\"streamname\":\"AFR_OTA-XYZ\",\"files\":[{\"filepath\":\"/test/demo\",\"filesize\":" OTA_TEST_FILE_SIZE_STR ",\"fileid\":0,\"certfile\":\"test.crt\",\"sig-sha256-ecdsa\":\"MEQCIF2QDvww1G/kpRGZ8FYvQrok1bSZvXjXefRk7sqNcyPTAiB4dvGt8fozIY5NC0vUDJ2MY42ZERYEcrbwA4n6q7vrBg==\"}] }}}}"
 #define JOB_DOC_B                         "{\"clientToken\":\"0:testclient\",\"timestamp\":1602795143,\"execution\":{\"jobId\":\"AFR_OTA-testjob21\",\"status\":\"QUEUED\",\"queuedAt\":1602795128,\"lastUpdatedAt\":1602795128,\"versionNumber\":1,\"executionNumber\":1,\"jobDocument\":{\"afr_ota\":{\"protocols\":[\"MQTT\"],\"streamname\":\"AFR_OTA-XYZ\",\"files\":[{\"filepath\":\"/test/demo\",\"filesize\":" OTA_TEST_FILE_SIZE_STR ",\"fileid\":0,\"certfile\":\"test.crt\",\"sig-sha256-ecdsa\":\"MEQCIF2QDvww1G/kpRGZ8FYvQrok1bSZvXjXefRk7sqNcyPTAiB4dvGt8fozIY5NC0vUDJ2MY42ZERYEcrbwA4n6q7vrBg==\"}] }}}}"
 #define JOB_DOC_SELF_TEST                 "{\"clientToken\":\"0:testclient\",\"timestamp\":1602795143,\"execution\":{\"jobId\":\"AFR_OTA-testjob20\",\"status\":\"IN_PROGRESS\",\"statusDetails\":{\"self_test\":\"ready\",\"updatedBy\":\"0x1000000\"},\"queuedAt\":1602795128,\"lastUpdatedAt\":1602795128,\"versionNumber\":1,\"executionNumber\":1,\"jobDocument\":{\"afr_ota\":{\"protocols\":[\"MQTT\"],\"streamname\":\"AFR_OTA-XYZ\",\"files\":[{\"filepath\":\"/test/demo\",\"filesize\":" OTA_TEST_FILE_SIZE_STR ",\"fileid\":0,\"certfile\":\"test.crt\",\"sig-sha256-ecdsa\":\"MEQCIF2QDvww1G/kpRGZ8FYvQrok1bSZvXjXefRk7sqNcyPTAiB4dvGt8fozIY5NC0vUDJ2MY42ZERYEcrbwA4n6q7vrBg==\"}] }}}}"
@@ -1802,6 +1803,18 @@ void test_OTA_ProcessJobDocumentValidJson()
     otaReceiveJobDocument();
     receiveAndProcessOtaEvent();
     TEST_ASSERT_EQUAL( OtaAgentStateCreatingFile, OTA_GetState() );
+}
+
+void test_OTA_ProcessEmptyJobDocumentValidJson()
+{
+    pOtaJobDoc = JOB_DOC_EMPTY;
+
+    otaGoToState( OtaAgentStateWaitingForJob );
+    TEST_ASSERT_EQUAL( OtaAgentStateWaitingForJob, OTA_GetState() );
+
+    otaReceiveJobDocument();
+    receiveAndProcessOtaEvent();
+    TEST_ASSERT_EQUAL( OtaAgentStateWaitingForJob, OTA_GetState() );
 }
 
 void test_OTA_ProcessJobDocumentPalCreateFileFail()

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -135,6 +135,7 @@ dns
 docmodel
 docparam
 docparseerrduplicatesnotallowed
+docparseerremptyjobdoc
 docparseerrfieldtypemismatch
 docparseerrinvalidmodelparamtype
 docparseerrinvalidnumchar
@@ -419,6 +420,7 @@ otaerragentstopped
 otaerrcleanupcontrolfailed
 otaerrcleanupdatafailed
 otaerrdowngradenotallowed
+otaerremptyjobdocument
 otaerrfailedtodecodecbor
 otaerrfailedtoencodecbor
 otaerrfilesizeoverflow


### PR DESCRIPTION
Description
-----------
Rough pass on handling empty job document errors. An empty job document will only contain the `clientToken` and `timestamp` fields which currently causes an issue.

Related issue - https://github.com/aws/ota-for-aws-iot-embedded-sdk/issues/482

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is formatted using Uncrustify.
- [x] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.