### PR TITLE
Explicitly set pointer to NULL

### DIFF
--- a/test/unit-test/ota_utest.c
+++ b/test/unit-test/ota_utest.c
@@ -3587,7 +3587,7 @@ void test_OTA_parseJobFailsNullJsonDocument()
 
 void test_OTA_parseJobFailsMoreBlocksThanBitmap()
 {
-    OtaFileContext_t * pContext;
+    OtaFileContext_t * pContext = NULL;
     bool updateJob = false;
     DocParseErr_t err;
     JsonDocParam_t otaCustomJobDocModelParamStructure[ 1 ] =
@@ -3607,7 +3607,7 @@ void test_OTA_parseJobFailsMoreBlocksThanBitmap()
 
 void test_OTA_extractParameterFailInvalidJobDocModel()
 {
-    OtaFileContext_t * pContext;
+    OtaFileContext_t * pContext = NULL;
     bool updateJob = false;
     DocParseErr_t err;
     JsonDocParam_t otaCustomJobDocModelParamStructure[ 1 ] =


### PR DESCRIPTION
Description
-----------
Fixing test cases by explicitly setting
pContext pointer to NULL for later check.

Testing
-----------
Checked out OTA package, built unit tests, observed two failing tests.
Build commands:
```
cmake -S test -B build
make -C build all
cd build && ctest
```

Previously failing tests:
```
Test project /home/kstribrn/workspace/ota-for-aws-iot-embedded-sdk/build
    Start 1: ota_utest
1/4 Test #1: ota_utest ........................***Failed    0.02 sec
    Start 2: ota_base64_utest
2/4 Test #2: ota_base64_utest .................   Passed    0.00 sec
    Start 3: ota_cbor_utest
3/4 Test #3: ota_cbor_utest ...................   Passed    0.00 sec
    Start 4: ota_os_posix_utest
4/4 Test #4: ota_os_posix_utest ...............   Passed    5.01 sec

75% tests passed, 1 tests failed out of 4

Total Test time (real) =   5.03 sec

The following tests FAILED:
	  1 - ota_utest (Failed)
Errors while running CTest

/home/kstribrn/workspace/ota-for-aws-iot-embedded-sdk/test/unit-test/ota_utest.c:3603:test_OTA_parseJobFailsMoreBlocksThanBitmap:FAIL: Expected NULL
/home/kstribrn/workspace/ota-for-aws-iot-embedded-sdk/test/unit-test/ota_utest.c:3623:test_OTA_extractParameterFailInvalidJobDocModel:FAIL: Expected NULL
-----------------------
150 Tests 2 Failures 0 Ignored 
```

Test results now:
```
Test project /home/kstribrn/workspace/ota-for-aws-iot-embedded-sdk/build
    Start 1: ota_utest
1/4 Test #1: ota_utest ........................   Passed    0.02 sec
    Start 2: ota_base64_utest
2/4 Test #2: ota_base64_utest .................   Passed    0.00 sec
    Start 3: ota_cbor_utest
3/4 Test #3: ota_cbor_utest ...................   Passed    0.00 sec
    Start 4: ota_os_posix_utest
4/4 Test #4: ota_os_posix_utest ...............   Passed    5.00 sec

100% tests passed, 0 tests failed out of 4

Total Test time (real) =   5.03 sec
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [X] I have tested my changes. No regression in existing tests.
- [X] My code is formatted using Uncrustify.
- [X] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.