### PR TITLE
Add public config option for OTA bitmap size

### DIFF
--- a/source/include/ota_config_defaults.h
+++ b/source/include/ota_config_defaults.h
@@ -99,6 +99,16 @@
 #endif
 
 /**
+ * @brief number of blocks to statically track in an OTA.
+ *
+ * <b>Possible values:</b> Any unsigned integer. <br>
+ * <b>Default value:</b> '128'
+ */
+#ifndef otaconfigMAX_BLOCK_BITMAP_SIZE
+    #define otaconfigMAX_BLOCK_BITMAP_SIZE   128U
+#endif
+
+/**
  * @brief Milliseconds to wait for the self test phase to succeed before we
  * force reset.
  *

--- a/source/include/ota_config_defaults.h
+++ b/source/include/ota_config_defaults.h
@@ -105,7 +105,7 @@
  * <b>Default value:</b> '128'
  */
 #ifndef otaconfigMAX_BLOCK_BITMAP_SIZE
-    #define otaconfigMAX_BLOCK_BITMAP_SIZE   128U
+    #define otaconfigMAX_BLOCK_BITMAP_SIZE    128U
 #endif
 
 /**

--- a/source/include/ota_private.h
+++ b/source/include/ota_private.h
@@ -63,7 +63,7 @@
 #define BITS_PER_BYTE                ( ( uint32_t ) 1U << LOG2_BITS_PER_BYTE )            /*!< @brief Number of bits in a byte. This is used by the block bitmap implementation. */
 #define OTA_FILE_BLOCK_SIZE          ( ( uint32_t ) 1U << otaconfigLOG2_FILE_BLOCK_SIZE ) /*!< @brief Data section size of the file data block message (excludes the header). */
 #define OTA_MAX_FILES                1U                                                   /*!< @brief [MUST REMAIN 1! Future support.] Maximum number of concurrent OTA files. */
-#define OTA_MAX_BLOCK_BITMAP_SIZE    128U                                                 /*!< @brief Max allowed number of bytes to track all blocks of an OTA file. Adjust block size if more range is needed. */
+#define OTA_MAX_BLOCK_BITMAP_SIZE    otaconfigMAX_BLOCK_BITMAP_SIZE                       /*!< @brief Max allowed number of bytes to track all blocks of an OTA file. Adjust block size if more range is needed. */
 #define OTA_REQUEST_MSG_MAX_SIZE     ( 3U * OTA_MAX_BLOCK_BITMAP_SIZE )                   /*!< @brief Maximum size of the message */
 #define OTA_REQUEST_URL_MAX_SIZE     ( 1500 )                                             /*!< @brief Maximum size of the S3 presigned URL */
 #define OTA_ERASED_BLOCKS_VAL        0xffU                                                /*!< @brief The starting state of a group of erased blocks in the Rx block bitmap. */


### PR DESCRIPTION
<!--- Title -->
Add public config option for OTA bitmap size

Description
-----------
<!--- Describe your changes in detail -->
This adds a public config option to override an existing private option.
This commit has no functional changes.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [ ] I have tested my changes. No regression in existing tests.
- [x] My code is formatted using Uncrustify.
- [x] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.