### PR TITLE
Fix Unit Test Instructions In Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,12 @@ To build unit tests, the submodule dependency of CMock is required. Use the
 following command to clone the submodule:
 
 ```
-git submodule update --checkout --init --recursive test/unit-test/CMock source/dependency/coreJSON
+git submodule update --checkout --init --recursive test/unit-test/CMock source/dependency/coreJSON source/dependency/3rdparty/tinycbor
 ```
 
 ### Platform Prerequisites
 
+- Linux
 - For building the library, **CMake 3.13.0** or later and a **C90 compiler**.
 - For running unit tests, **Ruby 2.0.0** or later is additionally required for
   the CMock test framework (that we use).


### PR DESCRIPTION
Fix Unit Test Instructions In Readme

Description
-----------
Missing dependency in submodule initialisation.
Added linux as a dependency for building. Using `mqueue.h` is not portable. I can't figure out if this is a posix issue or a macOS issue, but the effect is the same regardless. I can't see any Windows specific code and I pretty sure Windows is not posix compliant.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [x] My code is formatted using Uncrustify.
- [x] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.