### PR TITLE
Make explicit that stringBuilder CBMC proof is bounded

### DIFF
--- a/test/cbmc/proofs/stringBuilder/Makefile
+++ b/test/cbmc/proofs/stringBuilder/Makefile
@@ -10,9 +10,11 @@ DEFINES +=
 INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=
-UNWINDSET +=
+UNWINDSET += stringBuilder_harness.0:10
+UNWINDSET += stringBuilder_harness.1:10
+UNWINDSET += stringBuilder.0:10
 
-CBMC_FLAG_UNWINDING_ASSERTIONS =
+CBMC_FLAG_UNWINDING_ASSERTIONS = --no-unwinding-assertions
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/source/ota_mqtt.c


### PR DESCRIPTION
Description
-----------
With CBMC v6, unwinding assertions are enabled by default.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- Please refer to CONTRIBUTING.md for further guidelines -->
- [ ] I have tested my changes. No regression in existing tests.
- [x] My code is formatted using Uncrustify.
- [x] I have read and applied the rules stated in CONTRIBUTING.md. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.