### PR TITLE
Fixing Whitespace check bug in action.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,9 +114,7 @@ jobs:
         uses: FreeRTOS/CI-CD-Github-Actions/formatting@main
         with:
           path: ./
-          exclude-dirs: |
-            docs
-            .github
+          exclude-dirs: docs,.github
 
   git-secrets:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,17 +18,17 @@
  - [#413](https://github.com/aws/ota-for-aws-iot-embedded-sdk/pull/413) Clear timers in shutdown and suspend
 
 ### v3.3.0 (December 2021)
- - Added CBMC proofs of all public and private functions in the OTA library. 
+ - Added CBMC proofs of all public and private functions in the OTA library.
  - [#373](https://github.com/aws/ota-for-aws-iot-embedded-sdk/pull/373) Updated compiler flag for tinycbor source files
  - [#407](https://github.com/aws/ota-for-aws-iot-embedded-sdk/pull/407) Added checks to prevent arithmetic overflows
  - [#390](https://github.com/aws/ota-for-aws-iot-embedded-sdk/pull/390) Make OTA file type configurable.
- - [#329](https://github.com/aws/ota-for-aws-iot-embedded-sdk/pull/329) Misc fixes to remove build warnings 
+ - [#329](https://github.com/aws/ota-for-aws-iot-embedded-sdk/pull/329) Misc fixes to remove build warnings
  - [#356](https://github.com/aws/ota-for-aws-iot-embedded-sdk/pull/356) Add type cast to event functions as per POSIX spec
- 
+
 ### v3.2.0 (November 2021)
- - [#275](https://github.com/aws/ota-for-aws-iot-embedded-sdk/pull/276) Updated the doxygen version from 1.8.20 to 1.9.2 
+ - [#275](https://github.com/aws/ota-for-aws-iot-embedded-sdk/pull/276) Updated the doxygen version from 1.8.20 to 1.9.2
  - [#236](https://github.com/aws/ota-for-aws-iot-embedded-sdk/pull/236) Added C++ guards
- - [#231](https://github.com/aws/ota-for-aws-iot-embedded-sdk/pull/231) Added checks for http interface functions. 
+ - [#231](https://github.com/aws/ota-for-aws-iot-embedded-sdk/pull/231) Added checks for http interface functions.
 
 ### v3.1.0 (August 2021)
  - [#232](https://github.com/aws/ota-for-aws-iot-embedded-sdk/pull/232) Add updater version to the status details when job succeeds

--- a/MISRA.md
+++ b/MISRA.md
@@ -84,6 +84,6 @@ _Ref 21.3.2_
 #### Rule 21.8
 _Ref 21.8.1_
 
-- MISRA C-2012 Rule 21.8 Does not allow the use of some of the functions in stdlib.h. One of the OTA platform 
+- MISRA C-2012 Rule 21.8 Does not allow the use of some of the functions in stdlib.h. One of the OTA platform
     abstraction layer interfaces `abort` is flagged for this violation. This is implemented by a platform
     abstraction layer and always called through the OTA PAL interface.

--- a/test/cbmc/proofs/OTA_Init/Makefile
+++ b/test/cbmc/proofs/OTA_Init/Makefile
@@ -20,7 +20,7 @@ REMOVE_FUNCTION_BODY += __CPROVER_file_local_ota_c_initializeAppBuffers
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_ota_c_initializeLocalBuffers
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_ota_c_resetEventQueue
 
-RESTRICT_FUNCTION_POINTER += OTA_Init.function_pointer_call.1/init 
+RESTRICT_FUNCTION_POINTER += OTA_Init.function_pointer_call.1/init
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/test/cbmc/proofs/OtaStopTimer_FreeRTOS/Makefile
+++ b/test/cbmc/proofs/OtaStopTimer_FreeRTOS/Makefile
@@ -17,7 +17,7 @@ PROJECT_SOURCES += $(SRCDIR)/source/portable/os/ota_os_freertos.c
 
 NONDET_STATIC += "--nondet-static"
 
-REMOVE_FUNCTION_BODIES += 
+REMOVE_FUNCTION_BODIES +=
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will
 # restrict the number of EXPENSIVE CBMC jobs running at once. See the

--- a/test/cbmc/proofs/executeHandler/Makefile
+++ b/test/cbmc/proofs/executeHandler/Makefile
@@ -7,7 +7,7 @@ HARNESS_FILE = $(HARNESS_ENTRY)
 PROOF_UID = executeHandler_harness
 
 INCLUDES += -I$(SRCDIR)/source/dependency/coreJSON/source/include/
-INCLUDES += -I$(SRCDIR)/test/cbmc/include 
+INCLUDES += -I$(SRCDIR)/test/cbmc/include
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/source/ota.c

--- a/test/cbmc/proofs/ingestDataBlock/Makefile
+++ b/test/cbmc/proofs/ingestDataBlock/Makefile
@@ -9,7 +9,7 @@ PROOF_UID = ingestDataBlock
 DEFINES += -Dstatic=""
 
 INCLUDES += -I$(SRCDIR)/source/dependency/coreJSON/source/include/
-INCLUDES += -I$(SRCDIR)/test/cbmc/include 
+INCLUDES += -I$(SRCDIR)/test/cbmc/include
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/source/stubs.c

--- a/test/cbmc/proofs/otaClose/Makefile
+++ b/test/cbmc/proofs/otaClose/Makefile
@@ -9,7 +9,7 @@ PROOF_UID = otaClose
 DEFINES += -Dstatic=""
 
 INCLUDES += -I$(SRCDIR)/source/dependency/coreJSON/source/include/
-INCLUDES += -I$(SRCDIR)/test/cbmc/include 
+INCLUDES += -I$(SRCDIR)/test/cbmc/include
 
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/source/stubs.c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c

--- a/test/cbmc/proofs/processDataHandler/Makefile
+++ b/test/cbmc/proofs/processDataHandler/Makefile
@@ -20,11 +20,11 @@ REMOVE_FUNCTION_BODY += ingestDataBlock
 REMOVE_FUNCTION_BODY += dataHandlerCleanup
 REMOVE_FUNCTION_BODY += OTA_SignalEvent
 
-RESTRICT_FUNCTION_POINTER += processDataHandler.function_pointer_call.1/updateStatus 
+RESTRICT_FUNCTION_POINTER += processDataHandler.function_pointer_call.1/updateStatus
 RESTRICT_FUNCTION_POINTER += processDataHandler.function_pointer_call.2/setImageState
-RESTRICT_FUNCTION_POINTER += processDataHandler.function_pointer_call.3/updateStatus 
-RESTRICT_FUNCTION_POINTER += processDataHandler.function_pointer_call.4/updateStatus 
-RESTRICT_FUNCTION_POINTER += processDataHandler.function_pointer_call.5/start 
+RESTRICT_FUNCTION_POINTER += processDataHandler.function_pointer_call.3/updateStatus
+RESTRICT_FUNCTION_POINTER += processDataHandler.function_pointer_call.4/updateStatus
+RESTRICT_FUNCTION_POINTER += processDataHandler.function_pointer_call.5/start
 RESTRICT_FUNCTION_POINTER += callOtaCallback.function_pointer_call.1/otaAppCallback
 
 # If this proof is found to consume huge amounts of RAM, you can set the

--- a/test/cbmc/proofs/requestJob_Mqtt/Makefile
+++ b/test/cbmc/proofs/requestJob_Mqtt/Makefile
@@ -14,7 +14,7 @@ PROJECT_SOURCES += $(SRCDIR)/source/ota_mqtt.c
 # into a buffer. This is much higher than the 84 characters of the buffer
 # as null characters are used after the copied in strin to fill the buffer.
 UNWINDSET += strncpy.0:220
-# The strnlen function is used when calculating the maximum thingname length 
+# The strnlen function is used when calculating the maximum thingname length
 # which can be used to generate the client token.
 UNWINDSET += strnlen.0:54
 

--- a/test/cbmc/proofs/setImageStateWithReason/Makefile
+++ b/test/cbmc/proofs/setImageStateWithReason/Makefile
@@ -9,7 +9,7 @@ PROOF_UID = setImageStateWithReason_harness
 DEFINES += -Dstatic=""
 
 INCLUDES += -I$(SRCDIR)/source/dependency/coreJSON/source/include/
-INCLUDES += -I$(SRCDIR)/test/cbmc/include 
+INCLUDES += -I$(SRCDIR)/test/cbmc/include
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 

--- a/test/cbmc/proofs/startHandler/Makefile
+++ b/test/cbmc/proofs/startHandler/Makefile
@@ -18,8 +18,8 @@ PROJECT_SOURCES += $(SRCDIR)/source/ota.c
 
 REMOVE_FUNCTION_BODY += OTA_SignalEvent
 
-RESTRICT_FUNCTION_POINTER += platformInSelftest.function_pointer_call.1/getPlatformImageStateStub 
-RESTRICT_FUNCTION_POINTER += startHandler.function_pointer_call.1/startTimerStub 
+RESTRICT_FUNCTION_POINTER += platformInSelftest.function_pointer_call.1/getPlatformImageStateStub
+RESTRICT_FUNCTION_POINTER += startHandler.function_pointer_call.1/startTimerStub
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/test/cbmc/proofs/verifyActiveJobStatus/Makefile
+++ b/test/cbmc/proofs/verifyActiveJobStatus/Makefile
@@ -9,10 +9,10 @@ PROOF_UID = verifyActiveJobStatus
 DEFINES += -Dstatic=""
 
 INCLUDES += -I$(SRCDIR)/source/dependency/coreJSON/source/include/
-INCLUDES += -I$(SRCDIR)/test/cbmc/include 
+INCLUDES += -I$(SRCDIR)/test/cbmc/include
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
-PROOF_SOURCES += $(SRCDIR)/test/cbmc/source/stubs.c 
+PROOF_SOURCES += $(SRCDIR)/test/cbmc/source/stubs.c
 
 PROJECT_SOURCES += $(SRCDIR)/source/ota.c
 

--- a/tools/lexicon.txt
+++ b/tools/lexicon.txt
@@ -300,7 +300,7 @@ jobstatusfailedwithval
 jobstatusinprogress
 jobstatusrejected
 json
-jsondoc 
+jsondoc
 lastbyte
 lastupdatedat
 len


### PR DESCRIPTION
Fixing Whitespace check bug in action.yml

Description
-----------
The formatting action had a bug causing the job to never run and then return a pass. One part of this is handled by this FreeRTOS/CI-CD-GitHub-Actions#63. The other part is handled in this PR, also fixed the trailing whitespace in files that had it.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is formatted using Uncrustify.
- [x] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.